### PR TITLE
Voeg EmailModels en planner.EmailVerwerking tabel toe (#35)

### DIFF
--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -106,6 +106,16 @@ BEGIN
 END
 GO
 
+-- AppSettings: email-integratie velden vullen
+IF EXISTS (SELECT 1 FROM [dbo].[AppSettings] WHERE [PlannerAfzenderNaam] IS NULL)
+BEGIN
+    UPDATE [dbo].[AppSettings]
+    SET [PlannerAfzenderNaam] = 'VRC Veldplanner',
+        [CoordinatorFunctie] = N'Coördinator thuiswedstrijden'
+    WHERE [PlannerAfzenderNaam] IS NULL
+END
+GO
+
 -- Update the Season and datetable
 DECLARE @SeasonStartMonth INT = (SELECT [SeasonStartMonth] FROM [dbo].[AppSettings])
 EXEC [dbo].[sp_UpdateSeasonTable] @SeasonStartMonth;

--- a/Database/SportlinkSqlDb.sqlproj
+++ b/Database/SportlinkSqlDb.sqlproj
@@ -107,6 +107,7 @@
     <Build Include="planner\Tables\GeplandeWedstrijden.sql" />
     <Build Include="planner\Views\AlleWedstrijdenOpVeld.sql" />
     <Build Include="planner\Tables\HerplanVerzoeken.sql" />
+    <Build Include="planner\Tables\EmailVerwerking.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Script1.sql" />

--- a/Database/dbo/Tables/AppSettings.sql
+++ b/Database/dbo/Tables/AppSettings.sql
@@ -1,8 +1,12 @@
 ﻿CREATE TABLE [dbo].[AppSettings](
-	[ClubName]			NVARCHAR(100)	NOT NULL,
-	[SportlinkApiUrl]	NVARCHAR(100)	NOT NULL,
-	[SportlinkClientId]	NVARCHAR(50)	NOT NULL,
-	[SeasonStartMonth]	[int]			NOT NULL,
-	[LastSyncTimestamp]	DATETIME2		NULL,
-	[FetchSchedule]		NVARCHAR(50)	NOT NULL DEFAULT '0 0 4 * * *'
+	[ClubName]				NVARCHAR(100)	NOT NULL,
+	[SportlinkApiUrl]		NVARCHAR(100)	NOT NULL,
+	[SportlinkClientId]		NVARCHAR(50)	NOT NULL,
+	[SeasonStartMonth]		[int]			NOT NULL,
+	[LastSyncTimestamp]		DATETIME2		NULL,
+	[FetchSchedule]			NVARCHAR(50)	NOT NULL DEFAULT '0 0 4 * * *',
+	[PlannerAfzenderNaam]	NVARCHAR(100)	NULL,
+	[CoordinatorNaam]		NVARCHAR(100)	NULL,
+	[CoordinatorFunctie]	NVARCHAR(100)	NULL,
+	[PlannerEmailAdres]		NVARCHAR(200)	NULL
 	)

--- a/Database/planner/Tables/EmailVerwerking.sql
+++ b/Database/planner/Tables/EmailVerwerking.sql
@@ -1,0 +1,20 @@
+CREATE TABLE [planner].[EmailVerwerking] (
+    [Id]                    INT             IDENTITY(1,1) NOT NULL,
+    [MessageId]             NVARCHAR(500)   NOT NULL,
+    [ConversationId]        NVARCHAR(500)   NULL,
+    [Afzender]              NVARCHAR(200)   NOT NULL,
+    [Onderwerp]             NVARCHAR(500)   NOT NULL,
+    [OntvangstDatum]        DATETIME2       NOT NULL,
+    [EmailBody]             NVARCHAR(MAX)   NULL,
+    [VerzoekType]           NVARCHAR(50)    NOT NULL,
+    [GeextraheerdeData]     NVARCHAR(MAX)   NULL,
+    [PlannerResponse]       NVARCHAR(MAX)   NULL,
+    [AntwoordEmail]         NVARCHAR(MAX)   NULL,
+    [VerstuurdNaar]         NVARCHAR(200)   NULL,
+    [Status]                NVARCHAR(30)    NOT NULL CONSTRAINT [DF_EmailVerwerking_Status] DEFAULT 'Ontvangen',
+    [FoutMelding]           NVARCHAR(1000)  NULL,
+    [mta_inserted]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Ins] DEFAULT GETDATE(),
+    [mta_modified]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Mod] DEFAULT GETDATE(),
+    CONSTRAINT [PK_EmailVerwerking] PRIMARY KEY CLUSTERED ([Id] ASC),
+    CONSTRAINT [UQ_EmailVerwerking_MessageId] UNIQUE ([MessageId])
+);

--- a/FunctionApp/Email/EmailModels.cs
+++ b/FunctionApp/Email/EmailModels.cs
@@ -1,0 +1,54 @@
+namespace SportlinkFunction.Email;
+
+// Classificatie door AI
+public enum VerzoekType
+{
+    BeschikbaarheidCheck,
+    HerplanVerzoek,
+    Bevestiging,
+    BuitenScope
+}
+
+public enum NamensWie
+{
+    Afzender,
+    Tegenstander,
+    Onbekend
+}
+
+// AI classificatie response
+public class EmailClassificatie
+{
+    public VerzoekType Type { get; set; }
+    public string? Datum { get; set; }           // yyyy-MM-dd
+    public string? AanvangsTijd { get; set; }    // HH:mm
+    public string? TeamNaam { get; set; }
+    public string? LeeftijdsCategorie { get; set; }
+    public string? Tegenstander { get; set; }
+    public string Samenvatting { get; set; } = "";
+    public NamensWie NamensWie { get; set; }
+}
+
+// Inkomende email data
+public class InkomendEmail
+{
+    public string MessageId { get; set; } = "";
+    public string ConversationId { get; set; } = "";
+    public string Afzender { get; set; } = "";
+    public string AfzenderNaam { get; set; } = "";
+    public string Onderwerp { get; set; } = "";
+    public DateTime OntvangstDatum { get; set; }
+    public string Body { get; set; } = "";
+}
+
+// Verwerking status
+public enum EmailStatus
+{
+    Ontvangen,
+    Geclassificeerd,
+    Verwerkt,
+    AntwoordVerstuurd,
+    Review,
+    Fout,
+    BuitenScope
+}


### PR DESCRIPTION
## Summary
- `FunctionApp/Email/EmailModels.cs` — enums (`VerzoekType`, `NamensWie`, `EmailStatus`) en DTO's (`EmailClassificatie`, `InkomendEmail`) voor email-verwerking
- `Database/planner/Tables/EmailVerwerking.sql` — audit trail tabel met UNIQUE constraint op MessageId voor deduplicatie
- `dbo.AppSettings` uitgebreid met 4 kolommen: `PlannerAfzenderNaam`, `CoordinatorNaam`, `CoordinatorFunctie`, `PlannerEmailAdres`
- PostDeployment script vult default waarden voor nieuwe kolommen

Closes #35

## Verificatie
- [x] `dotnet build` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)