### PR TITLE
Voeg EmailAiService toe voor OpenAI email classificatie en antwoord (#37)

### DIFF
--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -106,6 +106,16 @@ BEGIN
 END
 GO
 
+-- AppSettings: email-integratie velden vullen
+IF EXISTS (SELECT 1 FROM [dbo].[AppSettings] WHERE [PlannerAfzenderNaam] IS NULL)
+BEGIN
+    UPDATE [dbo].[AppSettings]
+    SET [PlannerAfzenderNaam] = 'VRC Veldplanner',
+        [CoordinatorFunctie] = N'Coördinator thuiswedstrijden'
+    WHERE [PlannerAfzenderNaam] IS NULL
+END
+GO
+
 -- Update the Season and datetable
 DECLARE @SeasonStartMonth INT = (SELECT [SeasonStartMonth] FROM [dbo].[AppSettings])
 EXEC [dbo].[sp_UpdateSeasonTable] @SeasonStartMonth;

--- a/Database/SportlinkSqlDb.sqlproj
+++ b/Database/SportlinkSqlDb.sqlproj
@@ -107,6 +107,7 @@
     <Build Include="planner\Tables\GeplandeWedstrijden.sql" />
     <Build Include="planner\Views\AlleWedstrijdenOpVeld.sql" />
     <Build Include="planner\Tables\HerplanVerzoeken.sql" />
+    <Build Include="planner\Tables\EmailVerwerking.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Script1.sql" />

--- a/Database/dbo/Tables/AppSettings.sql
+++ b/Database/dbo/Tables/AppSettings.sql
@@ -1,8 +1,12 @@
 ﻿CREATE TABLE [dbo].[AppSettings](
-	[ClubName]			NVARCHAR(100)	NOT NULL,
-	[SportlinkApiUrl]	NVARCHAR(100)	NOT NULL,
-	[SportlinkClientId]	NVARCHAR(50)	NOT NULL,
-	[SeasonStartMonth]	[int]			NOT NULL,
-	[LastSyncTimestamp]	DATETIME2		NULL,
-	[FetchSchedule]		NVARCHAR(50)	NOT NULL DEFAULT '0 0 4 * * *'
+	[ClubName]				NVARCHAR(100)	NOT NULL,
+	[SportlinkApiUrl]		NVARCHAR(100)	NOT NULL,
+	[SportlinkClientId]		NVARCHAR(50)	NOT NULL,
+	[SeasonStartMonth]		[int]			NOT NULL,
+	[LastSyncTimestamp]		DATETIME2		NULL,
+	[FetchSchedule]			NVARCHAR(50)	NOT NULL DEFAULT '0 0 4 * * *',
+	[PlannerAfzenderNaam]	NVARCHAR(100)	NULL,
+	[CoordinatorNaam]		NVARCHAR(100)	NULL,
+	[CoordinatorFunctie]	NVARCHAR(100)	NULL,
+	[PlannerEmailAdres]		NVARCHAR(200)	NULL
 	)

--- a/Database/planner/Tables/EmailVerwerking.sql
+++ b/Database/planner/Tables/EmailVerwerking.sql
@@ -1,0 +1,20 @@
+CREATE TABLE [planner].[EmailVerwerking] (
+    [Id]                    INT             IDENTITY(1,1) NOT NULL,
+    [MessageId]             NVARCHAR(500)   NOT NULL,
+    [ConversationId]        NVARCHAR(500)   NULL,
+    [Afzender]              NVARCHAR(200)   NOT NULL,
+    [Onderwerp]             NVARCHAR(500)   NOT NULL,
+    [OntvangstDatum]        DATETIME2       NOT NULL,
+    [EmailBody]             NVARCHAR(MAX)   NULL,
+    [VerzoekType]           NVARCHAR(50)    NOT NULL,
+    [GeextraheerdeData]     NVARCHAR(MAX)   NULL,
+    [PlannerResponse]       NVARCHAR(MAX)   NULL,
+    [AntwoordEmail]         NVARCHAR(MAX)   NULL,
+    [VerstuurdNaar]         NVARCHAR(200)   NULL,
+    [Status]                NVARCHAR(30)    NOT NULL CONSTRAINT [DF_EmailVerwerking_Status] DEFAULT 'Ontvangen',
+    [FoutMelding]           NVARCHAR(1000)  NULL,
+    [mta_inserted]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Ins] DEFAULT GETDATE(),
+    [mta_modified]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Mod] DEFAULT GETDATE(),
+    CONSTRAINT [PK_EmailVerwerking] PRIMARY KEY CLUSTERED ([Id] ASC),
+    CONSTRAINT [UQ_EmailVerwerking_MessageId] UNIQUE ([MessageId])
+);

