### PR TITLE
Voeg EmailResponseGenerator toe voor email antwoord-opbouw (#38)

### DIFF
--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -106,6 +106,16 @@ BEGIN
 END
 GO
 
+-- AppSettings: email-integratie velden vullen
+IF EXISTS (SELECT 1 FROM [dbo].[AppSettings] WHERE [PlannerAfzenderNaam] IS NULL)
+BEGIN
+    UPDATE [dbo].[AppSettings]
+    SET [PlannerAfzenderNaam] = 'VRC Veldplanner',
+        [CoordinatorFunctie] = N'Coördinator thuiswedstrijden'
+    WHERE [PlannerAfzenderNaam] IS NULL
+END
+GO
+
 -- Update the Season and datetable
 DECLARE @SeasonStartMonth INT = (SELECT [SeasonStartMonth] FROM [dbo].[AppSettings])
 EXEC [dbo].[sp_UpdateSeasonTable] @SeasonStartMonth;

--- a/Database/SportlinkSqlDb.sqlproj
+++ b/Database/SportlinkSqlDb.sqlproj
@@ -107,6 +107,7 @@
     <Build Include="planner\Tables\GeplandeWedstrijden.sql" />
     <Build Include="planner\Views\AlleWedstrijdenOpVeld.sql" />
     <Build Include="planner\Tables\HerplanVerzoeken.sql" />
+    <Build Include="planner\Tables\EmailVerwerking.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Script1.sql" />

--- a/Database/dbo/Tables/AppSettings.sql
+++ b/Database/dbo/Tables/AppSettings.sql
@@ -1,8 +1,12 @@
 ﻿CREATE TABLE [dbo].[AppSettings](
-	[ClubName]			NVARCHAR(100)	NOT NULL,
-	[SportlinkApiUrl]	NVARCHAR(100)	NOT NULL,
-	[SportlinkClientId]	NVARCHAR(50)	NOT NULL,
-	[SeasonStartMonth]	[int]			NOT NULL,
-	[LastSyncTimestamp]	DATETIME2		NULL,
-	[FetchSchedule]		NVARCHAR(50)	NOT NULL DEFAULT '0 0 4 * * *'
+	[ClubName]				NVARCHAR(100)	NOT NULL,
+	[SportlinkApiUrl]		NVARCHAR(100)	NOT NULL,
+	[SportlinkClientId]		NVARCHAR(50)	NOT NULL,
+	[SeasonStartMonth]		[int]			NOT NULL,
+	[LastSyncTimestamp]		DATETIME2		NULL,
+	[FetchSchedule]			NVARCHAR(50)	NOT NULL DEFAULT '0 0 4 * * *',
+	[PlannerAfzenderNaam]	NVARCHAR(100)	NULL,
+	[CoordinatorNaam]		NVARCHAR(100)	NULL,
+	[CoordinatorFunctie]	NVARCHAR(100)	NULL,
+	[PlannerEmailAdres]		NVARCHAR(200)	NULL
 	)

--- a/Database/planner/Tables/EmailVerwerking.sql
+++ b/Database/planner/Tables/EmailVerwerking.sql
@@ -1,0 +1,20 @@
+CREATE TABLE [planner].[EmailVerwerking] (
+    [Id]                    INT             IDENTITY(1,1) NOT NULL,
+    [MessageId]             NVARCHAR(500)   NOT NULL,
+    [ConversationId]        NVARCHAR(500)   NULL,
+    [Afzender]              NVARCHAR(200)   NOT NULL,
+    [Onderwerp]             NVARCHAR(500)   NOT NULL,
+    [OntvangstDatum]        DATETIME2       NOT NULL,
+    [EmailBody]             NVARCHAR(MAX)   NULL,
+    [VerzoekType]           NVARCHAR(50)    NOT NULL,
+    [GeextraheerdeData]     NVARCHAR(MAX)   NULL,
+    [PlannerResponse]       NVARCHAR(MAX)   NULL,
+    [AntwoordEmail]         NVARCHAR(MAX)   NULL,
+    [VerstuurdNaar]         NVARCHAR(200)   NULL,
+    [Status]                NVARCHAR(30)    NOT NULL CONSTRAINT [DF_EmailVerwerking_Status] DEFAULT 'Ontvangen',
+    [FoutMelding]           NVARCHAR(1000)  NULL,
+    [mta_inserted]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Ins] DEFAULT GETDATE(),
+    [mta_modified]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Mod] DEFAULT GETDATE(),
+    CONSTRAINT [PK_EmailVerwerking] PRIMARY KEY CLUSTERED ([Id] ASC),
+    CONSTRAINT [UQ_EmailVerwerking_MessageId] UNIQUE ([MessageId])
+);

