### PR TITLE
Programma als primaire bron voor toekomstige wedstrijden

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,8 @@ Full docs: https://sportlinkservices.github.io/navajofeeds-json-parser/article/
 | Endpoint | Path | Notes |
 |---|---|---|
 | Teams | `/teams?clientId=` | All club teams |
-| Match results | `/uitslagen?clientId=&weekoffset=` | Results by week offset |
+| **Programma** | `/programma?clientId=&weekoffset=` | **Primaire bron** voor alle wedstrijden (competitie, beker, oefenwedstrijden). Bevat scheidsrechter, veld, kleedkamers, logos |
+| Uitslagen | `/uitslagen?clientId=&weekoffset=` | Alleen scoreverrijking voor verleden wedstrijden. Mag geen toekomstige wedstrijden toevoegen of programma-velden overschrijven |
 | Match details | `/wedstrijd-informatie?clientId=&wedstrijdcode=` | Per-match detail |
-| *Programma* | `/programma?clientId=` | Not yet implemented; richer than uitslagen (includes referee, venue, logos) |
 
 See `FunctionApp/CLAUDE.md` for detailed field reference including all `/programma` fields.

--- a/FunctionApp/CLAUDE.md
+++ b/FunctionApp/CLAUDE.md
@@ -188,17 +188,26 @@ Full docs: https://sportlinkservices.github.io/navajofeeds-json-parser/article/
 | Endpoint | URL | Description |
 |---|---|---|
 | teams | `/teams?clientId=` | All teams for the club |
-| matches (uitslagen) | `/uitslagen?clientId=&weekoffset=` | Match results per week offset |
+| programma | `/programma?clientId=&weekoffset=` | **Primaire bron** voor alle wedstrijden (competitie, beker, oefenwedstrijden). Bevat rijkere data: scheidsrechter, veld, kleedkamers, logos, vertrek-/verzameltijd |
+| uitslagen | `/uitslagen?clientId=&weekoffset=` | **Alleen scoreverrijking** voor verleden wedstrijden. Voegt uitslag, uitslag-regulier, etc. toe aan bestaande programma-rijen. Voegt GEEN nieuwe toekomstige wedstrijden toe |
 | match details | `/wedstrijd-informatie?clientId=&wedstrijdcode=` | Full detail per match |
 
 ### Available endpoints (not yet implemented)
 
 | Endpoint | URL | Description |
 |---|---|---|
-| programma | `/programma?clientId=` | Upcoming schedule with referee/venue info |
 | standen | `/standen?clientId=` | League standings |
 | spelers | `/spelers?clientId=` | Player roster |
-| wedstrijd-informatie | `/wedstrijd-informatie?clientId=&wedstrijdcode=` | Already in use as matchdetails |
+
+### Sync strategie: programma vs uitslagen
+
+`/programma` is de **single source of truth** voor toekomstige wedstrijden. `/uitslagen` mag:
+- Bestaande rijen verrijken met scorevelden (UPDATE alleen score-kolommen)
+- Nieuwe rijen toevoegen voor verleden wedstrijden die niet via `/programma` binnenkwamen
+
+`/uitslagen` mag NIET:
+- Gedeelde velden overschrijven (wedstrijd, thuisteam, uitteam, veld, aanvangstijd, etc.)
+- Nieuwe rijen toevoegen voor toekomstige wedstrijden
 
 ### Programma endpoint — all available fields
 
@@ -243,7 +252,7 @@ Fetched live from `https://data.sportlink.com/programma?clientId=YOUR_CLIENT_ID`
 | `kleedkamerscheidsrechter` | string | Referee changing room | `` |
 | `meer` | string | Link to match detail | `wedstrijd-informatie?wedstrijdcode=19816434` |
 
-> **Note:** `programma` returns upcoming fixtures with richer info than `uitslagen` (includes logos, referee, venue, changing rooms, gather/depart times). Consider using this as the primary matches source in a future iteration.
+> **Note:** `programma` is de primaire bron voor alle wedstrijden (competitie, beker én oefenwedstrijden). `/uitslagen` verrijkt alleen bestaande rijen met scores en voegt historische rijen toe voor verleden wedstrijden.
 
 ## Key Dependencies
 

