### PR TITLE
Fix weekday start time from 09:00 to 18:00

### DIFF
--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -75,10 +75,10 @@ BEGIN
     -- Monday-Thursday (1-4): only veld 5, until sunset
     INSERT INTO [dbo].[VeldBeschikbaarheid] ([VeldNummer], [DagVanWeek], [BeschikbaarVanaf], [BeschikbaarTot], [GebruikZonsondergang])
     VALUES
-        (5, 1, '09:00', '22:00', 1),
-        (5, 2, '09:00', '22:00', 1),
-        (5, 3, '09:00', '22:00', 1),
-        (5, 4, '09:00', '22:00', 1)
+        (5, 1, '18:00', '22:00', 1),
+        (5, 2, '18:00', '22:00', 1),
+        (5, 3, '18:00', '22:00', 1),
+        (5, 4, '18:00', '22:00', 1)
     -- Friday (5): no rows = no matches
     -- Sunday (7): no rows = no matches
 

--- a/FunctionApp/Planner/ARCHITECTURE.md
+++ b/FunctionApp/Planner/ARCHITECTURE.md
@@ -29,7 +29,7 @@ Veld 5 is only assigned when veld 1–4 are fully occupied in the requested time
 
 | Dag | Beschikbare velden | Tijdvenster | Bijzonderheden |
 |-----|-------------------|-------------|----------------|
-| Maandag–Donderdag | Veld 5 alleen | 09:00 – zonsondergang | Geen kunstlicht |
+| Maandag–Donderdag | Veld 5 alleen | 18:00 – zonsondergang | Geen kunstlicht, sportpark overdag gesloten |
 | Vrijdag | **Geen** | — | Geen wedstrijden toegestaan |
 | Zaterdag | Veld 1–4 + Veld 5 | 08:30 – 22:00 (veld 1–4) / 08:30 – 17:00 (veld 5) | 10 min buffer tussen wedstrijden |
 | Zondag | **Geen** | — | Geen wedstrijden toegestaan |

--- a/FunctionApp/docs/API.md
+++ b/FunctionApp/docs/API.md
@@ -308,7 +308,7 @@ None (empty POST).
 
 | Day | Fields | Hours | Notes |
 |-----|--------|-------|-------|
-| Monday-Thursday | Veld 5 only | 09:00 - sunset | No lights, veld 1-4 training |
+| Monday-Thursday | Veld 5 only | 18:00 - sunset | No lights, veld 1-4 training |
 | Friday | None | - | No matches |
 | Saturday | Veld 1-5 | 08:30 - 22:00 (1-4) / 08:30 - 17:00 (5) | 10 min buffer |
 | Sunday | None | - | No matches |


### PR DESCRIPTION
## Summary
- Changed `VeldBeschikbaarheid` seed data for Monday–Thursday from `09:00` to `18:00`
- Sportpark is not open during daytime on weekdays, only from 18:00
- Updated ARCHITECTURE.md and API.md documentation to match

## Test plan
- [ ] POST `/api/planner/check-availability` with `{"datum":"2026-04-07"}` returns window starting at 18:00
- [ ] POST with `{"datum":"2026-04-20","aanvangsTijd":"12:00","leeftijdsCategorie":"JO13"}` returns unavailable (12:00 < 18:00)

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)