### PR TITLE
Vertaal documentatie en code comments naar Nederlands

### DIFF
--- a/FunctionApp/Planner/ARCHITECTURE.md
+++ b/FunctionApp/Planner/ARCHITECTURE.md
@@ -1,14 +1,14 @@
-# Planner API — Architecture & Guidelines
+# Planner API — Architectuur & Richtlijnen
 
-This document defines the rules, constraints, and API contract for the VRC Veldplanner API. It is the single source of truth for scheduling logic.
+Dit document definieert de regels, beperkingen en API-contract voor de VRC Veldplanner API. Het is de enige bron van waarheid voor de planningslogica.
 
-## Purpose
+## Doel
 
-Automated field availability checking for friendly/practice matches at **Sportpark Spitsbergen, Veenendaal**. When someone asks (via email, WhatsApp, or other channels) to schedule a match, the API checks availability and returns whether the requested date/time works — or suggests alternatives.
+Geautomatiseerde veldbeschikbaarheidscontrole voor oefenwedstrijden op **Sportpark Spitsbergen, Veenendaal**. Wanneer iemand (via email, WhatsApp of andere kanalen) een wedstrijd wil plannen, controleert de API de beschikbaarheid en geeft aan of de gewenste datum/tijd mogelijk is — of stelt alternatieven voor.
 
 ---
 
-## Field Definitions
+## Velddefinities
 
 | Veld | Kunstlicht | Beschikbaar voor planner | Opmerkingen |
 |------|-----------|-------------------------|-------------|
@@ -19,13 +19,13 @@ Automated field availability checking for friendly/practice matches at **Sportpa
 | Veld 5 | **Nee** | Ma-do + zaterdag | Geen licht, zonsondergang-limiet |
 | Veld 6 | — | **Nooit** | Niet functioneel |
 
-**Field preference order:** Veld 1 > Veld 2 > Veld 3 > Veld 4 > Veld 5
+**Voorkeursvolgorde velden:** Veld 1 > Veld 2 > Veld 3 > Veld 4 > Veld 5
 
-Veld 5 is only assigned when veld 1–4 are fully occupied in the requested time window.
+Veld 5 wordt alleen toegewezen als veld 1–4 volledig bezet zijn in het gevraagde tijdvenster.
 
 ---
 
-## Availability Rules per Day
+## Beschikbaarheidsregels per dag
 
 | Dag | Beschikbare velden | Tijdvenster | Bijzonderheden |
 |-----|-------------------|-------------|----------------|
@@ -36,13 +36,13 @@ Veld 5 is only assigned when veld 1–4 are fully occupied in the requested time
 
 ---
 
-## Scheduling Rules
+## Planningsregels
 
-### Buffer between matches
+### Buffer tussen wedstrijden
 - **Standard buffer:** 10 minuten tussen opeenvolgende wedstrijden op hetzelfde veld (zaterdag)
 - **Team-specifieke buffers:** Configureerbaar via `dbo.TeamRegels` tabel
 
-### Team-specific exceptions (dbo.TeamRegels)
+### Teamspecifieke uitzonderingen (dbo.TeamRegels)
 
 | Team | Regel | Waarde | Toelichting |
 |------|-------|--------|-------------|
@@ -53,13 +53,13 @@ Toekomstige regels (voorbeelden):
 - `VoorkeurVeld`: team speelt altijd op een bepaald veld
 - `VoorkeurTijd`: team speelt altijd rond een bepaalde tijd
 
-### Sunset constraint (velden zonder kunstlicht)
+### Zonsondergang-beperking (velden zonder kunstlicht)
 - Wedstrijd moet eindigen **voor zonsondergang**
 - Zonsondergang berekend via NOAA solar algorithm voor Veenendaal (52.0284°N, 5.5579°E)
 - Opgeslagen in `dbo.Zonsondergang` tabel (handmatige overrides mogelijk)
 - **Geen harde buffer**, wel een waarschuwing als marge < 20 minuten
 
-### Morning-first preference for youth (zaterdag, soft rule)
+### Ochtend-eerst voorkeur voor jeugd (zaterdag, zachte regel)
 - JO7–JO10: voorkeur ochtend (08:30–11:00)
 - JO11–JO12: voorkeur mid-ochtend (10:00–13:00)
 - JO13+/Senioren: voorkeur middag (13:00+)
@@ -68,7 +68,7 @@ Dit zijn voorkeuren, geen harde beperkingen.
 
 ---
 
-## Field Capacity (deelveld-wedstrijden)
+## Veldcapaciteit (deelveld-wedstrijden)
 
 Een veld heeft capaciteit **1.00**. Wedstrijden gebruiken een fractie op basis van leeftijdscategorie:
 
@@ -111,7 +111,7 @@ Een veld heeft capaciteit **1.00**. Wedstrijden gebruiken een fractie op basis v
 
 ---
 