--- a/FunctionApp/Function1.cs
+++ b/FunctionApp/Function1.cs
@@ -557,7 +557,9 @@ namespace SportlinkFunction
                 int updated = 0;
                 foreach (var match in matches)
                 {
-                    // UPDATE score fields on existing programma row; INSERT full row if not present
+                    // UPDATE: alleen scorevelden bijwerken op bestaande programma-rij.
+                    // INSERT: alleen voor verleden wedstrijden die niet via /programma binnenkwamen.
+                    // /programma is de primaire bron voor toekomstige wedstrijden (inclusief oefenwedstrijden).
                     string query = @"
                         IF EXISTS (SELECT 1 FROM [stg].[matches] WHERE [wedstrijdcode] = @wedstrijdcode)
                             UPDATE [stg].[matches] SET
@@ -571,23 +573,8 @@ namespace SportlinkFunction
                                 ,[sportomschrijving]    = @sportomschrijving
                                 ,[verenigingswedstrijd] = @verenigingswedstrijd
                                 ,[status]               = @status
-                                ,[wedstrijddatum]       = @wedstrijddatum
-                                ,[datum]                = @datum
-                                ,[wedstrijd]            = @wedstrijd
-                                ,[accommodatie]         = @accommodatie
-                                ,[aanvangstijd]         = @aanvangstijd
-                                ,[thuisteam]            = @thuisteam
-                                ,[thuisteamid]          = @thuisteamid
-                                ,[thuisteamlogo]        = @thuisteamlogo
-                                ,[thuisteamclubrelatiecode] = @thuisteamclubrelatiecode
-                                ,[uitteamclubrelatiecode]   = @uitteamclubrelatiecode
-                                ,[uitteam]              = @uitteam
-                                ,[uitteamid]            = @uitteamid
-                                ,[uitteamlogo]          = @uitteamlogo
-                                ,[competitiesoort]      = @competitiesoort
-                                ,[meer]                 = @meer
                             WHERE [wedstrijdcode] = @wedstrijdcode
-                        ELSE
+                        ELSE IF @wedstrijddatum <= CONVERT(NVARCHAR(50), GETDATE(), 127)
                             INSERT INTO [stg].[matches] (
                                  [wedstrijddatum],[wedstrijdcode],[wedstrijdnummer],[datum],[wedstrijd]
                                 ,[accommodatie],[aanvangstijd],[thuisteam],[thuisteamid],[thuisteamlogo]


### PR DESCRIPTION
## Samenvatting

- `/programma` is nu de **single source of truth** voor alle toekomstige wedstrijden (competitie, beker én oefenwedstrijden)
- `/uitslagen` mag alleen nog scorevelden bijwerken (UPDATE) en verleden wedstrijden toevoegen (INSERT)
- `/uitslagen` overschrijft **geen** gedeelde velden meer (wedstrijd, thuisteam, uitteam, veld, aanvangstijd, etc.)

## Aanleiding

De oefenwedstrijd **VRC JO14-2 - SCW'23 JO14-1** (15 april, veld 5) werd in de database getoond als **VRC JO14-2 - DTS JO14-2**. De `/uitslagen` API retourneerde verouderde tegenstanderdata en overschreef de correcte `/programma`-gegevens.

## Wijzigingen

### `FunctionApp/Function1.cs`
- **UPDATE-branch**: verwijderd dat gedeelde velden (wedstrijd, thuisteam, uitteam, aanvangstijd, logos, etc.) worden overschreven. Alleen scorevelden (uitslag, uitslag-regulier, status, etc.) worden nog bijgewerkt
- **INSERT-branch**: datumfilter toegevoegd (`@wedstrijddatum <= GETDATE()`), zodat alleen verleden wedstrijden worden ingevoegd. Toekomstige wedstrijden die niet via `/programma` binnenkomen worden genegeerd

### `CLAUDE.md` + `FunctionApp/CLAUDE.md`
- Documentatie bijgewerkt: `/programma` als primaire bron, sync-strategie beschreven
- Verouderde vermelding "not yet implemented" verwijderd

## Testplan

- [ ] Build slaagt (`dotnet build -c Debug`)
- [ ] Sync uitvoeren: `GET /api/sync-matches?reset=true&season=2025`
- [ ] Controleer dat oefenwedstrijden de juiste tegenstander tonen (vergelijk met Sportlink portal)
- [ ] Controleer dat verleden wedstrijden nog steeds scores bevatten in `his.matches`
- [ ] Controleer dat toekomstige wedstrijden NIET via `/uitslagen` worden ingevoegd

🤖 Generated with [Claude Code](https://claude.com/claude-code)