### PR TITLE
Versoepel deelveld-sharing capaciteitscheck

### DIFF
--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -317,21 +317,29 @@ namespace SportlinkFunction.Planner
 
                 if (gelijktijdig)
                 {
-                    // Deelveld-sharing: alleen toegestaan als wedstrijden op EXACT hetzelfde
-                    // tijdstip beginnen (bewust als blok ingepland). Wedstrijden die toevallig
-                    // overlappen door verschillende start-/eindtijden delen het veld NIET.
-                    bool zelfdeStarttijd = occ.AanvangsTijd == start;
-                    if (zelfdeStarttijd && veldFractie < 1.0m && occ.VeldDeelGebruik < 1.0m)
+                    // Deelveld-sharing: beide wedstrijden gebruiken een deel van het veld
+                    // en overlappen in de tijd. Controleer of de totale capaciteit past.
+                    // Alleen toegestaan als GEEN van beide een heel veld (1.00) gebruikt.
+                    if (veldFractie < 1.0m && occ.VeldDeelGebruik < 1.0m)
                     {
-                        decimal gebruikteCapaciteit = fieldOccupations
-                            .Where(o => o.AanvangsTijd == start)
-                            .Sum(o => o.VeldDeelGebruik);
-                        if (gebruikteCapaciteit + veldFractie > 1.0m)
+                        // Controleer totale capaciteit op het drukste moment:
+                        // alle wedstrijden die overlappen met het nieuwe tijdvenster
+                        decimal maxCapaciteitInGebruik = 0;
+                        // Scan per minuut van start tot end om het drukste moment te vinden
+                        for (var checkTime = start; checkTime < end; checkTime = checkTime.AddMinutes(5))
+                        {
+                            var checkEnd = checkTime.AddMinutes(5);
+                            decimal capaciteitOpMoment = fieldOccupations
+                                .Where(o => o.VeldDeelGebruik < 1.0m && o.AanvangsTijd < checkEnd && o.EindTijd > checkTime)
+                                .Sum(o => o.VeldDeelGebruik);
+                            maxCapaciteitInGebruik = Math.Max(maxCapaciteitInGebruik, capaciteitOpMoment);
+                        }
+                        if (maxCapaciteitInGebruik + veldFractie > 1.0m)
                             return false;
                         // Deelveld delen is prima als capaciteit het toelaat
                         continue;
                     }
-                    // Overlap maar niet zelfde starttijd, of heel-veld: conflict
+                    // Overlap met heel-veld wedstrijd: altijd conflict
                     return false;
                 }
 


### PR DESCRIPTION
## Samenvatting
De vorige logica stond deelveld-sharing alleen toe bij exact dezelfde aanvangstijd. In de praktijk worden deelveld-wedstrijden (kwart/half veld) in blokken ingepland met verschillende starttijden die het veld delen.

Nieuwe logica: bij overlappende deelveld-wedstrijden wordt het drukste moment berekend (scan per 5 minuten). Alleen als de totale capaciteit op elk moment <= 1.00 is, past de wedstrijd.

## Voorbeeld
Veld 2 op 11 april om 09:30: JO8-8JM (0.25) staat er al. Een JO9 (0.25) past erbij (samen 0.50). Voorheen werd dit geweigerd.

## Testplan
- [ ] JO9 om 09:30 op 11 april → beschikbaar op veld 2 (naast JO8-8JM)
- [ ] Hele-veld wedstrijden worden nog steeds geblokkeerd bij overlap
- [ ] Deelveld-wedstrijden op vol veld (4x0.25 = 1.00) worden nog steeds geblokkeerd

🤖 Gegenereerd met [Claude Code](https://claude.com/claude-code)