-## Algorithm (processing order)
+## Algoritme (verwerkingsvolgorde)
 
 ```
 1. Resolve match parameters from Speeltijden (duration, field fraction)
@@ -132,7 +132,7 @@ Een veld heeft capaciteit **1.00**. Wedstrijden gebruiken een fractie op basis v
 
 ---
 
-## API Contract
+## API-contract
 
 ### Endpoint: `POST /api/planner/check-availability`
 
@@ -254,36 +254,36 @@ Bevestigt een slot en schrijft naar `planner.GeplandeWedstrijden`.
 
 ---
 
-## Database Schema (new tables)
+## Database schema (nieuwe tabellen)
 
 ### dbo.Velden
-Field definitions. Seed: veld 1–4 (lights), veld 5 (no lights), veld 6 (inactive).
+Velddefinities. Seeddata: veld 1–4 (kunstlicht), veld 5 (geen kunstlicht), veld 6 (inactief).
 
 ### dbo.VeldBeschikbaarheid
-Per day-of-week availability windows per field. Drives which fields are available on which days.
+Beschikbaarheidsvensters per dag van de week per veld. Bepaalt welke velden op welke dagen beschikbaar zijn.
 
 ### dbo.TeamRegels
-Configurable team-specific exceptions (buffers, field/time preferences). No code changes needed to add rules.
+Configureerbare teamspecifieke uitzonderingen (buffers, veld-/tijdvoorkeuren). Geen codewijzigingen nodig om regels toe te voegen.
 
 ### dbo.Zonsondergang
-Pre-computed sunset times per date. Populated by NOAA calculator, manually overridable.
+Vooraf berekende zonsondergangstijden per datum. Gevuld door NOAA-calculator, handmatig aan te passen.
 
 ### planner.GeplandeWedstrijden
-Planned matches booked through the API. Includes status (Gepland/Bevestigd/Geannuleerd).
+Geplande wedstrijden geboekt via de API. Bevat status (Gepland/Bevestigd/Geannuleerd).
 
 ### planner.AlleWedstrijdenOpVeld (view)
-Unified view combining competition matches (`his.matches`) with planner bookings. Single source for field occupation queries.
+Gecombineerde weergave van competitiewedstrijden (`his.matches`) met planner-boekingen. Enige bron voor veldbezettingsqueries.
 
 ---
 
-## Future: Messaging Integration
+## Toekomst: Berichtenintegratie
 
-The API is designed as a standalone REST endpoint. Two integration options are documented:
+De API is ontworpen als een zelfstandig REST-endpoint zodat elke integratielaag het kan aanroepen. Twee opties zijn gedocumenteerd:
 
-### Option A: Power Automate
-Trigger on email → AI Builder parses text → HTTP POST to API → auto-reply. Low-code, extends easily to Teams/WhatsApp.
+### Optie A: Power Automate
+Trigger bij email → AI Builder interpreteert tekst → HTTP POST naar API → automatisch antwoord. Low-code, eenvoudig uit te breiden naar Teams/WhatsApp.
 
-### Option B: Azure Function + Microsoft Graph API
-Custom function polls/receives emails via Graph API → LLM extracts parameters → calls PlannerService directly → sends reply via Graph. Full control, same codebase.
+### Optie B: Azure Function + Microsoft Graph API
+Eigen functie pollt/ontvangt emails via Graph API → LLM extraheert parameters → roept PlannerService direct aan → stuurt antwoord via Graph. Volledige controle, zelfde codebase.
 
-**AI choice deferred** — any LLM that parses Dutch natural language to the request JSON works. The API contract is the stable interface.
+**AI-keuze uitgesteld** — elke LLM die Nederlandse natuurlijke taal kan omzetten naar het API-request JSON formaat werkt. Het API-contract is de stabiele interface.

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -35,7 +35,7 @@ namespace SportlinkFunction.Planner
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
 
-            // Search in his.matches for this team on this date (home or away, by teamnaam or wedstrijd description)
+            // Zoeken in his.matches voor dit team op deze datum (thuis of uit, op teamnaam of wedstrijdomschrijving)
             using var cmd = new SqlCommand(@"
                 SELECT
                     CAST(m.[kaledatum] AS DATE) AS Datum,
@@ -94,7 +94,7 @@ namespace SportlinkFunction.Planner
         public static async Task<List<VeldBeschikbaarheidInfo>> GetAvailableFieldsAsync(DateOnly date)
         {
             var results = new List<VeldBeschikbaarheidInfo>();
-            // DayOfWeek: .NET Monday=1 matches our DB convention (1=Monday...7=Sunday)
+            // DayOfWeek: .NET Maandag=1 komt overeen met onze DB-conventie (1=Maandag...7=Zondag)
             int dagVanWeek = ((int)date.DayOfWeek == 0) ? 7 : (int)date.DayOfWeek;
 
             using var conn = new SqlConnection(ConnectionString);

--- a/FunctionApp/Planner/PlannerModels.cs
+++ b/FunctionApp/Planner/PlannerModels.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace SportlinkFunction.Planner
 {
-    // ── Request ──
+    // ── Aanvraag ──
 
     public class CheckAvailabilityRequest
     {
@@ -28,7 +28,7 @@ namespace SportlinkFunction.Planner
         public int? WedstrijdDuurMinuten { get; set; }
     }
 
-    // ── Response ──
+    // ── Antwoord ──
 
     public class CheckAvailabilityResponse
     {
@@ -70,7 +70,7 @@ namespace SportlinkFunction.Planner
         public string? Opmerking { get; set; }
     }
 
-    // ── Internal models ──
+    // ── Interne modellen ──
 
     public class Speeltijd
     {

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -16,23 +16,23 @@ namespace SportlinkFunction.Planner
         {
             var response = new CheckAvailabilityResponse();
 
-            // Parse date
+            // Datum verwerken
             if (!DateOnly.TryParse(request.Datum, out var date))
             {
                 response.Reden = $"Ongeldige datum: {request.Datum}";
                 return response;
             }
 
-            // Date must be in the future (not today, not in the past)
+            // Datum moet in de toekomst liggen (niet vandaag, niet in het verleden)
             if (date <= DateOnly.FromDateTime(DateTime.Today))
             {
                 response.Reden = $"De gewenste datum {request.Datum} kan niet verwerkt worden. Een datum moet in de toekomst zijn.";
                 return response;
             }
 
-            // Step 1: Resolve match parameters from Speeltijden
+            // Stap 1: Wedstrijdparameters bepalen uit Speeltijden
             Speeltijd? speeltijd = null;
-            int duurMinuten = 105; // default senior
+            int duurMinuten = 105; // standaard senioren
             decimal veldFractie = 1.00m;
 
             if (!string.IsNullOrEmpty(request.LeeftijdsCategorie))
@@ -51,7 +51,7 @@ namespace SportlinkFunction.Planner
                 duurMinuten = request.WedstrijdDuurMinuten.Value;
             }
 
-            // Step 2: Team conflict check
+            // Stap 2: Team conflictcontrole
             if (!string.IsNullOrEmpty(request.TeamNaam))
             {
                 var teamMatches = await PlannerDataAccess.GetTeamMatchesOnDateAsync(request.TeamNaam, date);
@@ -71,7 +71,7 @@ namespace SportlinkFunction.Planner
                 }
             }
 
-            // Step 3: Load available fields for this day
+            // Stap 3: Beschikbare velden voor deze dag laden
             var availableFields = await PlannerDataAccess.GetAvailableFieldsAsync(date);
             if (availableFields.Count == 0)
             {
@@ -84,31 +84,31 @@ namespace SportlinkFunction.Planner
                 return response;
             }
 
-            // Step 4: Load all existing occupations
+            // Stap 4: Alle huidige veldbezettingen laden
             var occupations = await PlannerDataAccess.GetFieldOccupationsAsync(date);
             var velden = await PlannerDataAccess.GetVeldenAsync();
 
-            // Step 5: Load team-specific rules
+            // Stap 5: Teamspecifieke regels laden
             var teamRules = new List<TeamRegel>();
             if (!string.IsNullOrEmpty(request.TeamNaam))
                 teamRules = await PlannerDataAccess.GetTeamRulesAsync(request.TeamNaam);
 
-            // Also load rules for teams already on the schedule (their buffers must be respected)
+            // Laad ook regels voor teams die al op het programma staan (hun buffers moeten gerespecteerd worden)
             var allTeamRules = new Dictionary<string, List<TeamRegel>>();
             foreach (var occ in occupations.Where(o => !string.IsNullOrEmpty(o.TeamNaam)).Select(o => o.TeamNaam!).Distinct())
             {
                 allTeamRules[occ] = await PlannerDataAccess.GetTeamRulesAsync(occ);
             }
 
-            // Step 6: Get sunset time
+            // Stap 6: Zonsondergangstijd ophalen
             var sunset = await PlannerDataAccess.GetSunsetAsync(date);
             if (sunset == null)
             {
-                // Compute on-the-fly if not in table
+                // Ter plekke berekenen als niet in tabel
                 sunset = SunsetCalculator.GetSunset(date);
             }
 
-            // Apply sunset constraint to field availability windows
+            // Zonsondergang-beperking toepassen op beschikbaarheidsvensters
             foreach (var field in availableFields)
             {
                 if (field.GebruikZonsondergang && sunset.HasValue)
@@ -118,18 +118,18 @@ namespace SportlinkFunction.Planner
                 }
             }
 
-            // Mode 2: no leeftijdsCategorie — return available windows
+            // Modus 2: geen leeftijdsCategorie — beschikbare vensters teruggeven
             if (string.IsNullOrEmpty(request.LeeftijdsCategorie) && !request.WedstrijdDuurMinuten.HasValue)
             {
                 return BuildWindowsResponse(date, availableFields, occupations, velden, sunset, request.Dagdeel);
             }
 
-            // Mode 1: specific slot assignment
+            // Modus 1: specifieke slottoewijzing
             TimeOnly? preferredTime = null;
             if (!string.IsNullOrEmpty(request.AanvangsTijd) && TimeOnly.TryParse(request.AanvangsTijd, out var parsed))
                 preferredTime = parsed;
 
-            // Apply dagdeel filter
+            // Dagdeelfilter toepassen
             TimeOnly dagdeelVan = new(8, 30);
             TimeOnly dagdeelTot = new(22, 0);
             if (!string.IsNullOrEmpty(request.Dagdeel))
@@ -142,7 +142,7 @@ namespace SportlinkFunction.Planner
                 }
             }
 
-            // Step 7: Try preferred time first (direct check, before full scan)
+            // Stap 7: Eerst voorkeurstijd proberen (directe controle, voor volledige scan)
             if (preferredTime.HasValue)
             {
                 var exactMatch = TryExactTime(preferredTime.Value, availableFields, occupations, velden,
@@ -157,14 +157,14 @@ namespace SportlinkFunction.Planner
                 }
             }
 
-            // Try to find alternative slots
+            // Alternatieve slots zoeken
             var candidates = FindAllSlots(availableFields, occupations, velden, allTeamRules, teamRules,
                                           veldFractie, duurMinuten, dagdeelVan, dagdeelTot, sunset);
 
-            // Step 8: Find best available slot
+            // Stap 8: Beste beschikbaar slot vinden
             if (candidates.Count > 0)
             {
-                // Sort by proximity to preferred time, or by scheduling preference
+                // Sorteren op nabijheid voorkeurstijd, of op planningsvoorkeur
                 var ordered = preferredTime.HasValue
                     ? candidates.OrderBy(c => Math.Abs(c.AanvangsTijd.ToTimeSpan().TotalMinutes - preferredTime.Value.ToTimeSpan().TotalMinutes))
                     : candidates.OrderBy(c => c.AanvangsTijd.ToTimeSpan().TotalMinutes);
@@ -174,7 +174,7 @@ namespace SportlinkFunction.Planner
 
                 if (preferredTime.HasValue)
                 {
-                    // Preferred time didn't match exactly — best is an alternative
+                    // Voorkeurstijd niet exact beschikbaar — beste als alternatief
                     response.Reden = $"Gewenste tijd {preferredTime.Value:HH:mm} is niet beschikbaar.";
                     response.Alternatieven = alternatives.Prepend(best)
                         .Select(c => ToSlotToewijzing(date, c, duurMinuten, velden)).Take(3).ToList();
@@ -210,10 +210,10 @@ namespace SportlinkFunction.Planner
         {
             var endTime = preferredTime.AddMinutes(duurMinuten);
 
-            // Try each field in preference order (veld 1-4 before veld 5)
+            // Elk veld proberen in voorkeursvolgorde (veld 1-4 voor veld 5)
             foreach (var field in availableFields.OrderBy(f => f.VeldNummer == 5 ? 1 : 0))
             {
-                // Check within availability window
+                // Controleer binnen beschikbaarheidsvenster
                 if (preferredTime < field.BeschikbaarVanaf || endTime > field.BeschikbaarTot)
                     continue;
 
@@ -249,11 +249,11 @@ namespace SportlinkFunction.Planner
                 var fieldOccupations = occupations.Where(o => o.VeldNummer == field.VeldNummer).ToList();
                 var veldInfo = velden.FirstOrDefault(v => v.VeldNummer == field.VeldNummer);
 
-                // Determine the effective time window for this field
+                // Effectief tijdvenster voor dit veld bepalen
                 var windowStart = dagdeelVan < field.BeschikbaarVanaf ? field.BeschikbaarVanaf : dagdeelVan;
                 var windowEnd = dagdeelTot > field.BeschikbaarTot ? field.BeschikbaarTot : dagdeelTot;
 
-                // Scan in 5-minute increments
+                // Scannen in stappen van 5 minuten
                 for (var time = windowStart; time.AddMinutes(duurMinuten) <= windowEnd; time = time.AddMinutes(5))
                 {
                     var endTime = time.AddMinutes(duurMinuten);
@@ -267,13 +267,13 @@ namespace SportlinkFunction.Planner
                             AanvangsTijd = time,
                             EindTijd = endTime
                         });
-                        // Skip ahead past this slot for this field to avoid overlapping candidates
-                        time = time.AddMinutes(duurMinuten + StandardBufferMinutes - 5); // -5 because loop adds 5
+                        // Vooruitspringen voorbij dit slot om overlappende kandidaten te vermijden
+                        time = time.AddMinutes(duurMinuten + StandardBufferMinutes - 5); // -5 omdat de lus 5 toevoegt
                     }
                 }
             }
 
-            // Sort: prefer veld 1-4 over veld 5
+            // Sorteren: veld 1-4 prefereren boven veld 5
             return candidates.OrderBy(c => c.VeldNummer == 5 ? 1 : 0)
                              .ThenBy(c => c.AanvangsTijd.ToTimeSpan().TotalMinutes)
                              .ToList();
@@ -285,7 +285,7 @@ namespace SportlinkFunction.Planner
             Dictionary<string, List<TeamRegel>> allTeamRules,
             List<TeamRegel> requestingTeamRules)
         {
-            // Get buffer requirements for the requesting team
+            // Buffervereisten voor het aanvragende team ophalen
             int bufferVoor = StandardBufferMinutes;
             int bufferNa = StandardBufferMinutes;
             foreach (var rule in requestingTeamRules)
@@ -301,33 +301,33 @@ namespace SportlinkFunction.Planner
 
             foreach (var occ in fieldOccupations)
             {
-                // Check if time windows overlap
+                // Controleer of tijdvensters overlappen
                 bool overlaps = occ.AanvangsTijd < bufferedEnd && occ.EindTijd > bufferedStart;
                 if (!overlaps) continue;
 
-                // For sub-field matches, check capacity during actual match time (not buffer time)
+                // Voor deelveld-wedstrijden, capaciteit controleren tijdens de wedstrijd (niet buffertijd)
                 if (veldFractie < 1.0m && occ.VeldDeelGebruik < 1.0m)
                 {
-                    // Only check actual overlap (not buffers) for sub-field capacity
+                    // Alleen daadwerkelijke overlap controleren (geen buffers) voor deelveld-capaciteit
                     bool actualOverlap = occ.AanvangsTijd < end && occ.EindTijd > start;
                     if (actualOverlap)
                     {
-                        // Check total capacity at this time slot
+                        // Totale capaciteit controleren voor dit tijdslot
                         decimal usedCapacity = fieldOccupations
                             .Where(o => o.AanvangsTijd < end && o.EindTijd > start)
                             .Sum(o => o.VeldDeelGebruik);
                         if (usedCapacity + veldFractie > 1.0m)
                             return false;
-                        continue; // sub-field sharing is fine if capacity allows
+                        continue; // deelveld delen is prima als capaciteit het toelaat
                     }
                     continue;
                 }
 
-                // For full-field matches, or if existing match is full-field: conflict
+                // Voor heel-veld wedstrijden, of als bestaande wedstrijd heel veld is: conflict
                 if (veldFractie >= 1.0m || occ.VeldDeelGebruik >= 1.0m)
                     return false;
 
-                // Also check existing team's buffer rules
+                // Controleer ook bufferregels van bestaand team
                 if (!string.IsNullOrEmpty(occ.TeamNaam) && allTeamRules.TryGetValue(occ.TeamNaam, out var existingRules))
                 {
                     int existingBufVoor = StandardBufferMinutes;

--- a/FunctionApp/Planner/SunsetCalculator.cs
+++ b/FunctionApp/Planner/SunsetCalculator.cs
@@ -3,8 +3,8 @@ using System;
 namespace SportlinkFunction.Planner
 {
     /// <summary>
-    /// NOAA Solar Calculator for sunset times at Sportpark Spitsbergen, Veenendaal.
-    /// Based on: https://gml.noaa.gov/grad/solcalc/solareqns.PDF
+    /// NOAA Zonnecalculator voor zonsondergangstijden op Sportpark Spitsbergen, Veenendaal.
+    /// Gebaseerd op: https://gml.noaa.gov/grad/solcalc/solareqns.PDF
     /// </summary>
     public static class SunsetCalculator
     {
@@ -15,13 +15,13 @@ namespace SportlinkFunction.Planner
 
         private static TimeZoneInfo GetAmsterdamTimeZone()
         {
-            // Windows uses "W. Europe Standard Time", Linux uses "Europe/Amsterdam"
+            // Windows gebruikt "W. Europe Standard Time", Linux gebruikt "Europe/Amsterdam"
             try { return TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time"); }
             catch { return TimeZoneInfo.FindSystemTimeZoneById("Europe/Amsterdam"); }
         }
 
         /// <summary>
-        /// Calculate sunset time for a given date in local Amsterdam time.
+        /// Bereken zonsondergangstijd voor een bepaalde datum in lokale Amsterdam-tijd.
         /// </summary>
         public static TimeOnly GetSunset(DateOnly date)
         {

--- a/FunctionApp/docs/API.md
+++ b/FunctionApp/docs/API.md
@@ -1,41 +1,41 @@
-# VRC Sportlink API Documentation
+# VRC Sportlink API Documentatie
 
-**Base URL:** `http://localhost:7094/api`
+**Basis-URL:** `http://localhost:7094/api`
 