--- a/FunctionApp/Email/EmailAiService.cs
+++ b/FunctionApp/Email/EmailAiService.cs
@@ -1,0 +1,204 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using OpenAI.Chat;
+
+namespace SportlinkFunction.Email;
+
+/// <summary>
+/// Service voor het classificeren van inkomende emails en het genereren van antwoorden
+/// met behulp van OpenAI GPT-4o-mini.
+/// </summary>
+public class EmailAiService
+{
+    private readonly ILogger<EmailAiService> _logger;
+    private readonly ChatClient _chatClient;
+
+    private const string ClassificatieSystemPrompt = """
+        Je bent een assistent voor de coördinator thuiswedstrijden van voetbalvereniging VRC Veenendaal.
+        Analyseer de inkomende email en classificeer het verzoek.
+
+        Typen verzoeken:
+        - beschikbaarheid_check: iemand vraagt of een datum/tijd/veld beschikbaar is voor een oefenwedstrijd
+        - herplan_verzoek: iemand wil een bestaande wedstrijd verplaatsen naar een andere datum/tijd
+        - bevestiging: een antwoord op een eerder voorstel ("ja dat is goed", "akkoord", etc.)
+        - buiten_scope: alles wat niet over veldbeschikbaarheid of herplannen gaat
+
+        Geef ALTIJD een JSON response met exact dit formaat:
+        {
+          "type": "beschikbaarheid_check | herplan_verzoek | bevestiging | buiten_scope",
+          "datum": "yyyy-MM-dd of null",
+          "aanvangsTijd": "HH:mm of null",
+          "teamNaam": "teamnaam of null",
+          "leeftijdsCategorie": "bijv. JO11 of null",
+          "tegenstander": "naam tegenstander of null",
+          "samenvatting": "korte samenvatting van het verzoek",
+          "namensWie": "afzender | tegenstander | onbekend"
+        }
+
+        Let op:
+        - Datums in emails zijn vaak relatief ("aanstaande zaterdag") — bereken de absolute datum op basis van vandaag
+        - Nederlandse tekst, informeel taalgebruik
+        - Als afzender @vv-vrc.nl domein heeft: VRC-intern
+        - Bij doorgestuurde berichten: bepaal namens wie het verzoek is
+        """;
+
+    private const string AntwoordSystemPrompt = """
+        Je bent de VRC Veldplanner, een geautomatiseerd systeem dat antwoordt namens de coördinator thuiswedstrijden van voetbalvereniging VRC Veenendaal.
+
+        Schrijfstijl:
+        - Kort en duidelijk, geen technische details
+        - Gebruik de tijdsgebonden aanhef (Goedemorgen/Goedemiddag/Goedenavond) gevolgd door de voornaam
+        - Maximaal 2-3 alternatieven noemen als de gevraagde tijd niet beschikbaar is
+        - Eindig met: "Met vriendelijke groet,\n\nVRC Veldplanner\nGeautomatiseerd antwoord namens de coördinator thuiswedstrijden"
+        """;
+
+    public EmailAiService(ILogger<EmailAiService> logger)
+    {
+        _logger = logger;
+
+        var apiKey = Environment.GetEnvironmentVariable("OpenAiApiKey")
+            ?? throw new InvalidOperationException("OpenAiApiKey environment variable is niet geconfigureerd.");
+
+        _chatClient = new ChatClient("gpt-4o-mini", apiKey);
+    }
+
+    /// <summary>
+    /// Classificeert een inkomende email met behulp van GPT-4o-mini.
+    /// Retourneert een EmailClassificatie met het type verzoek en geëxtraheerde gegevens.
+    /// </summary>
+    public async Task<EmailClassificatie> ClassificeerEmailAsync(string body, string subject, string afzender)
+    {
+        _logger.LogInformation("Email classificatie gestart voor onderwerp: {Subject}", subject);
+
+        var userPrompt = $"Van: {afzender}\nOnderwerp: {subject}\n\n{body}";
+
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage(ClassificatieSystemPrompt),
+            new UserChatMessage(userPrompt)
+        };
+
+        var options = new ChatCompletionOptions
+        {
+            Temperature = 0.1f,
+            ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat()
+        };
+
+        try
+        {
+            var completion = await _chatClient.CompleteChatAsync(messages, options);
+            var jsonResponse = completion.Value.Content[0].Text;
+
+            _logger.LogInformation("OpenAI classificatie response ontvangen");
+
+            var classificatie = ParseClassificatieResponse(jsonResponse);
+            return classificatie;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij het classificeren van email met onderwerp: {Subject}", subject);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Genereert een antwoord-email op basis van de classificatie en planner response.
+    /// </summary>
+    public async Task<string> GenereerAntwoordAsync(
+        EmailClassificatie classificatie,
+        string plannerResponseJson,
+        string afzenderNaam)
+    {
+        _logger.LogInformation("Antwoord generatie gestart voor type: {Type}", classificatie.Type);
+
+        var userPrompt = $"""
+            Classificatie van het verzoek:
+            - Type: {classificatie.Type}
+            - Samenvatting: {classificatie.Samenvatting}
+            - Team: {classificatie.TeamNaam ?? "onbekend"}
+            - Datum: {classificatie.Datum ?? "niet opgegeven"}
+            - Tijd: {classificatie.AanvangsTijd ?? "niet opgegeven"}
+            - Tegenstander: {classificatie.Tegenstander ?? "onbekend"}
+
+            Planner response:
+            {plannerResponseJson}
+
+            Naam afzender: {afzenderNaam}
+            """;
+
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage(AntwoordSystemPrompt),
+            new UserChatMessage(userPrompt)
+        };
+
+        var options = new ChatCompletionOptions
+        {
+            Temperature = 0.5f
+        };
+
+        try
+        {
+            var completion = await _chatClient.CompleteChatAsync(messages, options);
+            var antwoord = completion.Value.Content[0].Text;
+
+            _logger.LogInformation("Antwoord-email gegenereerd");
+            return antwoord;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij het genereren van antwoord-email");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Parst de JSON response van OpenAI naar een EmailClassificatie object.
+    /// </summary>
+    private static EmailClassificatie ParseClassificatieResponse(string jsonResponse)
+    {
+        using var doc = JsonDocument.Parse(jsonResponse);
+        var root = doc.RootElement;
+
+        var typeString = root.GetProperty("type").GetString() ?? "buiten_scope";
+        var namensWieString = root.GetProperty("namensWie").GetString() ?? "onbekend";
+
+        return new EmailClassificatie
+        {
+            Type = MapVerzoekType(typeString),
+            Datum = GetOptionalString(root, "datum"),
+            AanvangsTijd = GetOptionalString(root, "aanvangsTijd"),
+            TeamNaam = GetOptionalString(root, "teamNaam"),
+            LeeftijdsCategorie = GetOptionalString(root, "leeftijdsCategorie"),
+            Tegenstander = GetOptionalString(root, "tegenstander"),
+            Samenvatting = root.GetProperty("samenvatting").GetString() ?? "",
+            NamensWie = MapNamensWie(namensWieString)
+        };
+    }
+
+    private static VerzoekType MapVerzoekType(string type) => type switch
+    {
+        "beschikbaarheid_check" => VerzoekType.BeschikbaarheidCheck,
+        "herplan_verzoek" => VerzoekType.HerplanVerzoek,
+        "bevestiging" => VerzoekType.Bevestiging,
+        _ => VerzoekType.BuitenScope
+    };
+
+    private static NamensWie MapNamensWie(string namensWie) => namensWie switch
+    {
+        "afzender" => NamensWie.Afzender,
+        "tegenstander" => NamensWie.Tegenstander,
+        _ => NamensWie.Onbekend
+    };
+
+    private static string? GetOptionalString(JsonElement element, string propertyName)
+    {
+        if (element.TryGetProperty(propertyName, out var prop) &&
+            prop.ValueKind != JsonValueKind.Null)
+        {
+            var value = prop.GetString();
+            return value == "null" ? null : value;
+        }
+        return null;
+    }
+}

--- a/FunctionApp/Email/EmailModels.cs
+++ b/FunctionApp/Email/EmailModels.cs
@@ -1,0 +1,54 @@
+namespace SportlinkFunction.Email;
+
+// Classificatie door AI
+public enum VerzoekType
+{
+    BeschikbaarheidCheck,
+    HerplanVerzoek,
+    Bevestiging,
+    BuitenScope
+}
+
+public enum NamensWie
+{
+    Afzender,
+    Tegenstander,
+    Onbekend
+}
+
+// AI classificatie response
+public class EmailClassificatie
+{
+    public VerzoekType Type { get; set; }
+    public string? Datum { get; set; }           // yyyy-MM-dd
+    public string? AanvangsTijd { get; set; }    // HH:mm
+    public string? TeamNaam { get; set; }
+    public string? LeeftijdsCategorie { get; set; }
+    public string? Tegenstander { get; set; }
+    public string Samenvatting { get; set; } = "";
+    public NamensWie NamensWie { get; set; }
+}
+
+// Inkomende email data
+public class InkomendEmail
+{
+    public string MessageId { get; set; } = "";
+    public string ConversationId { get; set; } = "";
+    public string Afzender { get; set; } = "";
+    public string AfzenderNaam { get; set; } = "";
+    public string Onderwerp { get; set; } = "";
+    public DateTime OntvangstDatum { get; set; }
+    public string Body { get; set; } = "";
+}
+
+// Verwerking status
+public enum EmailStatus
+{
+    Ontvangen,
+    Geclassificeerd,
+    Verwerkt,
+    AntwoordVerstuurd,
+    Review,
+    Fout,
+    BuitenScope
+}


### PR DESCRIPTION
## Samenvatting
- **EmailAiService** toegevoegd in `FunctionApp/Email/EmailAiService.cs` met OpenAI GPT-4o-mini integratie
- `ClassificeerEmailAsync()` classificeert inkomende emails naar type verzoek (beschikbaarheid, herplannen, bevestiging, buiten scope) met structured JSON output
- `GenereerAntwoordAsync()` genereert een antwoord-email op basis van classificatie en planner response, in VRC-huisstijl

Closes #37

## Verificatie checklist
- [x] Bouwt zonder fouten (`dotnet build` succesvol)
- [x] OpenAI SDK v2.10.0 correct gebruikt (ChatClient, ChatCompletionOptions, ResponseFormat)
- [x] System prompts in het Nederlands met VRC-specifieke context
- [x] JSON response parsing met correcte enum mapping (VerzoekType, NamensWie)
- [x] Error handling: fouten worden gelogd en doorgegeven aan caller
- [x] Geen hardcoded API keys — leest uit environment variable `OpenAiApiKey`

🤖 Generated with [Claude Code](https://claude.com/claude-code)