--- a/FunctionApp/Email/EmailModels.cs
+++ b/FunctionApp/Email/EmailModels.cs
@@ -1,0 +1,54 @@
+namespace SportlinkFunction.Email;
+
+// Classificatie door AI
+public enum VerzoekType
+{
+    BeschikbaarheidCheck,
+    HerplanVerzoek,
+    Bevestiging,
+    BuitenScope
+}
+
+public enum NamensWie
+{
+    Afzender,
+    Tegenstander,
+    Onbekend
+}
+
+// AI classificatie response
+public class EmailClassificatie
+{
+    public VerzoekType Type { get; set; }
+    public string? Datum { get; set; }           // yyyy-MM-dd
+    public string? AanvangsTijd { get; set; }    // HH:mm
+    public string? TeamNaam { get; set; }
+    public string? LeeftijdsCategorie { get; set; }
+    public string? Tegenstander { get; set; }
+    public string Samenvatting { get; set; } = "";
+    public NamensWie NamensWie { get; set; }
+}
+
+// Inkomende email data
+public class InkomendEmail
+{
+    public string MessageId { get; set; } = "";
+    public string ConversationId { get; set; } = "";
+    public string Afzender { get; set; } = "";
+    public string AfzenderNaam { get; set; } = "";
+    public string Onderwerp { get; set; } = "";
+    public DateTime OntvangstDatum { get; set; }
+    public string Body { get; set; } = "";
+}
+
+// Verwerking status
+public enum EmailStatus
+{
+    Ontvangen,
+    Geclassificeerd,
+    Verwerkt,
+    AntwoordVerstuurd,
+    Review,
+    Fout,
+    BuitenScope
+}