-All endpoints require a function key via `x-functions-key` header or `?code=` query parameter (except local development).
+Alle endpoints vereisen een functiesleutel via `x-functions-key` header of `?code=` queryparameter (behalve lokale ontwikkeling).
 
 ---
 
-## Endpoints Overview
+## Overzicht endpoints
 
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `GET` | `/sync-matches` | Manual Sportlink data sync |
-| `POST` | `/planner/check-availability` | Check field availability |
-| `POST` | `/planner/bevestig` | Book a match slot |
-| `POST` | `/planner/populate-sunset` | Populate sunset lookup table |
+| Methode | Endpoint | Beschrijving |
+|---------|----------|-------------|
+| `GET` | `/sync-matches` | Handmatige Sportlink data synchronisatie |
+| `POST` | `/planner/check-availability` | Veldbeschikbaarheid controleren |
+| `POST` | `/planner/bevestig` | Wedstrijdslot boeken |
+| `POST` | `/planner/populate-sunset` | Zonsondergangtabel vullen |
 
 ---
 
 ## GET /api/sync-matches
 
-Manually trigger a Sportlink API sync (teams, matches, match details).
+Handmatig een Sportlink API synchronisatie starten (teams, wedstrijden, wedstrijddetails).
 
-### Query Parameters
+### Queryparameters
 
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `reset` | `boolean` | No | `true` = full season sync instead of incremental |
-| `season` | `integer` | No | Season start year (e.g. `2024`). Used with `reset=true` |
+| Parameter | Type | Verplicht | Beschrijving |
+|-----------|------|-----------|-------------|
+| `reset` | `boolean` | Nee | `true` = volledige seizoensynchronisatie in plaats van incrementeel |
+| `season` | `integer` | Nee | Startjaar seizoen (bijv. `2024`). Gebruikt met `reset=true` |
 
