### PR TITLE
Voeg EmailGraphService toe voor Graph API email-operaties (#36)

### DIFF
--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -106,6 +106,16 @@ BEGIN
 END
 GO
 
+-- AppSettings: email-integratie velden vullen
+IF EXISTS (SELECT 1 FROM [dbo].[AppSettings] WHERE [PlannerAfzenderNaam] IS NULL)
+BEGIN
+    UPDATE [dbo].[AppSettings]
+    SET [PlannerAfzenderNaam] = 'VRC Veldplanner',
+        [CoordinatorFunctie] = N'Coördinator thuiswedstrijden'
+    WHERE [PlannerAfzenderNaam] IS NULL
+END
+GO
+
 -- Update the Season and datetable
 DECLARE @SeasonStartMonth INT = (SELECT [SeasonStartMonth] FROM [dbo].[AppSettings])
 EXEC [dbo].[sp_UpdateSeasonTable] @SeasonStartMonth;

--- a/Database/SportlinkSqlDb.sqlproj
+++ b/Database/SportlinkSqlDb.sqlproj
@@ -107,6 +107,7 @@
     <Build Include="planner\Tables\GeplandeWedstrijden.sql" />
     <Build Include="planner\Views\AlleWedstrijdenOpVeld.sql" />
     <Build Include="planner\Tables\HerplanVerzoeken.sql" />
+    <Build Include="planner\Tables\EmailVerwerking.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Script1.sql" />

--- a/Database/dbo/Tables/AppSettings.sql
+++ b/Database/dbo/Tables/AppSettings.sql
@@ -1,8 +1,12 @@
 ﻿CREATE TABLE [dbo].[AppSettings](
-	[ClubName]			NVARCHAR(100)	NOT NULL,
-	[SportlinkApiUrl]	NVARCHAR(100)	NOT NULL,
-	[SportlinkClientId]	NVARCHAR(50)	NOT NULL,
-	[SeasonStartMonth]	[int]			NOT NULL,
-	[LastSyncTimestamp]	DATETIME2		NULL,
-	[FetchSchedule]		NVARCHAR(50)	NOT NULL DEFAULT '0 0 4 * * *'
+	[ClubName]				NVARCHAR(100)	NOT NULL,
+	[SportlinkApiUrl]		NVARCHAR(100)	NOT NULL,
+	[SportlinkClientId]		NVARCHAR(50)	NOT NULL,
+	[SeasonStartMonth]		[int]			NOT NULL,
+	[LastSyncTimestamp]		DATETIME2		NULL,
+	[FetchSchedule]			NVARCHAR(50)	NOT NULL DEFAULT '0 0 4 * * *',
+	[PlannerAfzenderNaam]	NVARCHAR(100)	NULL,
+	[CoordinatorNaam]		NVARCHAR(100)	NULL,
+	[CoordinatorFunctie]	NVARCHAR(100)	NULL,
+	[PlannerEmailAdres]		NVARCHAR(200)	NULL
 	)

--- a/Database/planner/Tables/EmailVerwerking.sql
+++ b/Database/planner/Tables/EmailVerwerking.sql
@@ -1,0 +1,20 @@
+CREATE TABLE [planner].[EmailVerwerking] (
+    [Id]                    INT             IDENTITY(1,1) NOT NULL,
+    [MessageId]             NVARCHAR(500)   NOT NULL,
+    [ConversationId]        NVARCHAR(500)   NULL,
+    [Afzender]              NVARCHAR(200)   NOT NULL,
+    [Onderwerp]             NVARCHAR(500)   NOT NULL,
+    [OntvangstDatum]        DATETIME2       NOT NULL,
+    [EmailBody]             NVARCHAR(MAX)   NULL,
+    [VerzoekType]           NVARCHAR(50)    NOT NULL,
+    [GeextraheerdeData]     NVARCHAR(MAX)   NULL,
+    [PlannerResponse]       NVARCHAR(MAX)   NULL,
+    [AntwoordEmail]         NVARCHAR(MAX)   NULL,
+    [VerstuurdNaar]         NVARCHAR(200)   NULL,
+    [Status]                NVARCHAR(30)    NOT NULL CONSTRAINT [DF_EmailVerwerking_Status] DEFAULT 'Ontvangen',
+    [FoutMelding]           NVARCHAR(1000)  NULL,
+    [mta_inserted]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Ins] DEFAULT GETDATE(),
+    [mta_modified]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Mod] DEFAULT GETDATE(),
+    CONSTRAINT [PK_EmailVerwerking] PRIMARY KEY CLUSTERED ([Id] ASC),
+    CONSTRAINT [UQ_EmailVerwerking_MessageId] UNIQUE ([MessageId])
+);