--- a/FunctionApp/Email/EmailResponseGenerator.cs
+++ b/FunctionApp/Email/EmailResponseGenerator.cs
@@ -1,0 +1,95 @@
+namespace SportlinkFunction.Email;
+
+public static class EmailResponseGenerator
+{
+    /// <summary>
+    /// Bouwt een compleet email-antwoord op inclusief review-header (indien actief), AI-tekst en handtekening.
+    /// </summary>
+    public static (string onderwerp, string body) BouwAntwoordOp(
+        string aiAntwoord,
+        EmailClassificatie classificatie,
+        InkomendEmail origineleEmail)
+    {
+        var onderwerp = $"Re: {origineleEmail.Onderwerp}";
+        var body = "";
+
+        // Review-mode header
+        var reviewMode = Environment.GetEnvironmentVariable("EmailReviewMode");
+        if (string.Equals(reviewMode, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            body += $"=== REVIEW MODE ===\n"
+                  + $"Originele afzender: {origineleEmail.Afzender}\n"
+                  + $"Onderwerp: {origineleEmail.Onderwerp}\n"
+                  + $"Classificatie: {classificatie.Type}\n"
+                  + $"==================\n\n";
+        }
+
+        body += aiAntwoord;
+        body += "\n\n" + GetHandtekening();
+
+        return (onderwerp, body);
+    }
+
+    /// <summary>
+    /// Standaard antwoord voor verzoeken die buiten scope vallen.
+    /// </summary>
+    public static (string onderwerp, string body) BouwBuitenScopeAntwoord(InkomendEmail origineleEmail)
+    {
+        var onderwerp = $"Re: {origineleEmail.Onderwerp}";
+        var aanhef = GetTijdsgebondenAanhef();
+        var voornaam = ExtractVoornaam(origineleEmail.AfzenderNaam);
+
+        var body = "";
+
+        var reviewMode = Environment.GetEnvironmentVariable("EmailReviewMode");
+        if (string.Equals(reviewMode, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            body += $"=== REVIEW MODE ===\n"
+                  + $"Originele afzender: {origineleEmail.Afzender}\n"
+                  + $"Onderwerp: {origineleEmail.Onderwerp}\n"
+                  + $"Classificatie: BuitenScope\n"
+                  + $"==================\n\n";
+        }
+
+        body += $"{aanhef} {voornaam},\n\n"
+              + "Bedankt voor je bericht. Dit verzoek vereist handmatige afhandeling "
+              + "en is ter beoordeling bij de coördinator neergelegd.\n\n"
+              + GetHandtekening();
+
+        return (onderwerp, body);
+    }
+
+    /// <summary>
+    /// Tijdsgebonden aanhef op basis van het huidige uur.
+    /// </summary>
+    public static string GetTijdsgebondenAanhef()
+    {
+        var uur = DateTime.Now.Hour;
+        if (uur < 12) return "Goedemorgen";
+        if (uur < 18) return "Goedemiddag";
+        return "Goedenavond";
+    }
+
+    private static string GetHandtekening()
+    {
+        var afzenderNaam = SystemUtilities.AppSettings.GetSetting("plannerAfzenderNaam") ?? "VRC Veldplanner";
+        var coordinatorNaam = SystemUtilities.AppSettings.GetSetting("coordinatorNaam");
+        var coordinatorFunctie = SystemUtilities.AppSettings.GetSetting("coordinatorFunctie") ?? "Coördinator thuiswedstrijden";
+
+        var handtekening = $"Met vriendelijke groet,\n\n{afzenderNaam}";
+        if (!string.IsNullOrEmpty(coordinatorNaam))
+            handtekening += $"\nGeautomatiseerd antwoord namens {coordinatorNaam}";
+        handtekening += $"\n{coordinatorFunctie}";
+
+        return handtekening;
+    }
+
+    private static string ExtractVoornaam(string volledigeNaam)
+    {
+        if (string.IsNullOrWhiteSpace(volledigeNaam))
+            return "";
+
+        var delen = volledigeNaam.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        return delen[0];
+    }
+}

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -18,7 +18,7 @@ namespace SportlinkFunction
                     using (SqlConnection connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString))
                     {
                         await connection.OpenAsync();
-                        string query = "SELECT [SportlinkApiUrl], [SportlinkClientId], [LastSyncTimestamp], [FetchSchedule] FROM [dbo].[AppSettings]";
+                        string query = "SELECT [SportlinkApiUrl], [SportlinkClientId], [LastSyncTimestamp], [FetchSchedule], [PlannerAfzenderNaam], [CoordinatorNaam], [CoordinatorFunctie], [PlannerEmailAdres] FROM [dbo].[AppSettings]";
                         using (SqlCommand command = new SqlCommand(query, connection))
                         using (SqlDataReader reader = await command.ExecuteReaderAsync())
                         {
@@ -31,6 +31,15 @@ namespace SportlinkFunction
                                 if (reader["LastSyncTimestamp"] != DBNull.Value)
                                     settings["lastSyncTimestamp"] = Convert.ToDateTime(reader["LastSyncTimestamp"]).ToString("yyyy-MM-dd HH:mm:ss");
                                 settings["fetchSchedule"] = reader["FetchSchedule"].ToString() ?? "0 0 4 * * *";
+
+                                if (reader["PlannerAfzenderNaam"] != DBNull.Value)
+                                    settings["plannerAfzenderNaam"] = reader["PlannerAfzenderNaam"].ToString() ?? "";
+                                if (reader["CoordinatorNaam"] != DBNull.Value)
+                                    settings["coordinatorNaam"] = reader["CoordinatorNaam"].ToString() ?? "";
+                                if (reader["CoordinatorFunctie"] != DBNull.Value)
+                                    settings["coordinatorFunctie"] = reader["CoordinatorFunctie"].ToString() ?? "";
+                                if (reader["PlannerEmailAdres"] != DBNull.Value)
+                                    settings["plannerEmailAdres"] = reader["PlannerEmailAdres"].ToString() ?? "";
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- `FunctionApp/Email/EmailResponseGenerator.cs` — bouwt complete email-antwoorden op met:
  - Tijdsgebonden aanhef (Goedemorgen/Goedemiddag/Goedenavond)
  - Review-mode header met originele afzender, onderwerp en classificatie
  - AI-gegenereerde tekst
  - Handtekening uit `dbo.AppSettings` (PlannerAfzenderNaam, CoordinatorNaam, CoordinatorFunctie)
  - Buiten-scope standaard antwoord als fallback
- `Utilities.cs` — AppSettings loader uitgebreid met 4 nieuwe planner-kolommen

Closes #38

## Verificatie
- [x] `dotnet build` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)