### PR TITLE
Voeg EmailProcessorFunction toe als timer-gestuurde orchestrator (#39)

### DIFF
--- a/FunctionApp/Email/EmailAiService.cs
+++ b/FunctionApp/Email/EmailAiService.cs
@@ -1,0 +1,204 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using OpenAI.Chat;
+
+namespace SportlinkFunction.Email;
+
+/// <summary>
+/// Service voor het classificeren van inkomende emails en het genereren van antwoorden
+/// met behulp van OpenAI GPT-4o-mini.
+/// </summary>
+public class EmailAiService
+{
+    private readonly ILogger<EmailAiService> _logger;
+    private readonly ChatClient _chatClient;
+
+    private const string ClassificatieSystemPrompt = """
+        Je bent een assistent voor de coördinator thuiswedstrijden van voetbalvereniging VRC Veenendaal.
+        Analyseer de inkomende email en classificeer het verzoek.
+
+        Typen verzoeken:
+        - beschikbaarheid_check: iemand vraagt of een datum/tijd/veld beschikbaar is voor een oefenwedstrijd
+        - herplan_verzoek: iemand wil een bestaande wedstrijd verplaatsen naar een andere datum/tijd
+        - bevestiging: een antwoord op een eerder voorstel ("ja dat is goed", "akkoord", etc.)
+        - buiten_scope: alles wat niet over veldbeschikbaarheid of herplannen gaat
+
+        Geef ALTIJD een JSON response met exact dit formaat:
+        {
+          "type": "beschikbaarheid_check | herplan_verzoek | bevestiging | buiten_scope",
+          "datum": "yyyy-MM-dd of null",
+          "aanvangsTijd": "HH:mm of null",
+          "teamNaam": "teamnaam of null",
+          "leeftijdsCategorie": "bijv. JO11 of null",
+          "tegenstander": "naam tegenstander of null",
+          "samenvatting": "korte samenvatting van het verzoek",
+          "namensWie": "afzender | tegenstander | onbekend"
+        }
+
+        Let op:
+        - Datums in emails zijn vaak relatief ("aanstaande zaterdag") — bereken de absolute datum op basis van vandaag
+        - Nederlandse tekst, informeel taalgebruik
+        - Als afzender @vv-vrc.nl domein heeft: VRC-intern
+        - Bij doorgestuurde berichten: bepaal namens wie het verzoek is
+        """;
+
+    private const string AntwoordSystemPrompt = """
+        Je bent de VRC Veldplanner, een geautomatiseerd systeem dat antwoordt namens de coördinator thuiswedstrijden van voetbalvereniging VRC Veenendaal.
+
+        Schrijfstijl:
+        - Kort en duidelijk, geen technische details
+        - Gebruik de tijdsgebonden aanhef (Goedemorgen/Goedemiddag/Goedenavond) gevolgd door de voornaam
+        - Maximaal 2-3 alternatieven noemen als de gevraagde tijd niet beschikbaar is
+        - Eindig met: "Met vriendelijke groet,\n\nVRC Veldplanner\nGeautomatiseerd antwoord namens de coördinator thuiswedstrijden"
+        """;
+
+    public EmailAiService(ILogger<EmailAiService> logger)
+    {
+        _logger = logger;
+
+        var apiKey = Environment.GetEnvironmentVariable("OpenAiApiKey")
+            ?? throw new InvalidOperationException("OpenAiApiKey environment variable is niet geconfigureerd.");
+
+        _chatClient = new ChatClient("gpt-4o-mini", apiKey);
+    }
+
+    /// <summary>
+    /// Classificeert een inkomende email met behulp van GPT-4o-mini.
+    /// Retourneert een EmailClassificatie met het type verzoek en geëxtraheerde gegevens.
+    /// </summary>
+    public async Task<EmailClassificatie> ClassificeerEmailAsync(string body, string subject, string afzender)
+    {
+        _logger.LogInformation("Email classificatie gestart voor onderwerp: {Subject}", subject);
+
+        var userPrompt = $"Van: {afzender}\nOnderwerp: {subject}\n\n{body}";
+
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage(ClassificatieSystemPrompt),
+            new UserChatMessage(userPrompt)
+        };
+
+        var options = new ChatCompletionOptions
+        {
+            Temperature = 0.1f,
+            ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat()
+        };
+
+        try
+        {
+            var completion = await _chatClient.CompleteChatAsync(messages, options);
+            var jsonResponse = completion.Value.Content[0].Text;
+
+            _logger.LogInformation("OpenAI classificatie response ontvangen");
+
+            var classificatie = ParseClassificatieResponse(jsonResponse);
+            return classificatie;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij het classificeren van email met onderwerp: {Subject}", subject);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Genereert een antwoord-email op basis van de classificatie en planner response.
+    /// </summary>
+    public async Task<string> GenereerAntwoordAsync(
+        EmailClassificatie classificatie,
+        string plannerResponseJson,
+        string afzenderNaam)
+    {
+        _logger.LogInformation("Antwoord generatie gestart voor type: {Type}", classificatie.Type);
+
+        var userPrompt = $"""
+            Classificatie van het verzoek:
+            - Type: {classificatie.Type}
+            - Samenvatting: {classificatie.Samenvatting}
+            - Team: {classificatie.TeamNaam ?? "onbekend"}
+            - Datum: {classificatie.Datum ?? "niet opgegeven"}
+            - Tijd: {classificatie.AanvangsTijd ?? "niet opgegeven"}
+            - Tegenstander: {classificatie.Tegenstander ?? "onbekend"}
+
+            Planner response:
+            {plannerResponseJson}
+
+            Naam afzender: {afzenderNaam}
+            """;
+
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage(AntwoordSystemPrompt),
+            new UserChatMessage(userPrompt)
+        };
+
+        var options = new ChatCompletionOptions
+        {
+            Temperature = 0.5f
+        };
+
+        try
+        {
+            var completion = await _chatClient.CompleteChatAsync(messages, options);
+            var antwoord = completion.Value.Content[0].Text;
+
+            _logger.LogInformation("Antwoord-email gegenereerd");
+            return antwoord;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij het genereren van antwoord-email");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Parst de JSON response van OpenAI naar een EmailClassificatie object.
+    /// </summary>
+    private static EmailClassificatie ParseClassificatieResponse(string jsonResponse)
+    {
+        using var doc = JsonDocument.Parse(jsonResponse);
+        var root = doc.RootElement;
+
+        var typeString = root.GetProperty("type").GetString() ?? "buiten_scope";
+        var namensWieString = root.GetProperty("namensWie").GetString() ?? "onbekend";
+
+        return new EmailClassificatie
+        {
+            Type = MapVerzoekType(typeString),
+            Datum = GetOptionalString(root, "datum"),
+            AanvangsTijd = GetOptionalString(root, "aanvangsTijd"),
+            TeamNaam = GetOptionalString(root, "teamNaam"),
+            LeeftijdsCategorie = GetOptionalString(root, "leeftijdsCategorie"),
+            Tegenstander = GetOptionalString(root, "tegenstander"),
+            Samenvatting = root.GetProperty("samenvatting").GetString() ?? "",
+            NamensWie = MapNamensWie(namensWieString)
+        };
+    }
+
+    private static VerzoekType MapVerzoekType(string type) => type switch
+    {
+        "beschikbaarheid_check" => VerzoekType.BeschikbaarheidCheck,
+        "herplan_verzoek" => VerzoekType.HerplanVerzoek,
+        "bevestiging" => VerzoekType.Bevestiging,
+        _ => VerzoekType.BuitenScope
+    };
+
+    private static NamensWie MapNamensWie(string namensWie) => namensWie switch
+    {
+        "afzender" => NamensWie.Afzender,
+        "tegenstander" => NamensWie.Tegenstander,
+        _ => NamensWie.Onbekend
+    };
+
+    private static string? GetOptionalString(JsonElement element, string propertyName)
+    {
+        if (element.TryGetProperty(propertyName, out var prop) &&
+            prop.ValueKind != JsonValueKind.Null)
+        {
+            var value = prop.GetString();
+            return value == "null" ? null : value;
+        }
+        return null;
+    }
+}

--- a/FunctionApp/Email/EmailGraphService.cs
+++ b/FunctionApp/Email/EmailGraphService.cs
@@ -1,0 +1,184 @@
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+using Microsoft.Graph.Models;
+using Microsoft.Graph.Users.Item.SendMail;
+
+namespace SportlinkFunction.Email;
+
+/// <summary>
+/// Wrapper rond Microsoft Graph SDK voor email-operaties via de coordinator-mailbox.
+/// Ondersteunt inbox polling, emails markeren als gelezen, en antwoorden versturen.
+/// </summary>
+public partial class EmailGraphService
+{
+    private readonly GraphServiceClient _graphClient;
+    private readonly ILogger<EmailGraphService> _logger;
+    private readonly string _mailbox;
+
+    public EmailGraphService(GraphServiceClient graphClient, ILogger<EmailGraphService> logger)
+    {
+        _graphClient = graphClient;
+        _logger = logger;
+        _mailbox = Environment.GetEnvironmentVariable("GraphMailbox")
+            ?? throw new InvalidOperationException("GraphMailbox environment variable is niet geconfigureerd");
+    }
+
+    /// <summary>
+    /// Haalt maximaal 10 ongelezen emails op uit de inbox van de coordinator-mailbox.
+    /// </summary>
+    public async Task<List<InkomendEmail>> GetUnreadEmailsAsync()
+    {
+        var resultaat = new List<InkomendEmail>();
+
+        try
+        {
+            var messages = await _graphClient.Users[_mailbox]
+                .MailFolders["inbox"]
+                .Messages
+                .GetAsync(config =>
+                {
+                    config.QueryParameters.Filter = "isRead eq false";
+                    config.QueryParameters.Top = 10;
+                    config.QueryParameters.Orderby = ["receivedDateTime"];
+                    config.QueryParameters.Select = ["id", "conversationId", "from", "subject", "receivedDateTime", "body"];
+                });
+
+            if (messages?.Value is null)
+            {
+                _logger.LogInformation("Geen ongelezen emails gevonden in {Mailbox}", _mailbox);
+                return resultaat;
+            }
+
+            foreach (var message in messages.Value)
+            {
+                try
+                {
+                    var email = new InkomendEmail
+                    {
+                        MessageId = message.Id ?? "",
+                        ConversationId = message.ConversationId ?? "",
+                        Afzender = message.From?.EmailAddress?.Address ?? "",
+                        AfzenderNaam = message.From?.EmailAddress?.Name ?? "",
+                        Onderwerp = message.Subject ?? "",
+                        OntvangstDatum = message.ReceivedDateTime?.DateTime ?? DateTime.MinValue,
+                        Body = StripHtml(message.Body?.Content ?? "")
+                    };
+
+                    resultaat.Add(email);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Fout bij verwerken van email {MessageId}, wordt overgeslagen",
+                        message.Id);
+                }
+            }
+
+            _logger.LogInformation("{Aantal} ongelezen email(s) opgehaald uit {Mailbox}",
+                resultaat.Count, _mailbox);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij ophalen van ongelezen emails uit {Mailbox}", _mailbox);
+        }
+
+        return resultaat;
+    }
+
+    /// <summary>
+    /// Markeert een email als gelezen in de coordinator-mailbox.
+    /// </summary>
+    public async Task MarkAsReadAsync(string messageId)
+    {
+        try
+        {
+            await _graphClient.Users[_mailbox]
+                .Messages[messageId]
+                .PatchAsync(new Message { IsRead = true });
+
+            _logger.LogInformation("Email {MessageId} gemarkeerd als gelezen", messageId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij markeren van email {MessageId} als gelezen", messageId);
+        }
+    }
+
+    /// <summary>
+    /// Verstuurt een antwoord-email via de coordinator-mailbox.
+    /// </summary>
+    public async Task SendReplyAsync(string to, string subject, string body, string? conversationId)
+    {
+        try
+        {
+            var message = new Message
+            {
+                Subject = subject,
+                Body = new ItemBody
+                {
+                    ContentType = BodyType.Text,
+                    Content = body
+                },
+                ToRecipients =
+                [
+                    new Recipient
+                    {
+                        EmailAddress = new EmailAddress { Address = to }
+                    }
+                ]
+            };
+
+            if (!string.IsNullOrEmpty(conversationId))
+            {
+                message.ConversationId = conversationId;
+            }
+
+            await _graphClient.Users[_mailbox]
+                .SendMail
+                .PostAsync(new SendMailPostRequestBody
+                {
+                    Message = message
+                });
+
+            _logger.LogInformation("Antwoord verstuurd naar {Ontvanger} met onderwerp '{Onderwerp}'",
+                to, subject);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij versturen van antwoord naar {Ontvanger} met onderwerp '{Onderwerp}'",
+                to, subject);
+        }
+    }
+
+    /// <summary>
+    /// Verwijdert HTML-tags uit tekst en normaliseert whitespace.
+    /// </summary>
+    private static string StripHtml(string html)
+    {
+        if (string.IsNullOrWhiteSpace(html))
+            return "";
+
+        // Verwijder HTML-tags
+        var tekst = HtmlTagRegex().Replace(html, " ");
+
+        // Decodeer veelvoorkomende HTML-entiteiten
+        tekst = tekst
+            .Replace("&nbsp;", " ")
+            .Replace("&amp;", "&")
+            .Replace("&lt;", "<")
+            .Replace("&gt;", ">")
+            .Replace("&quot;", "\"")
+            .Replace("&#39;", "'");
+
+        // Normaliseer whitespace
+        tekst = WhitespaceRegex().Replace(tekst, " ");
+
+        return tekst.Trim();
+    }
+
+    [GeneratedRegex("<[^>]+>")]
+    private static partial Regex HtmlTagRegex();
+
+    [GeneratedRegex(@"\s+")]
+    private static partial Regex WhitespaceRegex();
+}

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -1,0 +1,299 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+using Newtonsoft.Json;
+using SportlinkFunction.Planner;
+
+namespace SportlinkFunction.Email;
+
+public class EmailProcessorFunction
+{
+    [Function("ProcessIncomingEmails")]
+    public async Task Run(
+        [TimerTrigger("%EMAIL_POLL_SCHEDULE%")] TimerInfo timer,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("ProcessIncomingEmails");
+
+        // 1. Kill-switch
+        if (!string.Equals(Environment.GetEnvironmentVariable("EmailProcessorEnabled"),
+                "true", StringComparison.OrdinalIgnoreCase))
+        {
+            log.LogInformation("Email processor uitgeschakeld");
+            return;
+        }
+
+        // 2. Services initialiseren
+        var graphClient = context.InstanceServices.GetService<GraphServiceClient>();
+        if (graphClient == null)
+        {
+            log.LogError("GraphServiceClient niet beschikbaar — controleer Graph settings");
+            return;
+        }
+
+        await SystemUtilities.WaitForDatabaseAsync(log);
+        await SystemUtilities.AppSettings.LoadSettingsAsync(log);
+
+        var loggerFactory = context.InstanceServices.GetRequiredService<ILoggerFactory>();
+        var graphService = new EmailGraphService(graphClient, loggerFactory.CreateLogger<EmailGraphService>());
+        var aiService = new EmailAiService(loggerFactory.CreateLogger<EmailAiService>());
+
+        // 3. Ongelezen emails ophalen
+        var emails = await graphService.GetUnreadEmailsAsync();
+        if (emails.Count == 0)
+        {
+            log.LogInformation("Geen ongelezen emails");
+            return;
+        }
+
+        int verwerkt = 0, fouten = 0;
+
+        // 4. Verwerk elke email
+        foreach (var email in emails)
+        {
+            try
+            {
+                await VerwerkEmailAsync(email, graphService, aiService, log);
+                verwerkt++;
+            }
+            catch (Exception ex)
+            {
+                fouten++;
+                log.LogError(ex, "Fout bij verwerken van email {MessageId}: {Onderwerp}",
+                    email.MessageId, email.Onderwerp);
+                try { await UpdateFoutAsync(email.MessageId, ex.Message); }
+                catch { /* fout bij fout-logging mag niet cascaderen */ }
+            }
+        }
+
+        log.LogInformation("Email verwerking afgerond: {Verwerkt} verwerkt, {Fouten} fouten",
+            verwerkt, fouten);
+    }
+
+    private static async Task VerwerkEmailAsync(
+        InkomendEmail email,
+        EmailGraphService graphService,
+        EmailAiService aiService,
+        ILogger log)
+    {
+        // 4a. Deduplicatie
+        if (await BestaatMessageIdAsync(email.MessageId))
+        {
+            log.LogInformation("Email {MessageId} al verwerkt, overslaan", email.MessageId);
+            await graphService.MarkAsReadAsync(email.MessageId);
+            return;
+        }
+
+        // 4b. INSERT in EmailVerwerking (Status = Ontvangen)
+        var verwerkingId = await InsertEmailVerwerkingAsync(email);
+        log.LogInformation("Email {MessageId} geregistreerd met id {Id}", email.MessageId, verwerkingId);
+
+        // 4c. Classificeer met AI
+        var classificatie = await aiService.ClassificeerEmailAsync(
+            email.Body, email.Onderwerp, email.Afzender);
+
+        var classificatieJson = JsonConvert.SerializeObject(classificatie);
+        await UpdateStatusAsync(verwerkingId, EmailStatus.Geclassificeerd, classificatieJson);
+        log.LogInformation("Email {Id} geclassificeerd als {Type}", verwerkingId, classificatie.Type);
+
+        string onderwerp;
+        string antwoordBody;
+
+        if (classificatie.Type == VerzoekType.BuitenScope)
+        {
+            // 4e. Buiten scope — standaard antwoord
+            (onderwerp, antwoordBody) = EmailResponseGenerator.BouwBuitenScopeAntwoord(email);
+            await UpdateStatusAsync(verwerkingId, EmailStatus.BuitenScope, null);
+        }
+        else
+        {
+            // 4f. Roep PlannerService aan op basis van classificatie
+            var plannerResponseJson = await VerwerkMetPlannerAsync(classificatie, log);
+            await UpdatePlannerResponseAsync(verwerkingId, plannerResponseJson);
+            await UpdateStatusAsync(verwerkingId, EmailStatus.Verwerkt, null);
+
+            // 4h. Genereer AI-antwoord
+            var aiAntwoord = await aiService.GenereerAntwoordAsync(
+                classificatie, plannerResponseJson, email.AfzenderNaam);
+
+            // 4i. Bouw compleet antwoord op
+            (onderwerp, antwoordBody) = EmailResponseGenerator.BouwAntwoordOp(
+                aiAntwoord, classificatie, email);
+        }
+
+        // 4j. Bepaal ontvanger (review mode vs productie)
+        var reviewMode = Environment.GetEnvironmentVariable("EmailReviewMode");
+        var ontvanger = string.Equals(reviewMode, "true", StringComparison.OrdinalIgnoreCase)
+            ? Environment.GetEnvironmentVariable("EmailReviewRecipient") ?? email.Afzender
+            : email.Afzender;
+
+        // 4k. Verstuur antwoord
+        await graphService.SendReplyAsync(ontvanger, onderwerp, antwoordBody, email.ConversationId);
+
+        // 4l. Update status
+        await UpdateAntwoordVerstuurdAsync(verwerkingId, ontvanger, antwoordBody);
+
+        // 4m. Markeer als gelezen
+        await graphService.MarkAsReadAsync(email.MessageId);
+
+        log.LogInformation("Email {Id} volledig verwerkt, antwoord verstuurd naar {Ontvanger}",
+            verwerkingId, ontvanger);
+    }
+
+    /// <summary>
+    /// Vertaalt de AI-classificatie naar de juiste PlannerService-aanroep.
+    /// </summary>
+    private static async Task<string> VerwerkMetPlannerAsync(
+        EmailClassificatie classificatie, ILogger log)
+    {
+        switch (classificatie.Type)
+        {
+            case VerzoekType.BeschikbaarheidCheck:
+                var checkRequest = new CheckAvailabilityRequest
+                {
+                    Datum = classificatie.Datum ?? "",
+                    AanvangsTijd = classificatie.AanvangsTijd,
+                    LeeftijdsCategorie = classificatie.LeeftijdsCategorie,
+                    TeamNaam = classificatie.TeamNaam,
+                    Tegenstander = classificatie.Tegenstander
+                };
+                var checkResponse = await PlannerService.CheckAvailabilityAsync(checkRequest, log);
+                return JsonConvert.SerializeObject(checkResponse);
+
+            case VerzoekType.HerplanVerzoek:
+                if (!string.IsNullOrEmpty(classificatie.TeamNaam) && !string.IsNullOrEmpty(classificatie.Datum))
+                {
+                    if (DateOnly.TryParse(classificatie.Datum, out var datum))
+                    {
+                        var wedstrijd = await PlannerDataAccess.FindMatchAsync(classificatie.TeamNaam, datum);
+                        if (wedstrijd != null)
+                        {
+                            var herplanRequest = new HerplanCheckRequest
+                            {
+                                Wedstrijdcode = wedstrijd.Wedstrijdcode,
+                                VoorkeurTijd = classificatie.AanvangsTijd
+                            };
+                            var herplanResponse = await PlannerService.CheckRescheduleAvailabilityAsync(herplanRequest, log);
+                            return JsonConvert.SerializeObject(new { wedstrijd, herplanOpties = herplanResponse });
+                        }
+                        return JsonConvert.SerializeObject(new { gevonden = false, reden = $"Geen wedstrijd gevonden voor {classificatie.TeamNaam} op {classificatie.Datum}" });
+                    }
+                }
+                return JsonConvert.SerializeObject(new { error = "Onvoldoende gegevens voor herplanverzoek (team en datum nodig)" });
+
+            case VerzoekType.Bevestiging:
+                return JsonConvert.SerializeObject(new { status = "Bevestiging ontvangen", opmerking = "Bevestigingen vereisen handmatige afhandeling door de coördinator" });
+
+            default:
+                return JsonConvert.SerializeObject(new { status = "Niet verwerkt" });
+        }
+    }
+
+    // --- Database operaties ---
+
+    private static async Task<bool> BestaatMessageIdAsync(string messageId)
+    {
+        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+        await connection.OpenAsync();
+        using var command = new SqlCommand(
+            "SELECT COUNT(1) FROM [planner].[EmailVerwerking] WHERE [MessageId] = @MessageId", connection);
+        command.Parameters.AddWithValue("@MessageId", messageId);
+        var count = (int)(await command.ExecuteScalarAsync())!;
+        return count > 0;
+    }
+
+    private static async Task<int> InsertEmailVerwerkingAsync(InkomendEmail email)
+    {
+        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+        await connection.OpenAsync();
+        using var command = new SqlCommand(@"
+            INSERT INTO [planner].[EmailVerwerking]
+                ([MessageId], [ConversationId], [Afzender], [Onderwerp], [OntvangstDatum], [EmailBody], [VerzoekType], [Status])
+            VALUES
+                (@MessageId, @ConversationId, @Afzender, @Onderwerp, @OntvangstDatum, @EmailBody, 'Onbekend', 'Ontvangen');
+            SELECT CAST(SCOPE_IDENTITY() AS INT);", connection);
+
+        command.Parameters.AddWithValue("@MessageId", email.MessageId);
+        command.Parameters.AddWithValue("@ConversationId", (object?)email.ConversationId ?? DBNull.Value);
+        command.Parameters.AddWithValue("@Afzender", email.Afzender);
+        command.Parameters.AddWithValue("@Onderwerp", email.Onderwerp);
+        command.Parameters.AddWithValue("@OntvangstDatum", email.OntvangstDatum);
+        command.Parameters.AddWithValue("@EmailBody", (object?)email.Body ?? DBNull.Value);
+
+        return (int)(await command.ExecuteScalarAsync())!;
+    }
+
+    private static async Task UpdateStatusAsync(int verwerkingId, EmailStatus status, string? geextraheerdeData)
+    {
+        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+        await connection.OpenAsync();
+
+        var setClauses = "[Status] = @Status, [mta_modified] = GETDATE()";
+        if (geextraheerdeData != null)
+            setClauses += ", [GeextraheerdeData] = @Data, [VerzoekType] = @VerzoekType";
+
+        using var command = new SqlCommand(
+            $"UPDATE [planner].[EmailVerwerking] SET {setClauses} WHERE [Id] = @Id", connection);
+        command.Parameters.AddWithValue("@Id", verwerkingId);
+        command.Parameters.AddWithValue("@Status", status.ToString());
+
+        if (geextraheerdeData != null)
+        {
+            command.Parameters.AddWithValue("@Data", geextraheerdeData);
+            // Extraheer VerzoekType uit de classificatie JSON
+            try
+            {
+                var classificatie = JsonConvert.DeserializeObject<EmailClassificatie>(geextraheerdeData);
+                command.Parameters.AddWithValue("@VerzoekType", classificatie?.Type.ToString() ?? "Onbekend");
+            }
+            catch
+            {
+                command.Parameters.AddWithValue("@VerzoekType", "Onbekend");
+            }
+        }
+
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task UpdatePlannerResponseAsync(int verwerkingId, string plannerResponseJson)
+    {
+        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+        await connection.OpenAsync();
+        using var command = new SqlCommand(@"
+            UPDATE [planner].[EmailVerwerking]
+            SET [PlannerResponse] = @Response, [mta_modified] = GETDATE()
+            WHERE [Id] = @Id", connection);
+        command.Parameters.AddWithValue("@Id", verwerkingId);
+        command.Parameters.AddWithValue("@Response", plannerResponseJson);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task UpdateAntwoordVerstuurdAsync(int verwerkingId, string verstuurdNaar, string antwoordEmail)
+    {
+        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+        await connection.OpenAsync();
+        using var command = new SqlCommand(@"
+            UPDATE [planner].[EmailVerwerking]
+            SET [Status] = 'AntwoordVerstuurd', [VerstuurdNaar] = @Naar, [AntwoordEmail] = @Antwoord, [mta_modified] = GETDATE()
+            WHERE [Id] = @Id", connection);
+        command.Parameters.AddWithValue("@Id", verwerkingId);
+        command.Parameters.AddWithValue("@Naar", verstuurdNaar);
+        command.Parameters.AddWithValue("@Antwoord", antwoordEmail);
+        await command.ExecuteNonQueryAsync();
+    }
+
+    private static async Task UpdateFoutAsync(string messageId, string foutMelding)
+    {
+        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+        await connection.OpenAsync();
+        using var command = new SqlCommand(@"
+            UPDATE [planner].[EmailVerwerking]
+            SET [Status] = 'Fout', [FoutMelding] = @Fout, [mta_modified] = GETDATE()
+            WHERE [MessageId] = @MessageId", connection);
+        command.Parameters.AddWithValue("@MessageId", messageId);
+        command.Parameters.AddWithValue("@Fout", foutMelding.Length > 1000 ? foutMelding[..1000] : foutMelding);
+        await command.ExecuteNonQueryAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- `FunctionApp/Email/EmailProcessorFunction.cs` — hoofd-orchestratiefunctie voor email-verwerking:
  - Timer trigger (`%EMAIL_POLL_SCHEDULE%`, default elke 5 min)
  - Kill-switch via `EmailProcessorEnabled` setting
  - Per email: deduplicatie → AI classificatie → PlannerService aanroep → antwoord generatie → verzending
  - Review-mode: antwoorden naar review-mailbox ipv originele afzender
  - Fout-isolatie: exception per email wordt gevangen, andere emails worden gewoon verwerkt
  - Volledige audit trail in `planner.EmailVerwerking` met status-updates per stap
- Integreert alle email-componenten: EmailGraphService (#36), EmailAiService (#37), EmailResponseGenerator (#38)
- PlannerService wordt direct aangeroepen (geen HTTP roundtrip)

Closes #39

## Verificatie
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `func start` — `ProcessIncomingEmails: timerTrigger` registreert correct
- [x] Kill-switch: `EmailProcessorEnabled=false` → geen verwerking

🤖 Generated with [Claude Code](https://claude.com/claude-code)