### PR TITLE
Voeg Graph API en OpenAI NuGet packages toe met DI setup (#34)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/FunctionApp"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "NuGet"

--- a/FunctionApp/Program.cs
+++ b/FunctionApp/Program.cs
@@ -1,10 +1,24 @@
+using Azure.Identity;
 using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Graph;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 builder.ConfigureFunctionsWebApplication();
 
 // Application Insights wordt automatisch geconfigureerd via host.json
 // en de APPINSIGHTS_INSTRUMENTATIONKEY app setting in Azure
+
+// Graph client met client credentials (application permissions)
+var tenantId = Environment.GetEnvironmentVariable("GraphTenantId");
+var clientId = Environment.GetEnvironmentVariable("GraphClientId");
+var clientSecret = Environment.GetEnvironmentVariable("GraphClientSecret");
+
+if (!string.IsNullOrEmpty(tenantId) && !string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret))
+{
+    var credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
+    builder.Services.AddSingleton(new GraphServiceClient(credential));
+}
 
 builder.Build().Run();

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -17,13 +17,16 @@
     <!-- Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4. -->
     <!-- <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" /> -->
     <!-- <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0-preview5" /> -->
+    <PackageReference Include="Azure.Identity" Version="1.*" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.*" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="OpenAI" Version="2.*" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -17,16 +17,16 @@
     <!-- Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4. -->
     <!-- <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" /> -->
     <!-- <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0-preview5" /> -->
-    <PackageReference Include="Azure.Identity" Version="1.*" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Graph" Version="5.*" />
+    <PackageReference Include="Microsoft.Graph" Version="5.103.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="OpenAI" Version="2.*" />
+    <PackageReference Include="OpenAI" Version="2.10.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/FunctionApp/local.settings.template.json
+++ b/FunctionApp/local.settings.template.json
@@ -4,6 +4,15 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "SqlConnectionString": "Server=YOUR_SERVER;Database=SportlinkSqlDb;Integrated Security=True;TrustServerCertificate=True;",
-    "FETCH_SCHEDULE": "0 0 4 * * *"
+    "FETCH_SCHEDULE": "0 0 4 * * *",
+    "GraphTenantId": "",
+    "GraphClientId": "",
+    "GraphClientSecret": "",
+    "GraphMailbox": "",
+    "OpenAiApiKey": "",
+    "EmailProcessorEnabled": "false",
+    "EmailReviewMode": "true",
+    "EmailReviewRecipient": "",
+    "EMAIL_POLL_SCHEDULE": "0 */5 * * * *"
   }
 }


### PR DESCRIPTION
## Summary
- NuGet packages `Microsoft.Graph 5.*`, `Azure.Identity 1.*` en `OpenAI 2.*` toegevoegd
- `Program.cs` uitgebreid met DI registratie voor `GraphServiceClient` (graceful skip als settings ontbreken)
- `local.settings.template.json` bijgewerkt met 9 nieuwe email-gerelateerde app settings

Closes #34

## Verificatie
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `func start` — start succesvol zonder Graph settings (graceful handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)