### PR TITLE
Soak test fixes: hybride templates, herplan-filter, dag-datum validatie

### DIFF
--- a/FunctionApp/Email/EmailAiService.cs
+++ b/FunctionApp/Email/EmailAiService.cs
@@ -43,15 +43,6 @@ public class EmailAiService
         - Leeftijdscategorieën: "O13", "Onder 13", "onder 13" etc. normaliseren naar "JO13". Idem voor alle leeftijden (O7→JO7, O19→JO19, etc.). Meisjes: "MO13" blijft "MO13"
         """;
 
-    private const string AntwoordSystemPrompt = """
-        Je bent de VRC Veldplanner, een geautomatiseerd systeem dat antwoordt namens de coördinator thuiswedstrijden van voetbalvereniging VRC Veenendaal.
-
-        Schrijfstijl:
-        - Kort en duidelijk, geen technische details
-        - Gebruik de tijdsgebonden aanhef (Goedemorgen/Goedemiddag/Goedenavond) gevolgd door de voornaam
-        - Maximaal 2-3 alternatieven noemen als de gevraagde tijd niet beschikbaar is
-        - Voeg GEEN afsluiting of handtekening toe (geen "Met vriendelijke groet" etc.) — die wordt automatisch toegevoegd
-        """;
 
     public EmailAiService(ILogger<EmailAiService> logger)
     {
@@ -98,57 +89,6 @@ public class EmailAiService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Fout bij het classificeren van email met onderwerp: {Subject}", subject);
-            throw;
-        }
-    }
-
-    /// <summary>
-    /// Genereert een antwoord-email op basis van de classificatie en planner response.
-    /// </summary>
-    public async Task<string> GenereerAntwoordAsync(
-        EmailClassificatie classificatie,
-        string plannerResponseJson,
-        string afzenderNaam)
-    {
-        _logger.LogInformation("Antwoord generatie gestart voor type: {Type}", classificatie.Type);
-
-        var userPrompt = $"""
-            Classificatie van het verzoek:
-            - Type: {classificatie.Type}
-            - Samenvatting: {classificatie.Samenvatting}
-            - Team: {classificatie.TeamNaam ?? "onbekend"}
-            - Datum: {classificatie.Datum ?? "niet opgegeven"}
-            - Tijd: {classificatie.AanvangsTijd ?? "niet opgegeven"}
-            - Tegenstander: {classificatie.Tegenstander ?? "onbekend"}
-
-            Planner response:
-            {plannerResponseJson}
-
-            Naam afzender: {afzenderNaam}
-            """;
-
-        var messages = new List<ChatMessage>
-        {
-            new SystemChatMessage(AntwoordSystemPrompt),
-            new UserChatMessage(userPrompt)
-        };
-
-        var options = new ChatCompletionOptions
-        {
-            Temperature = 0.5f
-        };
-
-        try
-        {
-            var completion = await _chatClient.CompleteChatAsync(messages, options);
-            var antwoord = completion.Value.Content[0].Text;
-
-            _logger.LogInformation("Antwoord-email gegenereerd");
-            return antwoord;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Fout bij het genereren van antwoord-email");
             throw;
         }
     }

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -103,9 +103,13 @@ public class EmailProcessorFunction
         var classificatie = await aiService.ClassificeerEmailAsync(
             email.Body, email.Onderwerp, email.Afzender);
 
+        // Valideer dag-datum combinatie (bijv. "zaterdag" + woensdag-datum → corrigeer)
+        ValideerDagDatum(classificatie, email.Body);
+
         var classificatieJson = JsonConvert.SerializeObject(classificatie);
         await UpdateStatusAsync(verwerkingId, EmailStatus.Geclassificeerd, classificatieJson);
-        log.LogInformation("Email {Id} geclassificeerd als {Type}", verwerkingId, classificatie.Type);
+        log.LogInformation("Email {Id} geclassificeerd als {Type}, datum={Datum}",
+            verwerkingId, classificatie.Type, classificatie.Datum);
 
         string onderwerp;
         string antwoordBody;
@@ -123,13 +127,9 @@ public class EmailProcessorFunction
             await UpdatePlannerResponseAsync(verwerkingId, plannerResponseJson);
             await UpdateStatusAsync(verwerkingId, EmailStatus.Verwerkt, null);
 
-            // 4h. Genereer AI-antwoord
-            var aiAntwoord = await aiService.GenereerAntwoordAsync(
-                classificatie, plannerResponseJson, email.AfzenderNaam);
-
-            // 4i. Bouw compleet antwoord op
-            (onderwerp, antwoordBody) = EmailResponseGenerator.BouwAntwoordOp(
-                aiAntwoord, classificatie, email);
+            // 4h. Bouw antwoord via templates (geen AI nodig)
+            (onderwerp, antwoordBody) = BouwTemplateAntwoord(
+                classificatie, plannerResponseJson, email);
         }
 
         // 4j. Bepaal ontvanger (review mode vs productie)
@@ -149,6 +149,83 @@ public class EmailProcessorFunction
 
         log.LogInformation("Email {Id} volledig verwerkt, antwoord verstuurd naar {Ontvanger}",
             verwerkingId, ontvanger);
+    }
+
+    /// <summary>
+    /// Bouwt het antwoord via templates op basis van het classificatietype en PlannerService response.
+    /// </summary>
+    private static (string onderwerp, string body) BouwTemplateAntwoord(
+        EmailClassificatie classificatie,
+        string plannerResponseJson,
+        InkomendEmail email)
+    {
+        switch (classificatie.Type)
+        {
+            case VerzoekType.BeschikbaarheidCheck:
+                var checkResponse = JsonConvert.DeserializeObject<CheckAvailabilityResponse>(plannerResponseJson);
+                return EmailResponseGenerator.BouwBeschikbaarheidAntwoord(
+                    checkResponse ?? new CheckAvailabilityResponse(), classificatie, email);
+
+            case VerzoekType.HerplanVerzoek:
+                // Herplan response is een compound object: { wedstrijd, herplanOpties }
+                var herplanData = Newtonsoft.Json.Linq.JObject.Parse(plannerResponseJson);
+                var wedstrijd = herplanData["wedstrijd"]?.ToObject<ZoekWedstrijdResponse>();
+                var herplanOpties = herplanData["herplanOpties"]?.ToObject<HerplanCheckResponse>();
+                return EmailResponseGenerator.BouwHerplanAntwoord(
+                    wedstrijd, herplanOpties, classificatie, email);
+
+            case VerzoekType.Bevestiging:
+                return EmailResponseGenerator.BouwBevestigingAntwoord(email, classificatie);
+
+            default:
+                return EmailResponseGenerator.BouwBuitenScopeAntwoord(email);
+        }
+    }
+
+    /// <summary>
+    /// Valideert dag-datum combinatie. Als de email expliciet een dag noemt
+    /// ("zaterdag") maar de AI een datum retourneert die niet op die dag valt,
+    /// corrigeer naar de eerstvolgende/vorige matching datum.
+    /// </summary>
+    private static void ValideerDagDatum(EmailClassificatie classificatie, string emailBody)
+    {
+        if (string.IsNullOrEmpty(classificatie.Datum)) return;
+        if (!DateOnly.TryParse(classificatie.Datum, out var datum)) return;
+
+        var dagNamen = new Dictionary<string, DayOfWeek>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["maandag"] = DayOfWeek.Monday, ["dinsdag"] = DayOfWeek.Tuesday,
+            ["woensdag"] = DayOfWeek.Wednesday, ["donderdag"] = DayOfWeek.Thursday,
+            ["vrijdag"] = DayOfWeek.Friday, ["zaterdag"] = DayOfWeek.Saturday,
+            ["zondag"] = DayOfWeek.Sunday
+        };
+
+        var bodyLower = emailBody.ToLowerInvariant();
+        foreach (var (naam, dag) in dagNamen)
+        {
+            if (!bodyLower.Contains(naam)) continue;
+
+            // Email noemt deze dag — klopt de datum?
+            if (datum.DayOfWeek == dag) return; // Klopt
+
+            // Zoek de eerstvolgende matching datum (max 7 dagen vooruit/achteruit)
+            for (int offset = 1; offset <= 7; offset++)
+            {
+                var vooruit = datum.AddDays(offset);
+                if (vooruit.DayOfWeek == dag)
+                {
+                    classificatie.Datum = vooruit.ToString("yyyy-MM-dd");
+                    return;
+                }
+                var achteruit = datum.AddDays(-offset);
+                if (achteruit.DayOfWeek == dag)
+                {
+                    classificatie.Datum = achteruit.ToString("yyyy-MM-dd");
+                    return;
+                }
+            }
+            return;
+        }
     }
 
     /// <summary>

--- a/FunctionApp/Email/EmailResponseGenerator.cs
+++ b/FunctionApp/Email/EmailResponseGenerator.cs
@@ -1,73 +1,266 @@
+using System.Globalization;
+using SportlinkFunction.Planner;
+
 namespace SportlinkFunction.Email;
 
 public static class EmailResponseGenerator
 {
-    /// <summary>
-    /// Bouwt een compleet email-antwoord op inclusief review-header (indien actief), AI-tekst en handtekening.
-    /// </summary>
-    public static (string onderwerp, string body) BouwAntwoordOp(
-        string aiAntwoord,
+    private static readonly CultureInfo NL = new("nl-NL");
+
+    // ── Beschikbaarheid ──
+
+    public static (string onderwerp, string body) BouwBeschikbaarheidAntwoord(
+        CheckAvailabilityResponse response,
         EmailClassificatie classificatie,
-        InkomendEmail origineleEmail)
+        InkomendEmail email)
     {
-        var onderwerp = $"Re: {origineleEmail.Onderwerp}";
-        var body = "";
-
-        // Review-mode header
-        var reviewMode = Environment.GetEnvironmentVariable("EmailReviewMode");
-        if (string.Equals(reviewMode, "true", StringComparison.OrdinalIgnoreCase))
-        {
-            body += $"=== REVIEW MODE ===\n"
-                  + $"Originele afzender: {origineleEmail.Afzender}\n"
-                  + $"Onderwerp: {origineleEmail.Onderwerp}\n"
-                  + $"Classificatie: {classificatie.Type}\n"
-                  + $"==================\n\n";
-        }
-
-        body += aiAntwoord;
-        body += "\n\n" + GetHandtekening();
-
-        return (onderwerp, body);
-    }
-
-    /// <summary>
-    /// Standaard antwoord voor verzoeken die buiten scope vallen.
-    /// </summary>
-    public static (string onderwerp, string body) BouwBuitenScopeAntwoord(InkomendEmail origineleEmail)
-    {
-        var onderwerp = $"Re: {origineleEmail.Onderwerp}";
         var aanhef = GetTijdsgebondenAanhef();
-        var voornaam = ExtractVoornaam(origineleEmail.AfzenderNaam);
+        var voornaam = ExtractVoornaam(email.AfzenderNaam);
+        var datumTekst = FormatDatum(classificatie.Datum);
 
-        var body = "";
+        string inhoud;
 
-        var reviewMode = Environment.GetEnvironmentVariable("EmailReviewMode");
-        if (string.Equals(reviewMode, "true", StringComparison.OrdinalIgnoreCase))
+        if (response.Beschikbaar && response.Toewijzing != null)
         {
-            body += $"=== REVIEW MODE ===\n"
-                  + $"Originele afzender: {origineleEmail.Afzender}\n"
-                  + $"Onderwerp: {origineleEmail.Onderwerp}\n"
-                  + $"Classificatie: BuitenScope\n"
-                  + $"==================\n\n";
+            var t = response.Toewijzing;
+            inhoud = $"{aanhef} {voornaam},\n\n"
+                   + $"Op {datumTekst} is {t.VeldNaam} beschikbaar om {t.AanvangsTijd}. "
+                   + $"De wedstrijd eindigt om {t.EindTijd}.";
+
+            if (response.Waarschuwingen.Count > 0)
+                inhoud += "\n\nLet op: " + string.Join(" ", response.Waarschuwingen);
+        }
+        else if (response.BeschikbareVensters?.Count > 0)
+        {
+            // Open vraag — toon beschikbare vensters
+            var vensters = FilterKunstgrasVensters(response.BeschikbareVensters);
+            inhoud = $"{aanhef} {voornaam},\n\n"
+                   + $"Op {datumTekst} zijn de volgende mogelijkheden:\n";
+            foreach (var v in vensters)
+            {
+                inhoud += $"- {v.VeldNaam}: beschikbaar van {v.Van} tot {v.Tot}";
+                if (!string.IsNullOrEmpty(v.Opmerking))
+                    inhoud += $" ({v.Opmerking})";
+                inhoud += "\n";
+            }
+            inhoud += "\nGeef een voorkeurstijd door, dan plannen we het in.";
+        }
+        else if (!response.Beschikbaar && response.Alternatieven.Count > 0)
+        {
+            var alternatieven = FilterAlternatieven(response.Alternatieven);
+            inhoud = $"{aanhef} {voornaam},\n\n"
+                   + $"Op {datumTekst}";
+            if (!string.IsNullOrEmpty(classificatie.AanvangsTijd))
+                inhoud += $" om {classificatie.AanvangsTijd}";
+            inhoud += " is helaas geen ruimte.";
+
+            if (alternatieven.Count > 0)
+            {
+                inhoud += " Alternatieven:\n";
+                foreach (var alt in alternatieven.Take(3))
+                    inhoud += $"- {alt.VeldNaam} om {alt.AanvangsTijd} (eindigt {alt.EindTijd})\n";
+            }
+
+            if (response.Waarschuwingen.Count > 0)
+                inhoud += "\nLet op: " + string.Join(" ", response.Waarschuwingen);
+        }
+        else
+        {
+            inhoud = $"{aanhef} {voornaam},\n\n"
+                   + $"Op {datumTekst} is helaas geen veld beschikbaar.";
+            if (!string.IsNullOrEmpty(response.Reden))
+                inhoud += $" {response.Reden}";
         }
 
-        body += $"{aanhef} {voornaam},\n\n"
-              + "Bedankt voor je bericht. Dit verzoek vereist handmatige afhandeling "
-              + "en is ter beoordeling bij de coördinator neergelegd.\n\n"
-              + GetHandtekening();
-
-        return (onderwerp, body);
+        return WrapMetReviewEnHandtekening(inhoud, classificatie, email);
     }
 
-    /// <summary>
-    /// Tijdsgebonden aanhef op basis van het huidige uur.
-    /// </summary>
+    // ── Herplannen ──
+
+    public static (string onderwerp, string body) BouwHerplanAntwoord(
+        ZoekWedstrijdResponse? wedstrijd,
+        HerplanCheckResponse? herplanOpties,
+        EmailClassificatie classificatie,
+        InkomendEmail email)
+    {
+        var aanhef = GetTijdsgebondenAanhef();
+        var voornaam = ExtractVoornaam(email.AfzenderNaam);
+        string inhoud;
+
+        if (wedstrijd == null)
+        {
+            inhoud = $"{aanhef} {voornaam},\n\n"
+                   + $"Er is geen wedstrijd gevonden voor {classificatie.TeamNaam ?? "het opgegeven team"} "
+                   + $"op {FormatDatum(classificatie.Datum)}. "
+                   + "Controleer de teamnaam en datum en probeer het opnieuw.";
+        }
+        else if (herplanOpties == null || herplanOpties.Alternatieven.Count == 0)
+        {
+            inhoud = $"{aanhef} {voornaam},\n\n"
+                   + $"De wedstrijd {wedstrijd.Wedstrijd} op {FormatDatum(wedstrijd.Datum)} om {wedstrijd.AanvangsTijd} "
+                   + $"op {wedstrijd.VeldNaam} kan helaas niet verplaatst worden. "
+                   + "Er zijn geen alternatieven beschikbaar.";
+        }
+        else
+        {
+            // Filter: verwijder huidige slot en slots < 30 min verschil
+            var huidigeAanvang = TimeOnly.TryParse(wedstrijd.AanvangsTijd, out var ha) ? ha : TimeOnly.MinValue;
+            var zinvolleAlternatieven = herplanOpties.Alternatieven
+                .Where(a => TimeOnly.TryParse(a.AanvangsTijd, out var at)
+                    && Math.Abs((at.ToTimeSpan() - huidigeAanvang.ToTimeSpan()).TotalMinutes) >= 30)
+                .ToList();
+
+            var eerdere = zinvolleAlternatieven
+                .Where(a => TimeOnly.Parse(a.AanvangsTijd) < huidigeAanvang)
+                .ToList();
+            eerdere = FilterAlternatieven(eerdere);
+
+            var latere = zinvolleAlternatieven
+                .Where(a => TimeOnly.Parse(a.AanvangsTijd) > huidigeAanvang)
+                .ToList();
+            latere = FilterAlternatieven(latere);
+
+            if (eerdere.Count == 0 && latere.Count == 0)
+            {
+                inhoud = $"{aanhef} {voornaam},\n\n"
+                       + $"De wedstrijd {wedstrijd.Wedstrijd} staat gepland op {FormatDatum(wedstrijd.Datum)} "
+                       + $"om {wedstrijd.AanvangsTijd} op {wedstrijd.VeldNaam}. "
+                       + "Het is een volle wedstrijddag en er zijn helaas geen zinvolle alternatieven beschikbaar.";
+            }
+            else
+            {
+                inhoud = $"{aanhef} {voornaam},\n\n"
+                       + $"De wedstrijd {wedstrijd.Wedstrijd} staat gepland op {FormatDatum(wedstrijd.Datum)} "
+                       + $"om {wedstrijd.AanvangsTijd} op {wedstrijd.VeldNaam}.\n";
+
+                if (eerdere.Count > 0)
+                {
+                    inhoud += "\nEerdere mogelijkheden:\n";
+                    foreach (var alt in eerdere.Take(3))
+                        inhoud += $"- {alt.VeldNaam} om {alt.AanvangsTijd} (eindigt {alt.EindTijd})\n";
+                }
+                if (latere.Count > 0)
+                {
+                    inhoud += "\nLatere mogelijkheden:\n";
+                    foreach (var alt in latere.Take(3))
+                        inhoud += $"- {alt.VeldNaam} om {alt.AanvangsTijd} (eindigt {alt.EindTijd})\n";
+                }
+
+                inhoud += "\nLaat weten welke optie de voorkeur heeft.";
+            }
+        }
+
+        return WrapMetReviewEnHandtekening(inhoud, classificatie, email);
+    }
+
+    // ── Bevestiging ──
+
+    public static (string onderwerp, string body) BouwBevestigingAntwoord(
+        InkomendEmail email, EmailClassificatie classificatie)
+    {
+        var aanhef = GetTijdsgebondenAanhef();
+        var voornaam = ExtractVoornaam(email.AfzenderNaam);
+
+        var inhoud = $"{aanhef} {voornaam},\n\n"
+                   + "Bedankt voor je bevestiging. Het verzoek is geregistreerd "
+                   + "en wordt door de coördinator verwerkt.";
+
+        return WrapMetReviewEnHandtekening(inhoud, classificatie, email);
+    }
+
+    // ── Buiten scope ──
+
+    public static (string onderwerp, string body) BouwBuitenScopeAntwoord(InkomendEmail email)
+    {
+        var aanhef = GetTijdsgebondenAanhef();
+        var voornaam = ExtractVoornaam(email.AfzenderNaam);
+
+        var classificatie = new EmailClassificatie { Type = VerzoekType.BuitenScope };
+        var inhoud = $"{aanhef} {voornaam},\n\n"
+                   + "Bedankt voor je bericht. Dit verzoek vereist handmatige afhandeling "
+                   + "en is ter beoordeling bij de coördinator neergelegd.";
+
+        return WrapMetReviewEnHandtekening(inhoud, classificatie, email);
+    }
+
+    // ── Fout ──
+
+    public static (string onderwerp, string body) BouwFoutAntwoord(
+        InkomendEmail email, EmailClassificatie classificatie)
+    {
+        var aanhef = GetTijdsgebondenAanhef();
+        var voornaam = ExtractVoornaam(email.AfzenderNaam);
+
+        var inhoud = $"{aanhef} {voornaam},\n\n"
+                   + "Er is een fout opgetreden bij het verwerken van je verzoek. "
+                   + "De coördinator is op de hoogte gesteld en neemt zo snel mogelijk contact op.";
+
+        return WrapMetReviewEnHandtekening(inhoud, classificatie, email);
+    }
+
+    // ── Helpers ──
+
     public static string GetTijdsgebondenAanhef()
     {
         var uur = DateTime.Now.Hour;
         if (uur < 12) return "Goedemorgen";
         if (uur < 18) return "Goedemiddag";
         return "Goedenavond";
+    }
+
+    /// <summary>
+    /// Filter veld 5 (grasveld) uit alternatieven als er 3+ kunstgrasvelden beschikbaar zijn.
+    /// </summary>
+    private static List<SlotToewijzing> FilterAlternatieven(List<SlotToewijzing> alternatieven)
+    {
+        var kunstgrasSlots = alternatieven.Where(a => a.VeldNummer >= 1 && a.VeldNummer <= 4).ToList();
+        var kunstgrasVelden = kunstgrasSlots.Select(a => a.VeldNummer).Distinct().Count();
+
+        // Als 3+ kunstgrasvelden beschikbaar zijn, laat grasvelden weg
+        if (kunstgrasVelden >= 3)
+            return kunstgrasSlots;
+
+        return alternatieven;
+    }
+
+    /// <summary>
+    /// Filter veld 5 uit beschikbare vensters als er 3+ kunstgrasvelden beschikbaar zijn.
+    /// </summary>
+    private static List<BeschikbaarVenster> FilterKunstgrasVensters(List<BeschikbaarVenster> vensters)
+    {
+        var kunstgrasVensters = vensters.Where(v => v.VeldNummer >= 1 && v.VeldNummer <= 4).ToList();
+        if (kunstgrasVensters.Count >= 3)
+            return kunstgrasVensters;
+        return vensters;
+    }
+
+    private static string FormatDatum(string? datumString)
+    {
+        if (DateOnly.TryParse(datumString, out var datum))
+            return $"{datum.ToString("dddd d MMMM yyyy", NL)}";
+        return datumString ?? "de opgegeven datum";
+    }
+
+    private static (string onderwerp, string body) WrapMetReviewEnHandtekening(
+        string inhoud, EmailClassificatie classificatie, InkomendEmail email)
+    {
+        var onderwerp = $"Re: {email.Onderwerp}";
+        var body = "";
+
+        var reviewMode = Environment.GetEnvironmentVariable("EmailReviewMode");
+        if (string.Equals(reviewMode, "true", StringComparison.OrdinalIgnoreCase))
+        {
+            body += $"=== REVIEW MODE ===\n"
+                  + $"Originele afzender: {email.Afzender}\n"
+                  + $"Onderwerp: {email.Onderwerp}\n"
+                  + $"Classificatie: {classificatie.Type}\n"
+                  + $"==================\n\n";
+        }
+
+        body += inhoud;
+        body += "\n\n" + GetHandtekening();
+
+        return (onderwerp, body);
     }
 
     private static string GetHandtekening()
@@ -88,7 +281,6 @@ public static class EmailResponseGenerator
     {
         if (string.IsNullOrWhiteSpace(volledigeNaam))
             return "";
-
         var delen = volledigeNaam.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
         return delen[0];
     }


### PR DESCRIPTION
## Summary
Drie soak test issues opgelost in één PR:

- **#54 Hybride antwoord-generatie** — AI alleen voor classificatie, antwoorden via templates. `GenereerAntwoordAsync()` verwijderd. Kosten gehalveerd.
- **#53 Veld 5 filtering** — grasvelden niet tonen als 3+ kunstgrasvelden beschikbaar
- **#55 Herplan-check** — huidige slot en <30min alternatieven eruit, eerder/later splitsen, "volle dag" melding

Bonus: dag-datum validatie corrigeert "zaterdag" + woensdag-datum fouten van AI.

Closes #53
Closes #54
Closes #55

## Bestanden
- `EmailResponseGenerator.cs` — volledig herschreven met scenario-templates
- `EmailAiService.cs` — `GenereerAntwoordAsync()` + `AntwoordSystemPrompt` verwijderd
- `EmailProcessorFunction.cs` — template-router + dag-datum validatie + AI antwoord verwijderd

## Verificatie
- [x] `dotnet build` — 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)