### PR TITLE
Sla LastSyncTimestamp op na sync

### DIFF
--- a/Database/dbo/Tables/AppSettings.sql
+++ b/Database/dbo/Tables/AppSettings.sql
@@ -2,5 +2,6 @@
 	[ClubName]			NVARCHAR(100)	NOT NULL,
 	[SportlinkApiUrl]	NVARCHAR(100)	NOT NULL,
 	[SportlinkClientId]	NVARCHAR(50)	NOT NULL,
-	[SeasonStartMonth]	[int]			NOT NULL
+	[SeasonStartMonth]	[int]			NOT NULL,
+	[LastSyncTimestamp]	DATETIME2		NULL
 	)

--- a/FunctionApp/Function1.cs
+++ b/FunctionApp/Function1.cs
@@ -147,6 +147,8 @@ namespace SportlinkFunction
             await new MergeStgToHis("stg", "teams",        "his", "teams").ExecuteAsync(log);
             await new MergeStgToHis("stg", "matches",      "his", "matches").ExecuteAsync(log);
             await new MergeStgToHis("stg", "matchdetails", "his", "matchdetails").ExecuteAsync(log);
+
+            await SystemUtilities.AppSettings.SaveLastSyncTimestampAsync(log);
         }
 
         private static async Task FetchAndStoreMatchDetails(string apiUrl, ILogger log)

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -425,5 +425,17 @@ namespace SportlinkFunction.Planner
 
             return (int)(await cmd.ExecuteScalarAsync())!;
         }
+
+        public static async Task<DateTime?> GetLastSyncTimestampAsync()
+        {
+            using var conn = new SqlConnection(ConnectionString);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(
+                "SELECT [LastSyncTimestamp] FROM [dbo].[AppSettings]", conn);
+            var result = await cmd.ExecuteScalarAsync();
+            if (result != null && result != DBNull.Value)
+                return Convert.ToDateTime(result);
+            return null;
+        }
     }
 }

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -18,16 +18,18 @@ namespace SportlinkFunction
                     using (SqlConnection connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString))
                     {
                         await connection.OpenAsync();
-                        string query = "SELECT [SportlinkApiUrl], [SportlinkClientId] FROM [dbo].[AppSettings]";
+                        string query = "SELECT [SportlinkApiUrl], [SportlinkClientId], [LastSyncTimestamp] FROM [dbo].[AppSettings]";
                         using (SqlCommand command = new SqlCommand(query, connection))
                         using (SqlDataReader reader = await command.ExecuteReaderAsync())
                         {
                             while (await reader.ReadAsync())
                             {
-                                string sportlinkApiUrl          = reader["SportlinkApiUrl"].ToString() ?? string.Empty; 
+                                string sportlinkApiUrl          = reader["SportlinkApiUrl"].ToString() ?? string.Empty;
                                 string sportlinkClientId        = reader["SportlinkClientId"].ToString() ?? string.Empty;
                                 settings["sportlinkApiUrl"]     = sportlinkApiUrl;
                                 settings["sportlinkClientId"]   = sportlinkClientId;
+                                if (reader["LastSyncTimestamp"] != DBNull.Value)
+                                    settings["lastSyncTimestamp"] = Convert.ToDateTime(reader["LastSyncTimestamp"]).ToString("yyyy-MM-dd HH:mm:ss");
                             }
                         }
                     }
@@ -42,6 +44,23 @@ namespace SportlinkFunction
             public static string? GetSetting(string key)
             {
                 return settings.ContainsKey(key) ? settings[key] : null;
+            }
+
+            public static async Task SaveLastSyncTimestampAsync(ILogger log)
+            {
+                try
+                {
+                    using var connection = new SqlConnection(DatabaseConfig.ConnectionString);
+                    await connection.OpenAsync();
+                    using var command = new SqlCommand(
+                        "UPDATE [dbo].[AppSettings] SET [LastSyncTimestamp] = GETDATE()", connection);
+                    await command.ExecuteNonQueryAsync();
+                    log.LogInformation("Last sync timestamp updated.");
+                }
+                catch (Exception ex)
+                {
+                    log.LogError($"Error saving last sync timestamp: {ex.Message}");
+                }
             }
         }
         public static class DatabaseConfig


### PR DESCRIPTION
## Samenvatting

- Voegt `LastSyncTimestamp` kolom toe aan `dbo.AppSettings`
- Na elke succesvolle sync (timer + HTTP) wordt de actuele tijd opgeslagen
- `PlannerDataAccess.GetLastSyncTimestampAsync()` beschikbaar voor planner-endpoints
- `AppSettings.LoadSettingsAsync()` laadt de timestamp mee in de settings dictionary

## Aanleiding

Wanneer een wedstrijd is verplaatst in Sportlink maar nog niet gesynchroniseerd, moet de planner dit kunnen melden: "Wedstrijden bijgewerkt tot dd-mmmm, mogelijk is de wedstrijd nadien verplaatst."

## Wijzigingen

- `Database/dbo/Tables/AppSettings.sql` — kolom `LastSyncTimestamp DATETIME2 NULL`
- `FunctionApp/Utilities.cs` — query uitgebreid, `SaveLastSyncTimestampAsync()` toegevoegd
- `FunctionApp/Function1.cs` — na merge: timestamp opslaan
- `FunctionApp/Planner/PlannerDataAccess.cs` — `GetLastSyncTimestampAsync()`

## Migratie

Op bestaande databases: `ALTER TABLE [dbo].[AppSettings] ADD [LastSyncTimestamp] DATETIME2 NULL;`

## Testplan

- [ ] Build slaagt
- [ ] Sync uitvoeren → `SELECT LastSyncTimestamp FROM dbo.AppSettings` bevat timestamp
- [ ] Tweede sync → timestamp is bijgewerkt

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)