### PR TITLE
Corrigeer 10 minuten buffer tussen wedstrijden

### DIFF
--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -296,56 +296,57 @@ namespace SportlinkFunction.Planner
                     bufferNa = Math.Max(bufferNa, rule.WaardeMinuten.Value);
             }
 
-            var bufferedStart = start.AddMinutes(-bufferVoor);
-            var bufferedEnd = end.AddMinutes(bufferNa);
-
             foreach (var occ in fieldOccupations)
             {
-                // Controleer of tijdvensters overlappen
-                bool overlaps = occ.AanvangsTijd < bufferedEnd && occ.EindTijd > bufferedStart;
-                if (!overlaps) continue;
-
-                // Voor deelveld-wedstrijden, capaciteit controleren tijdens de wedstrijd (niet buffertijd)
-                if (veldFractie < 1.0m && occ.VeldDeelGebruik < 1.0m)
-                {
-                    // Alleen daadwerkelijke overlap controleren (geen buffers) voor deelveld-capaciteit
-                    bool actualOverlap = occ.AanvangsTijd < end && occ.EindTijd > start;
-                    if (actualOverlap)
-                    {
-                        // Totale capaciteit controleren voor dit tijdslot
-                        decimal usedCapacity = fieldOccupations
-                            .Where(o => o.AanvangsTijd < end && o.EindTijd > start)
-                            .Sum(o => o.VeldDeelGebruik);
-                        if (usedCapacity + veldFractie > 1.0m)
-                            return false;
-                        continue; // deelveld delen is prima als capaciteit het toelaat
-                    }
-                    continue;
-                }
-
-                // Voor heel-veld wedstrijden, of als bestaande wedstrijd heel veld is: conflict
-                if (veldFractie >= 1.0m || occ.VeldDeelGebruik >= 1.0m)
-                    return false;
-
-                // Controleer ook bufferregels van bestaand team
+                // Controleer bufferregels van bestaand team
+                int occBufVoor = StandardBufferMinutes;
+                int occBufNa = StandardBufferMinutes;
                 if (!string.IsNullOrEmpty(occ.TeamNaam) && allTeamRules.TryGetValue(occ.TeamNaam, out var existingRules))
                 {
-                    int existingBufVoor = StandardBufferMinutes;
-                    int existingBufNa = StandardBufferMinutes;
                     foreach (var rule in existingRules)
                     {
                         if (rule.RegelType == "BufferVoor" && rule.WaardeMinuten.HasValue)
-                            existingBufVoor = Math.Max(existingBufVoor, rule.WaardeMinuten.Value);
+                            occBufVoor = Math.Max(occBufVoor, rule.WaardeMinuten.Value);
                         if (rule.RegelType == "BufferNa" && rule.WaardeMinuten.HasValue)
-                            existingBufNa = Math.Max(existingBufNa, rule.WaardeMinuten.Value);
+                            occBufNa = Math.Max(occBufNa, rule.WaardeMinuten.Value);
                     }
-
-                    var existingBufferedStart = occ.AanvangsTijd.AddMinutes(-existingBufVoor);
-                    var existingBufferedEnd = occ.EindTijd.AddMinutes(existingBufNa);
-
-                    if (start < existingBufferedEnd && end > existingBufferedStart)
-                        return false;
                 }
+
+                // Daadwerkelijke overlap: spelen beide wedstrijden tegelijkertijd?
+                bool gelijktijdig = occ.AanvangsTijd < end && occ.EindTijd > start;
+
+                if (gelijktijdig)
+                {
+                    // Deelveld-sharing: alleen toegestaan als wedstrijden op EXACT hetzelfde
+                    // tijdstip beginnen (bewust als blok ingepland). Wedstrijden die toevallig
+                    // overlappen door verschillende start-/eindtijden delen het veld NIET.
+                    bool zelfdeStarttijd = occ.AanvangsTijd == start;
+                    if (zelfdeStarttijd && veldFractie < 1.0m && occ.VeldDeelGebruik < 1.0m)
+                    {
+                        decimal gebruikteCapaciteit = fieldOccupations
+                            .Where(o => o.AanvangsTijd == start)
+                            .Sum(o => o.VeldDeelGebruik);
+                        if (gebruikteCapaciteit + veldFractie > 1.0m)
+                            return false;
+                        // Deelveld delen is prima als capaciteit het toelaat
+                        continue;
+                    }
+                    // Overlap maar niet zelfde starttijd, of heel-veld: conflict
+                    return false;
+                }
+
+                // Niet gelijktijdig: controleer buffer (10 min standaard, of teamspecifiek)
+                // Nieuwe wedstrijd mag niet in de bufferzone van bestaande wedstrijd vallen
+                var occBeschermdeStart = occ.AanvangsTijd.AddMinutes(-occBufVoor);
+                var occBeschermdeEinde = occ.EindTijd.AddMinutes(occBufNa);
+                if (start < occBeschermdeEinde && end > occBeschermdeStart)
+                    return false;
+
+                // Bestaande wedstrijd mag niet in de bufferzone van nieuwe wedstrijd vallen
+                var nieuwBeschermdeStart = start.AddMinutes(-bufferVoor);
+                var nieuwBeschermdeEinde = end.AddMinutes(bufferNa);
+                if (occ.AanvangsTijd < nieuwBeschermdeEinde && occ.EindTijd > nieuwBeschermdeStart)
+                    return false;
             }
 
             return true;


### PR DESCRIPTION
## Samenvatting
- De 10 minuten buffer tussen opeenvolgende wedstrijden op hetzelfde veld werd niet afgedwongen bij deelveld-wedstrijden (kwart/half veld)
- Alleen gelijktijdige deelveld-wedstrijden mogen de buffer overslaan (capaciteitscheck: som <= 1.00)
- Wedstrijden die na elkaar komen krijgen nu altijd de buffer (10 min standaard, teamspecifiek bij VRC 1: 60 min voor, 30 min na)

## Testplan
- [ ] JO8 om 10:00 op 9 mei wordt afgewezen (JO11-1 eindigt 10:30, buffer tot 10:40, maar 10:10 past wel gelijktijdig als deelveld)
- [ ] VRC 1 bufferzone (13:00-14:00 voor, 15:30-16:00 na) blokkeert correct
- [ ] Gelijktijdige deelveld-wedstrijden (bijv. JO8 + JO11 = 0.75 < 1.00) worden nog steeds geaccepteerd

🤖 Gegenereerd met [Claude Code](https://claude.com/claude-code)