### PR TITLE
Timer schedule configureerbaar via app setting (#25)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ No automated tests or linter configured.
 Serverless ETL pipeline: **Sportlink REST API -> Azure Function -> SQL Server**
 
 **Two trigger functions** in `FunctionApp/Function1.cs`:
-- `FetchAndStoreApiData` — Timer trigger (daily at 04:00, `0 0 4 * * *`), fetches teams, matches, and match details
+- `FetchAndStoreApiData` — Timer trigger (schedule via `%FETCH_SCHEDULE%` app setting, default `0 0 4 * * *`), fetches teams, matches, and match details
 - `SyncMatchesHttp` — HTTP GET `/api/sync`, manual trigger with optional weekoffset params
 
 **Data flow:** Sportlink JSON -> C# entity models -> staging tables (`stg.*`) -> stored procedure MERGE -> history tables (`his.*`) -> public views (`pub.*`)
@@ -36,7 +36,7 @@ Serverless ETL pipeline: **Sportlink REST API -> Azure Function -> SQL Server**
 - `his` — persistent history with `mta_inserted`/`mta_modified` metadata columns
 - `mta` — `source_target_mapping` table drives dynamic table creation and merge operations
 - `pub` — read-only views for consumers
-- `dbo` — `AppSettings` (API URL, client ID), `Season`, `DateTable`, `Speeltijden`
+- `dbo` — `AppSettings` (API URL, client ID, fetch schedule), `Season`, `DateTable`, `Speeltijden`
 
 **Key stored procedures:** `sp_CreateTargetTableFromSource` (dynamic DDL), `sp_MergeStgToHis` (UPSERT via MERGE)
 

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -12,16 +12,18 @@ Post-Deployment Script Template
 -- New setup needed for the first time
 IF (SELECT [ClubName] FROM [dbo].[AppSettings]) IS NULL
 BEGIN
-	INSERT INTO [dbo].[AppSettings] 
-		([ClubName]		
+	INSERT INTO [dbo].[AppSettings]
+		([ClubName]
 		,[SportlinkApiUrl]
 		,[SportlinkClientId]
-		,[SeasonStartMonth])
+		,[SeasonStartMonth]
+		,[FetchSchedule])
 	VALUES
 		('Uw clubnaam'
 		,'https://data.sportlink.com'
 		,'APIKEY'
-		,7)
+		,7
+		,'0 0 4 * * *')
 END
 GO
 

--- a/Database/dbo/Tables/AppSettings.sql
+++ b/Database/dbo/Tables/AppSettings.sql
@@ -3,5 +3,6 @@
 	[SportlinkApiUrl]	NVARCHAR(100)	NOT NULL,
 	[SportlinkClientId]	NVARCHAR(50)	NOT NULL,
 	[SeasonStartMonth]	[int]			NOT NULL,
-	[LastSyncTimestamp]	DATETIME2		NULL
+	[LastSyncTimestamp]	DATETIME2		NULL,
+	[FetchSchedule]		NVARCHAR(50)	NOT NULL DEFAULT '0 0 4 * * *'
 	)

--- a/FunctionApp/CLAUDE.md
+++ b/FunctionApp/CLAUDE.md
@@ -35,14 +35,14 @@ History Tables (his.teams, his.matches, his.matchdetails)
 ### Key Components
 
 **[Function1.cs](Function1.cs)**
-- `FetchAndStoreApiData`: Timer trigger (daily at 04:00) that orchestrates the sync
+- `FetchAndStoreApiData`: Timer trigger (schedule via `%FETCH_SCHEDULE%` app setting, default `0 0 4 * * *`) that orchestrates the sync
 - `SyncAndStoreViaHttpTrigger`: HTTP endpoint for manual sync (GET `/api/sync`)
 - Handles: Teams fetch, matches fetch (last 5 weeks), match details fetch
 - Uses retry logic via `SystemUtilities.WaitForDatabaseAsync()`
 
 **[Utilities.cs](Utilities.cs)**
 - `SystemUtilities.AppSettings`: Loads settings from `dbo.AppSettings` table
-  - Fields: `SportlinkApiUrl`, `SportlinkClientId`
+  - Fields: `SportlinkApiUrl`, `SportlinkClientId`, `FetchSchedule`
 - `SystemUtilities.DatabaseConfig`: Manages connection string from environment variables
 - `SystemUtilities.SeasonHelper`: Calculates season end week offsets from `dbo.Season` table
 - Database retry logic with 5 retries, 5-second delays between attempts
@@ -119,6 +119,7 @@ Stored in `local.settings.json` (development) and Azure Key Vault (production):
 - `SqlConnectionString`: Connection string to SQL database (loaded from local.settings.json or Azure Key Vault)
 - `FUNCTIONS_WORKER_RUNTIME`: Always `"dotnet-isolated"`
 - `AzureWebJobsStorage`: Storage for function state (dev uses `UseDevelopmentStorage=true`)
