### PR TITLE
Detecteer lege zaterdag, sla optimalisatie over

### DIFF
--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -147,6 +147,14 @@ namespace SportlinkFunction.Planner
 
                 var format = req.Query.ContainsKey("format") ? req.Query["format"].ToString() : "";
 
+                if (response.VoldoendeRuimte && (format == "html" || format == "email"))
+                {
+                    var meldingHtml = $"<div style='background:#1a3a1a;border:1px solid #2ea043;padding:16px;border-radius:8px;margin-bottom:20px;color:#e6edf3;font-family:sans-serif;'>" +
+                        $"<strong>&#10003; {response.VoldoendeRuimteMelding}</strong></div>";
+                    var volleHtml = meldingHtml + response.HtmlPlanner;
+                    return new ContentResult { Content = volleHtml, ContentType = "text/html", StatusCode = 200 };
+                }
+
                 if (format == "html")
                     return new ContentResult { Content = response.HtmlPlanner, ContentType = "text/html", StatusCode = 200 };
 

--- a/FunctionApp/Planner/PlannerModels.cs
+++ b/FunctionApp/Planner/PlannerModels.cs
@@ -139,6 +139,18 @@ namespace SportlinkFunction.Planner
         public int AantalVanVeld5Verplaatst { get; set; }
         public List<OptimalisatieSuggestie> Suggesties { get; set; } = new();
         public string HtmlPlanner { get; set; } = string.Empty;
+        public bool VoldoendeRuimte { get; set; }
+        public string? VoldoendeRuimteMelding { get; set; }
+        public VeldCapaciteitInfo? CapaciteitOverzicht { get; set; }
+    }
+
+    public class VeldCapaciteitInfo
+    {
+        public int TotaalBeschikbareMinuten { get; set; }
+        public int TotaalBezettMinuten { get; set; }
+        public double BezettingsPercentage { get; set; }
+        public int AantalWedstrijdenOpVeld5 { get; set; }
+        public int AantalLegeVelden { get; set; }
     }
 
     public class OptimalisatieSuggestie

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -9,6 +9,7 @@ namespace SportlinkFunction.Planner
     public static class PlannerService
     {
         private const int StandardBufferMinutes = 15; // Standaard 15 min, kan per club verlaagd worden via dbo.AppSettings
+        private const double MaxBezettingsPercentageVoorOverslaan = 50.0;
 
         /// <summary>
         /// Rond aanvangstijd naar boven af op 5 minuten.
@@ -597,6 +598,23 @@ namespace SportlinkFunction.Planner
             // Buffer uit request of standaard
             int bufferMin = request.BufferMinuten ?? StandardBufferMinutes;
 
+            // Capaciteitsberekening: check of optimalisatie nodig is
+            var capaciteit = BerekenCapaciteit(bezettingen, availableFields);
+            response.CapaciteitOverzicht = capaciteit;
+
+            if (capaciteit.AantalWedstrijdenOpVeld5 == 0 && capaciteit.BezettingsPercentage < MaxBezettingsPercentageVoorOverslaan)
+            {
+                response.VoldoendeRuimte = true;
+                response.VoldoendeRuimteMelding =
+                    $"Voldoende ruimte op {date.ToString("dddd d MMMM", nl)}: " +
+                    $"geen wedstrijden op veld 5, {capaciteit.BezettingsPercentage:F0}% bezet " +
+                    $"({capaciteit.AantalLegeVelden} veld(en) ongebruikt). Geen optimalisatie nodig.";
+                response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(
+                    date, bezettingen, new List<OptimalisatieSuggestie>(), velden,
+                    request.Doel ?? "optimaliseren");
+                return response;
+            }
+
             var suggesties = new List<OptimalisatieSuggestie>();
             var doel = request.Doel?.ToLowerInvariant() ?? "";
 
@@ -635,6 +653,32 @@ namespace SportlinkFunction.Planner
             response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(date, bezettingen, suggesties, velden, request.Doel ?? "optimaliseren");
 
             return response;
+        }
+
+        private static VeldCapaciteitInfo BerekenCapaciteit(
+            List<BestaandeWedstrijd> bezettingen,
+            List<VeldBeschikbaarheidInfo> beschikbareVelden)
+        {
+            int totaalBeschikbaar = 0;
+            foreach (var veld in beschikbareVelden)
+                totaalBeschikbaar += (int)(veld.BeschikbaarTot.ToTimeSpan() - veld.BeschikbaarVanaf.ToTimeSpan()).TotalMinutes;
+
+            int totaalBezet = 0;
+            foreach (var b in bezettingen)
+                totaalBezet += (int)((b.EindTijd.ToTimeSpan() - b.AanvangsTijd.ToTimeSpan()).TotalMinutes * (double)b.VeldDeelGebruik);
+
+            var bezetteVelden = bezettingen.Select(b => b.VeldNummer).Distinct().ToHashSet();
+            int aantalLegeVelden = beschikbareVelden.Count(v => !bezetteVelden.Contains(v.VeldNummer));
+
+            return new VeldCapaciteitInfo
+            {
+                TotaalBeschikbareMinuten = totaalBeschikbaar,
+                TotaalBezettMinuten = totaalBezet,
+                BezettingsPercentage = totaalBeschikbaar > 0
+                    ? (double)totaalBezet / totaalBeschikbaar * 100.0 : 0,
+                AantalWedstrijdenOpVeld5 = bezettingen.Count(b => b.VeldNummer == 5),
+                AantalLegeVelden = aantalLegeVelden
+            };
         }
 
         private static List<OptimalisatieSuggestie> OptimaliseerVeld5Ontlasten(


### PR DESCRIPTION
## Samenvatting

- Bij optimaliseren: als geen wedstrijden op veld 5 EN < 50% capaciteit bezet → melding "voldoende ruimte, geen optimalisatie nodig"
- `CapaciteitOverzicht` wordt altijd meegestuurd (bezettingspercentage, lege velden, veld 5 count)
- HTML/email output toont groene meldingsbanner bij voldoende ruimte

## Aanleiding

Op zaterdagen met weinig wedstrijden is optimalisatie overbodig. Het systeem genereerde onnodig suggesties terwijl er meer dan genoeg ruimte was.

## Wijzigingen

- `PlannerModels.cs` — `VoldoendeRuimte`, `VoldoendeRuimteMelding`, `CapaciteitOverzicht` aan OptimaliseerResponse + `VeldCapaciteitInfo` klasse
- `PlannerService.cs` — `BerekenCapaciteit()` methode + early return in `OptimaliseerAsync()` als drempel niet bereikt
- `PlannerFunction.cs` — groene HTML-banner bij voldoende ruimte voor html/email formaat

## Drempel

- Constante `MaxBezettingsPercentageVoorOverslaan = 50.0`
- Criteria: `AantalWedstrijdenOpVeld5 == 0 AND BezettingsPercentage < 50%`

## Testplan

- [ ] Build slaagt
- [ ] Optimaliseer voor drukke zaterdag → nog steeds suggesties
- [ ] Optimaliseer voor lege zaterdag → `voldoendeRuimte: true` + melding, geen suggesties
- [ ] HTML-formaat toont groene banner bij voldoende ruimte
- [ ] JSON bevat altijd `capaciteitOverzicht`

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)