--- a/FunctionApp/Email/EmailGraphService.cs
+++ b/FunctionApp/Email/EmailGraphService.cs
@@ -1,0 +1,184 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Users.Item.SendMail;
+
+namespace SportlinkFunction.Email;
+
+/// <summary>
+/// Wrapper rond Microsoft Graph SDK voor email-operaties via de coordinator-mailbox.
+/// Ondersteunt inbox polling, emails markeren als gelezen, en antwoorden versturen.
+/// </summary>
+public partial class EmailGraphService
+{
+    private readonly GraphServiceClient _graphClient;
+    private readonly ILogger<EmailGraphService> _logger;
+    private readonly string _mailbox;
+
+    public EmailGraphService(GraphServiceClient graphClient, ILogger<EmailGraphService> logger)
+    {
+        _graphClient = graphClient;
+        _logger = logger;
+        _mailbox = Environment.GetEnvironmentVariable("GraphMailbox")
+            ?? throw new InvalidOperationException("GraphMailbox environment variable is niet geconfigureerd");
+    }
+
+    /// <summary>
+    /// Haalt maximaal 10 ongelezen emails op uit de inbox van de coordinator-mailbox.
+    /// </summary>
+    public async Task<List<InkomendEmail>> GetUnreadEmailsAsync()
+    {
+        var resultaat = new List<InkomendEmail>();
+
+        try
+        {
+            var messages = await _graphClient.Users[_mailbox]
+                .MailFolders["inbox"]
+                .Messages
+                .GetAsync(config =>
+                {
+                    config.QueryParameters.Filter = "isRead eq false";
+                    config.QueryParameters.Top = 10;
+                    config.QueryParameters.Orderby = ["receivedDateTime"];
+                    config.QueryParameters.Select = ["id", "conversationId", "from", "subject", "receivedDateTime", "body"];
+                });
+
+            if (messages?.Value is null)
+            {
+                _logger.LogInformation("Geen ongelezen emails gevonden in {Mailbox}", _mailbox);
+                return resultaat;
+            }
+
+            foreach (var message in messages.Value)
+            {
+                try
+                {
+                    var email = new InkomendEmail
+                    {
+                        MessageId = message.Id ?? "",
+                        ConversationId = message.ConversationId ?? "",
+                        Afzender = message.From?.EmailAddress?.Address ?? "",
+                        AfzenderNaam = message.From?.EmailAddress?.Name ?? "",
+                        Onderwerp = message.Subject ?? "",
+                        OntvangstDatum = message.ReceivedDateTime?.DateTime ?? DateTime.MinValue,
+                        Body = StripHtml(message.Body?.Content ?? "")
+                    };
+
+                    resultaat.Add(email);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Fout bij verwerken van email {MessageId}, wordt overgeslagen",
+                        message.Id);
+                }
+            }
+
+            _logger.LogInformation("{Aantal} ongelezen email(s) opgehaald uit {Mailbox}",
+                resultaat.Count, _mailbox);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij ophalen van ongelezen emails uit {Mailbox}", _mailbox);
+        }
+
+        return resultaat;
+    }
+
+    /// <summary>
+    /// Markeert een email als gelezen in de coordinator-mailbox.
+    /// </summary>
+    public async Task MarkAsReadAsync(string messageId)
+    {
+        try
+        {
+            await _graphClient.Users[_mailbox]
+                .Messages[messageId]
+                .PatchAsync(new Message { IsRead = true });
+
+            _logger.LogInformation("Email {MessageId} gemarkeerd als gelezen", messageId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij markeren van email {MessageId} als gelezen", messageId);
+        }
+    }
+
+    /// <summary>
+    /// Verstuurt een antwoord-email via de coordinator-mailbox.
+    /// </summary>
+    public async Task SendReplyAsync(string to, string subject, string body, string? conversationId)
+    {
+        try
+        {
+            var message = new Message
+            {
+                Subject = subject,
+                Body = new ItemBody
+                {
+                    ContentType = BodyType.Text,
+                    Content = body
+                },
+                ToRecipients =
+                [
+                    new Recipient
+                    {
+                        EmailAddress = new EmailAddress { Address = to }
+                    }
+                ]
+            };
+
+            if (!string.IsNullOrEmpty(conversationId))
+            {
+                message.ConversationId = conversationId;
+            }
+
+            await _graphClient.Users[_mailbox]
+                .SendMail
+                .PostAsync(new SendMailPostRequestBody
+                {
+                    Message = message
+                });
+
+            _logger.LogInformation("Antwoord verstuurd naar {Ontvanger} met onderwerp '{Onderwerp}'",
+                to, subject);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij versturen van antwoord naar {Ontvanger} met onderwerp '{Onderwerp}'",
+                to, subject);
+        }
+    }
+
+    /// <summary>
+    /// Verwijdert HTML-tags uit tekst en normaliseert whitespace.
+    /// </summary>
+    private static string StripHtml(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return "";
+
+        // Verwijder HTML-tags
+        var tekst = HtmlTagRegex().Replace(html, " ");
+
+        // Decodeer veelvoorkomende HTML-entiteiten
+        tekst = tekst
+            .Replace("&nbsp;", " ")
+            .Replace("&amp;", "&")
+            .Replace("&lt;", "<")
+            .Replace("&gt;", ">")
+            .Replace("&quot;", "\"")
+            .Replace("&#39;", "'");
+
+        // Normaliseer whitespace
+        tekst = WhitespaceRegex().Replace(tekst, " ");
+
+        return tekst.Trim();
+    }
+
+    [GeneratedRegex("<[^>]+>")]
+    private static partial Regex HtmlTagRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/FunctionApp/Email/EmailModels.cs
+++ b/FunctionApp/Email/EmailModels.cs
@@ -1,0 +1,54 @@
+namespace SportlinkFunction.Email;
+
+// Classificatie door AI
+public enum VerzoekType
+{
+    BeschikbaarheidCheck,
+    HerplanVerzoek,
+    Bevestiging,
+    BuitenScope
+}
+
+public enum NamensWie
+{
+    Afzender,
+    Tegenstander,
+    Onbekend
+}
+
+// AI classificatie response
+public class EmailClassificatie
+{
+    public VerzoekType Type { get; set; }
+    public string? Datum { get; set; }           // yyyy-MM-dd
+    public string? AanvangsTijd { get; set; }    // HH:mm
+    public string? TeamNaam { get; set; }
+    public string? LeeftijdsCategorie { get; set; }
+    public string? Tegenstander { get; set; }
+    public string Samenvatting { get; set; } = "";
+    public NamensWie NamensWie { get; set; }
+}
+
+// Inkomende email data
+public class InkomendEmail
+{
+    public string MessageId { get; set; } = "";
+    public string ConversationId { get; set; } = "";
+    public string Afzender { get; set; } = "";
+    public string AfzenderNaam { get; set; } = "";
+    public string Onderwerp { get; set; } = "";
+    public DateTime OntvangstDatum { get; set; }
+    public string Body { get; set; } = "";
+}
+
+// Verwerking status
+public enum EmailStatus
+{
+    Ontvangen,
+    Geclassificeerd,
+    Verwerkt,
+    AntwoordVerstuurd,
+    Review,
+    Fout,
+    BuitenScope
+}


### PR DESCRIPTION
## Summary

- **Nieuw bestand** `FunctionApp/Email/EmailGraphService.cs` — wrapper rond Microsoft Graph SDK v5 voor email-operaties via de coordinator-mailbox
- **GetUnreadEmailsAsync()** — haalt max 10 ongelezen emails op, mapt naar `InkomendEmail` model, stript HTML naar plain text
- **MarkAsReadAsync()** — markeert email als gelezen via Graph PATCH
- **SendReplyAsync()** — verstuurt antwoord als plain text via Graph sendMail, bewaart conversationId voor threading

Closes #36

## Verificatie

- [x] `dotnet build` compileert zonder fouten of waarschuwingen
- [x] Gebruikt Microsoft.Graph SDK v5 syntax (collection expressions, `GetAsync` met config lambda)
- [x] Error handling: log fout + ga door (1 fout blokkeert niet de rest)
- [x] Mailbox adres uit `GraphMailbox` environment variable
- [x] HTML stripping via source-generated regex (performant)
- [x] Constructor injecteert `GraphServiceClient` en `ILogger<EmailGraphService>` via DI
- [x] Afhankelijk van #35 (`InkomendEmail` model uit `EmailModels.cs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)