+- `FETCH_SCHEDULE`: CRON-expressie voor de timer trigger (default `0 0 4 * * *` = dagelijks om 04:00)
 
 ### Database Settings
 
@@ -170,7 +171,7 @@ DROP TABLE IF EXISTS [his].[matchdetails];
 
 ### Check Timer Trigger Execution
 
-Monitor function logs in Azure portal or locally in console output. Function runs at `0 0 4 * * *` (daily at 04:00).
+Monitor function logs in Azure portal or locally in console output. Schedule is configureerbaar via de `FETCH_SCHEDULE` app setting (default `0 0 4 * * *` = dagelijks om 04:00).
 
 Manual execution via HTTP:
 ```

--- a/FunctionApp/Function1.cs
+++ b/FunctionApp/Function1.cs
@@ -17,7 +17,7 @@ namespace SportlinkFunction
         private static readonly HttpClient client = new HttpClient();
 
         [Function("FetchAndStoreApiData")]
-        public static async Task Run([TimerTrigger("0 0 4 * * *")] TimerInfo myTimer, FunctionContext context)
+        public static async Task Run([TimerTrigger("%FETCH_SCHEDULE%")] TimerInfo myTimer, FunctionContext context)
         {
             var log = context.GetLogger("FetchAndStoreApiData");
             log.LogInformation($"Azure Function executed at: {DateTime.Now}");

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -18,7 +18,7 @@ namespace SportlinkFunction
                     using (SqlConnection connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString))
                     {
                         await connection.OpenAsync();
-                        string query = "SELECT [SportlinkApiUrl], [SportlinkClientId], [LastSyncTimestamp] FROM [dbo].[AppSettings]";
+                        string query = "SELECT [SportlinkApiUrl], [SportlinkClientId], [LastSyncTimestamp], [FetchSchedule] FROM [dbo].[AppSettings]";
                         using (SqlCommand command = new SqlCommand(query, connection))
                         using (SqlDataReader reader = await command.ExecuteReaderAsync())
                         {
@@ -30,6 +30,7 @@ namespace SportlinkFunction
                                 settings["sportlinkClientId"]   = sportlinkClientId;
                                 if (reader["LastSyncTimestamp"] != DBNull.Value)
                                     settings["lastSyncTimestamp"] = Convert.ToDateTime(reader["LastSyncTimestamp"]).ToString("yyyy-MM-dd HH:mm:ss");
+                                settings["fetchSchedule"] = reader["FetchSchedule"].ToString() ?? "0 0 4 * * *";
                             }
                         }
                     }

--- a/FunctionApp/local.settings.template.json
+++ b/FunctionApp/local.settings.template.json
@@ -3,6 +3,7 @@
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-    "SqlConnectionString": "Server=YOUR_SERVER;Database=SportlinkSqlDb;Integrated Security=True;TrustServerCertificate=True;"
+    "SqlConnectionString": "Server=YOUR_SERVER;Database=SportlinkSqlDb;Integrated Security=True;TrustServerCertificate=True;",
+    "FETCH_SCHEDULE": "0 0 4 * * *"
   }
 }


### PR DESCRIPTION
## Samenvatting

Verplaatst de timer-schedule van hardcoded CRON in code naar een configureerbare app setting, zodat clubs hun eigen sync-schema kunnen instellen zonder code-wijzigingen.

- **Function1.cs:** `[TimerTrigger("0 0 4 * * *")]` → `[TimerTrigger("%FETCH_SCHEDULE%")]`
- **AppSettings.sql:** Nieuwe kolom `FetchSchedule` (default `0 0 4 * * *`)
- **Utilities.cs:** Settings loader leest `FetchSchedule` mee uit database
- **local.settings.template.json:** `FETCH_SCHEDULE` app setting toegevoegd
- **Documentatie:** CLAUDE.md bestanden bijgewerkt

## Achtergrond

Azure Functions timer triggers worden bij **startup** geëvalueerd. De `%SETTING%`-syntax leest de CRON-expressie uit een omgevingsvariabele. De waarde wordt ook opgeslagen in `dbo.AppSettings` als referentie voor de toekomstige Admin UI (zie epic #26, story #27).

## Voorbeelden CRON-expressies

| Expressie | Betekenis |
|---|---|
| `0 0 4 * * *` | Dagelijks om 04:00 (default) |
| `0 0 */4 * * *` | Elke 4 uur |
| `0 0 * * * *` | Elk uur |
| `0 */30 * * * *` | Elke 30 minuten |

## Testplan

- [ ] `dotnet build` slaagt zonder fouten
- [ ] `FETCH_SCHEDULE` in `local.settings.json` zetten → `func start` → timer start correct
- [ ] Ongeldige CRON testen → runtime geeft foutmelding bij startup
- [ ] Database: `FetchSchedule` kolom bestaat met default waarde

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)