-### Example
+### Voorbeeld
 
 ```
 GET /api/sync-matches
 GET /api/sync-matches?reset=true&season=2025
 ```
 
-### Response
+### Antwoord
 
 ```
 200 OK
@@ -45,9 +45,9 @@ GET /api/sync-matches?reset=true&season=2025
 
 ## POST /api/planner/check-availability
 
-Check if a field is available for a friendly/practice match. Returns a specific slot assignment, available time windows, or a team conflict.
+Controleer of een veld beschikbaar is voor een oefenwedstrijd. Geeft een specifieke slottoewijzing, beschikbare tijdvensters, of een teamconflict terug.
 
-### Request Body
+### Aanvraag
 
 ```json
 {
@@ -61,21 +61,21 @@ Check if a field is available for a friendly/practice match. Returns a specific 
 }
 ```
 
-### Request Fields
+### Aanvraagvelden
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `datum` | `string` | **Yes** | Date in `yyyy-MM-dd` format |
-| `aanvangsTijd` | `string` | No | Preferred kick-off time `HH:mm`. Omit to find best slot |
-| `dagdeel` | `string` | No | Time-of-day filter: `"ochtend"`, `"middag"`, or `"avond"` |
-| `leeftijdsCategorie` | `string` | No | Age category (e.g. `JO11`, `MO17`, `VR`, `1-99`). Determines match duration and field size. Omit to get available windows |
-| `teamNaam` | `string` | No | Team name for conflict check and team-specific rules |
-| `tegenstander` | `string` | No | Opponent name (for records only) |
-| `wedstrijdDuurMinuten` | `integer` | No | Override match duration in minutes (default from Speeltijden) |
+| Veld | Type | Verplicht | Beschrijving |
+|------|------|-----------|-------------|
+| `datum` | `string` | **Ja** | Datum in `yyyy-MM-dd` formaat |
+| `aanvangsTijd` | `string` | Nee | Gewenste aftrapttijd `HH:mm`. Weglaten om beste slot te vinden |
+| `dagdeel` | `string` | Nee | Dagdeelfilter: `"ochtend"`, `"middag"`, of `"avond"` |
+| `leeftijdsCategorie` | `string` | Nee | Leeftijdscategorie (bijv. `JO11`, `MO17`, `VR`, `1-99`). Bepaalt wedstrijdduur en veldgrootte. Weglaten voor beschikbare vensters |
+| `teamNaam` | `string` | Nee | Teamnaam voor conflictcontrole en teamspecifieke regels |
+| `tegenstander` | `string` | Nee | Tegenstander (alleen voor administratie) |
+| `wedstrijdDuurMinuten` | `integer` | Nee | Overschrijf wedstrijdduur in minuten (standaard uit Speeltijden) |
 
-### Response — Slot Assigned (200)
+### Antwoord — Slot toegewezen (200)
 
-When `leeftijdsCategorie` is provided and a slot is available:
+Als `leeftijdsCategorie` is opgegeven en een slot beschikbaar is:
 
 ```json
 {
@@ -97,9 +97,9 @@ When `leeftijdsCategorie` is provided and a slot is available:
 }
 ```
 
-### Response — Unavailable with Alternatives (200)
+### Antwoord — Niet beschikbaar met alternatieven (200)
 
-When the requested time is not available:
+Als de gevraagde tijd niet beschikbaar is:
 
 ```json
 {
@@ -132,9 +132,9 @@ When the requested time is not available:
 }
 ```
 
-### Response — Available Windows (200)
+### Antwoord — Beschikbare vensters (200)
 
-When `leeftijdsCategorie` is omitted — returns open time windows per field:
+Als `leeftijdsCategorie` niet is opgegeven — geeft open tijdvensters per veld:
 
 ```json
 {
@@ -159,9 +159,9 @@ When `leeftijdsCategorie` is omitted — returns open time windows per field:
 }
 ```
 
-### Response — Team Conflict (200)
+### Antwoord — Teamconflict (200)
 
-When the team already has a match on the requested date:
+Als het team al een wedstrijd heeft op de gevraagde datum:
 
 ```json
 {
@@ -180,9 +180,9 @@ When the team already has a match on the requested date:
 }
 ```
 
-### Response — No Matches Allowed (200)
+### Antwoord — Geen wedstrijden toegestaan (200)
 
-When the requested day does not allow matches (Friday/Sunday):
+Als de gevraagde dag geen wedstrijden toelaat (vrijdag/zondag):
 
 ```json
 {
@@ -196,19 +196,19 @@ When the requested day does not allow matches (Friday/Sunday):
 }
 ```
 
-### Response Fields
+### Antwoordvelden
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `beschikbaar` | `boolean` | Whether a slot is available |
-| `toewijzing` | `object\|null` | Assigned slot (Mode 1 only) |
-| `teamConflict` | `object\|null` | Existing match for the team on this date |
-| `reden` | `string\|null` | Reason when unavailable |
-| `alternatieven` | `array` | Up to 3 alternative time slots |
-| `beschikbareVensters` | `array\|null` | Available windows per field (Mode 2 only) |
-| `waarschuwingen` | `array` | Warnings (sunset margin, weekday restrictions) |
+| Veld | Type | Beschrijving |
+|------|------|-------------|
+| `beschikbaar` | `boolean` | Of een slot beschikbaar is |
+| `toewijzing` | `object\|null` | Toegewezen slot (alleen Modus 1) |
+| `teamConflict` | `object\|null` | Bestaande wedstrijd voor het team op deze datum |
+| `reden` | `string\|null` | Reden als niet beschikbaar |
+| `alternatieven` | `array` | Tot 3 alternatieve tijdsloten |
+| `beschikbareVensters` | `array\|null` | Beschikbare vensters per veld (alleen Modus 2) |
+| `waarschuwingen` | `array` | Waarschuwingen (zonsondergangmarge, doordeweekse beperkingen) |
 
-### Error Response (400)
+### Foutantwoord (400)
 
 ```json
 {
@@ -220,9 +220,9 @@ When the requested day does not allow matches (Friday/Sunday):
 
 ## POST /api/planner/bevestig
 
-Confirm and book a match slot. Writes to `planner.GeplandeWedstrijden` table.
+Bevestig en boek een wedstrijdslot. Schrijft naar de `planner.GeplandeWedstrijden` tabel.
 
-### Request Body
+### Aanvraag
 
 ```json
 {
@@ -237,18 +237,18 @@ Confirm and book a match slot. Writes to `planner.GeplandeWedstrijden` table.
 }
 ```
 
-### Request Fields
+### Aanvraagvelden
 
-| Field | Type | Required | Description |
+| Veld | Type | Verplicht | Beschrijving |
 |-------|------|----------|-------------|
-| `datum` | `string` | **Yes** | Date in `yyyy-MM-dd` format |
-| `aanvangsTijd` | `string` | **Yes** | Kick-off time `HH:mm` |
-| `veldNummer` | `integer` | **Yes** | Field number (1-5) |
-| `leeftijdsCategorie` | `string` | No | Age category for auto duration/field size |
-| `teamNaam` | `string` | No | Team name |
-| `tegenstander` | `string` | No | Opponent name |
-| `aangevraagdDoor` | `string` | No | Who requested (email, phone, name) |
-| `wedstrijdDuurMinuten` | `integer` | No | Override match duration (default from Speeltijden or 105) |
+| `datum` | `string` | **Ja** | Datum in `yyyy-MM-dd` formaat |
+| `aanvangsTijd` | `string` | **Ja** | Aftrapttijd `HH:mm` |
+| `veldNummer` | `integer` | **Ja** | Veldnummer (1-5) |
+| `leeftijdsCategorie` | `string` | Nee | Leeftijdscategorie voor automatische duur/veldgrootte |
+| `teamNaam` | `string` | Nee | Teamnaam |
+| `tegenstander` | `string` | Nee | Tegenstander |
+| `aangevraagdDoor` | `string` | Nee | Wie het verzoek heeft gedaan |
+| `wedstrijdDuurMinuten` | `integer` | Nee | Overschrijf wedstrijdduur (standaard uit Speeltijden of 105) |
 
 ### Response (200)
 
@@ -263,18 +263,18 @@ Confirm and book a match slot. Writes to `planner.GeplandeWedstrijden` table.
 }
 ```
 
-### Response Fields
+### Antwoordvelden
 
-| Field | Type | Description |
+| Veld | Type | Beschrijving |
 |-------|------|-------------|
-| `id` | `integer` | Database ID of the booked match |
-| `datum` | `string` | Confirmed date |
-| `aanvangsTijd` | `string` | Confirmed kick-off time |
-| `eindTijd` | `string` | Calculated end time |
-| `veldNummer` | `integer` | Assigned field |
-| `status` | `string` | Always `"Gepland"` on creation |
+| `id` | `integer` | Database-ID van de geboekte wedstrijd |
+| `datum` | `string` | Bevestigde datum |
+| `aanvangsTijd` | `string` | Bevestigde aftrapttijd |
+| `eindTijd` | `string` | Berekende eindtijd |
+| `veldNummer` | `integer` | Toegewezen veld |
+| `status` | `string` | Altijd `"Gepland"` bij aanmaak |
 
-### Error Response (400)
+### Foutantwoord (400)
 
 ```json
 {
@@ -286,13 +286,13 @@ Confirm and book a match slot. Writes to `planner.GeplandeWedstrijden` table.
 
 ## POST /api/planner/populate-sunset
 
-Populate the sunset lookup table with NOAA-calculated sunset times for Veenendaal. Run once after initial setup, or when the season/date range expands.
+Vul de zonsondergangtabel met NOAA-berekende tijden voor Veenendaal. Eenmalig uitvoeren na initiële setup, of wanneer het seizoen/datumbereik wordt uitgebreid.
 
-### Request Body
+### Aanvraag
 
-None (empty POST).
+Geen (lege POST).
 
-### Response (200)
+### Antwoord (200)
 
 ```json
 {
@@ -302,46 +302,46 @@ None (empty POST).
 
 ---
 
-## Scheduling Rules Reference
+## Overzicht planningsregels
 
-### Field Availability
+### Veldbeschikbaarheid
 
-| Day | Fields | Hours | Notes |
-|-----|--------|-------|-------|
-| Monday-Thursday | Veld 5 only | 18:00 - sunset | No lights, veld 1-4 training |
-| Friday | None | - | No matches |
-| Saturday | Veld 1-5 | 08:30 - 22:00 (1-4) / 08:30 - 17:00 (5) | 10 min buffer |
-| Sunday | None | - | No matches |
+| Dag | Velden | Tijdvenster | Opmerkingen |
+|-----|--------|-------------|-------------|
+| Maandag-Donderdag | Alleen veld 5 | 18:00 - zonsondergang | Geen kunstlicht, veld 1-4 training |
+| Vrijdag | Geen | - | Geen wedstrijden |
+| Zaterdag | Veld 1-5 | 08:30 - 22:00 (1-4) / 08:30 - 17:00 (5) | 10 min buffer |
+| Zondag | Geen | - | Geen wedstrijden |
 
-### Field Priority
+### Veldvoorkeur
 
-Veld 1 > Veld 2 > Veld 3 > Veld 4 > Veld 5 (last resort)
+Veld 1 > Veld 2 > Veld 3 > Veld 4 > Veld 5 (laatste keuze)
 
-### Age Categories (Speeltijden)
+### Leeftijdscategorieën (Speeltijden)
 
-| Category | Field Size | Duration | Field Sharing |
+| Categorie | Veldgrootte | Duur | Veld delen |
 |----------|-----------|----------|---------------|
-| JO7, JO8, JO9 | 0.25 (quarter) | 50 min | 4 per field |
-| JO10 | 0.25 (quarter) | 65 min | 4 per field |
-| JO11, JO12 | 0.50 (half) | 75 min | 2 per field |
-| JO13, MO13 | 1.00 (full) | 75 min | 1 per field |
-| JO14, JO15 | 1.00 (full) | 85 min | 1 per field |
-| MO15 | 1.00 (full) | 85 min | 1 per field |
-| JO16, JO17, MO17 | 1.00 (full) | 95 min | 1 per field |
-| JO18, JO19, JO23, MO19, MO20, VR, 1-99 | 1.00 (full) | 105 min | 1 per field |
+| JO7, JO8, JO9 | 0.25 (kwart) | 50 min | 4 per veld |
+| JO10 | 0.25 (kwart) | 65 min | 4 per veld |
+| JO11, JO12 | 0.50 (half) | 75 min | 2 per veld |
+| JO13, MO13 | 1.00 (heel) | 75 min | 1 per veld |
+| JO14, JO15 | 1.00 (heel) | 85 min | 1 per veld |
+| MO15 | 1.00 (heel) | 85 min | 1 per veld |
+| JO16, JO17, MO17 | 1.00 (heel) | 95 min | 1 per veld |
+| JO18, JO19, JO23, MO19, MO20, VR, 1-99 | 1.00 (heel) | 105 min | 1 per veld |
 
-### Team-Specific Rules (dbo.TeamRegels)
+### Teamspecifieke regels (dbo.TeamRegels)
 
-| Team | Rule | Value |
+| Team | Regel | Waarde |
 |------|------|-------|
-| VRC 1 | BufferVoor | 60 min before match, no other matches on same field |
-| VRC 1 | BufferNa | 30 min after match, no other matches on same field |
+| VRC 1 | BufferVoor | 60 min voor wedstrijd, geen andere wedstrijden op hetzelfde veld |
+| VRC 1 | BufferNa | 30 min na wedstrijd, geen andere wedstrijden op hetzelfde veld |
 
 ---
 
-## curl Examples
+## curl Voorbeelden
 
-### Check availability for JO13 on a Saturday
+### Beschikbaarheid controleren voor JO13 op zaterdag
 
 ```bash
 curl -X POST http://localhost:7094/api/planner/check-availability \
@@ -349,7 +349,7 @@ curl -X POST http://localhost:7094/api/planner/check-availability \
   -d '{"datum":"2026-04-25","aanvangsTijd":"12:00","leeftijdsCategorie":"JO13"}'
 ```
 
-### Check Monday evening availability (no category)
+### Maandagavond beschikbaarheid controleren (zonder categorie)
 
 ```bash
 curl -X POST http://localhost:7094/api/planner/check-availability \
@@ -357,7 +357,7 @@ curl -X POST http://localhost:7094/api/planner/check-availability \
   -d '{"datum":"2026-05-18","dagdeel":"avond"}'
 ```
 
-### Check with team conflict detection
+### Controleren met teamconflictdetectie
 
 ```bash
 curl -X POST http://localhost:7094/api/planner/check-availability \
@@ -365,7 +365,7 @@ curl -X POST http://localhost:7094/api/planner/check-availability \
   -d '{"datum":"2026-05-16","aanvangsTijd":"12:00","leeftijdsCategorie":"JO11","teamNaam":"VRC JO11-9"}'
 ```
 
-### Book a match
+### Wedstrijd boeken
 
 ```bash
 curl -X POST http://localhost:7094/api/planner/bevestig \
@@ -373,13 +373,13 @@ curl -X POST http://localhost:7094/api/planner/bevestig \
   -d '{"datum":"2026-04-25","aanvangsTijd":"12:00","veldNummer":3,"leeftijdsCategorie":"JO13","teamNaam":"VRC JO13-1","tegenstander":"Ede JO13-2","aangevraagdDoor":"coach@vrc.nl"}'
 ```
 
-### Populate sunset table
+### Zonsondergangtabel vullen
 
 ```bash
 curl -X POST http://localhost:7094/api/planner/populate-sunset
 ```
 
-### Manual Sportlink sync
+### Handmatige Sportlink synchronisatie
 
 ```bash
 curl http://localhost:7094/api/sync-matches


### PR DESCRIPTION
## Samenvatting
- ARCHITECTURE.md volledig vertaald naar Nederlands (sectiekoppen, beschrijvingen, toelichting)
- API.md volledig vertaald naar Nederlands (alle koppen, tabellen, veldbeschrijvingen, voorbeelden)
- Code comments in PlannerService.cs (~25 comments), PlannerModels.cs, PlannerDataAccess.cs en SunsetCalculator.cs vertaald
- CLAUDE.md bestanden bewust in het Engels gelaten (worden door Claude Code gelezen)
- Variabele- en methodenamen blijven Engels (technische conventie)

## Testplan
- [ ] `dotnet build` compileert zonder fouten
- [ ] Geen Engelse koppen of beschrijvingen meer in ARCHITECTURE.md en API.md
- [ ] Code comments in Planner bestanden zijn Nederlands

Sluit #7

🤖 Gegenereerd met [Claude Code](https://claude.com/claude-code)