### PR TITLE
Reject past and today dates in planner

### DIFF
--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -23,6 +23,13 @@ namespace SportlinkFunction.Planner
                 return response;
             }
 
+            // Date must be in the future (not today, not in the past)
+            if (date <= DateOnly.FromDateTime(DateTime.Today))
+            {
+                response.Reden = $"De gewenste datum {request.Datum} kan niet verwerkt worden. Een datum moet in de toekomst zijn.";
+                return response;
+            }
+
             // Step 1: Resolve match parameters from Speeltijden
             Speeltijd? speeltijd = null;
             int duurMinuten = 105; // default senior


### PR DESCRIPTION
## Summary
- Added date validation as the first check before any database queries
- Dates in the past or today are immediately rejected with a clear message
- Returns: "De gewenste datum {datum} kan niet verwerkt worden. Een datum moet in de toekomst zijn."

## Test plan
- [ ] POST with `{"datum":"2026-04-04"}` (yesterday) → rejected
- [ ] POST with `{"datum":"2026-04-05"}` (today) → rejected
- [ ] POST with `{"datum":"2026-04-06"}` (tomorrow) → processed normally

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)