### PR TITLE
Fix: team-swap bug bij externe clubnamen in herplanverzoeken

### DIFF
--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -346,8 +346,12 @@ public class EmailProcessorFunction
             && !t.StartsWith("MO", StringComparison.OrdinalIgnoreCase))
             t = "J" + t.ToUpper();
 
-        // Voeg "VRC " prefix toe als het ontbreekt
-        if (!t.StartsWith("VRC ", StringComparison.OrdinalIgnoreCase))
+        // Alleen "VRC " prefix toevoegen als de naam er uitziet als een eigen team
+        // (start met JO/MO/VR/JM/V + cijfer, of is puur cijfer/letters zonder clubnaam).
+        // Namen met spatie erin zijn meestal externe clubs (bijv. "VOP JO14-1", "Hooglanderveen JO16-4").
+        bool looksLikeVrcTeam = System.Text.RegularExpressions.Regex.IsMatch(t, @"^(JO|MO|VR|JM|ZO)\d", System.Text.RegularExpressions.RegexOptions.IgnoreCase)
+                              || !t.Contains(' ');
+        if (looksLikeVrcTeam && !t.StartsWith("VRC ", StringComparison.OrdinalIgnoreCase))
             t = "VRC " + t;
 
         return t;
@@ -385,14 +389,18 @@ public class EmailProcessorFunction
 
         // Heuristiek: naam zonder clubnaam erin is waarschijnlijk het VRC-team
         // Externe teams bevatten vaak de clubnaam (bijv. "Woudenberg MO15-1", "Hooglanderveen JO16-4")
-        bool teamIsVrc = !team.Contains(' ') || team.StartsWith("VRC", StringComparison.OrdinalIgnoreCase);
-        bool tegenstanderIsVrc = !tegenstander.Contains(' ') || tegenstander.StartsWith("VRC", StringComparison.OrdinalIgnoreCase);
-
-        if (!teamIsVrc && tegenstanderIsVrc)
+        // Swap alleen als BEIDE velden gevuld zijn en de rollen duidelijk omgedraaid zijn
+        if (!string.IsNullOrWhiteSpace(team) && !string.IsNullOrWhiteSpace(tegenstander))
         {
-            // Tegenstander veld bevat het VRC-team → swap
-            classificatie.TeamNaam = tegenstander;
-            classificatie.Tegenstander = team;
+            bool teamIsVrc = !team.Contains(' ') || team.StartsWith("VRC", StringComparison.OrdinalIgnoreCase);
+            bool tegenstanderIsVrc = !tegenstander.Contains(' ') || tegenstander.StartsWith("VRC", StringComparison.OrdinalIgnoreCase);
+
+            if (!teamIsVrc && tegenstanderIsVrc)
+            {
+                // Tegenstander veld bevat het VRC-team → swap
+                classificatie.TeamNaam = tegenstander;
+                classificatie.Tegenstander = team;
+            }
         }
 
         classificatie.TeamNaam = NormaliseerTeamNaam(classificatie.TeamNaam);


### PR DESCRIPTION
## Samenvatting

Bugfix gevonden tijdens email-validatie van 10 inkomende verzoeken: herplanverzoek van Rudy Harmse ('VOP JO14-1 wil wedstrijd verzetten van 9 mei naar 23 mei') kreeg antwoord 'Geen wedstrijd gevonden voor  op zaterdag 9 mei 2026' (let op de dubbele spatie waar de teamnaam hoort).

## Oorzaak

Twee samenwerkende bugs in [EmailProcessorFunction.cs](FunctionApp/Email/EmailProcessorFunction.cs):

1. **Team-swap bug**: de swap TeamNaam ↔ Tegenstander voerde ook uit als Tegenstander leeg was (empty string bevat geen spatie → werd als 'VRC-team' gezien). Resultaat: TeamNaam werd `""`.

2. **NormaliseerTeamNaam bug**: plaatste 'VRC ' prefix voor ELKE naam, dus `'VOP JO14-1'` → `'VRC VOP JO14-1'` (onzinnig). Combinatie met bug #1 leverde de LIKE-zoekopdracht `'%VRC %'` op.

## Fix

- Swap alleen uitvoeren als **beide** velden gevuld zijn
- 'VRC ' prefix alleen toevoegen als de naam er uitziet als VRC-team: `JOxx/MOxx/VRx/JMx/ZOx` format, of geen spatie bevat

## Verificatie

Na de fix vindt `FindMatchAsync('VOP JO14-1', '2026-05-09')` correct de wedstrijd via LIKE-match op de `[wedstrijd]` kolom:

```json
{
  "gevonden": true,
  "wedstrijd": {
    "wedstrijd": "VRC JO14-3JM - VOP JO14-1",
    "datum": "2026-05-09",
    "aanvangsTijd": "17:40",
    "veldNaam": "veld 2"
  }
}
```

## Openstaande verbeterpunten (niet in deze PR)

Tijdens de validatie nog gevonden, niet binnen scope:

- **ID 32/33**: 'Fw: JO17-1 vs VRC JO17-4' — afzender accepteert een eerder voorstel (5 mei om 18:30). AI classificeerde als HerplanVerzoek, moet Bevestiging zijn met verwijzing naar bestaande thread-context.
- **ID 40**: 'MO17-1 en JO15-1 op 9 mei' — verzoek raakt twee wedstrijden tegelijk. AI behandelt er maar één. Vergt uitbreiding van classificatie met een `wedstrijden[]` lijst.

## Test plan

- [x] ZoekWedstrijd API werkt met externe clubnaam als `teamNaam`
- [x] CheckAvailability API werkt voor GewensteDatum
- [ ] End-to-end email-flow test (vereist email opnieuw ongelezen markeren)
- [ ] Regressie: VRC-team emails blijven correct werken (prefix toevoeging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)