### PR TITLE
Email: vervroeg-richting + BuitenScope zonder reply + slash-team-naam fix

### DIFF
--- a/FunctionApp/Email/EmailGraphService.cs
+++ b/FunctionApp/Email/EmailGraphService.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Graph;
 using Microsoft.Graph.Models;
 using Microsoft.Graph.Users.Item.SendMail;
+using Microsoft.Graph.Users.Item.Outlook.MasterCategories;
 
 namespace SportlinkFunction.Email;
 
@@ -83,6 +84,77 @@ public partial class EmailGraphService
         }
 
         return resultaat;
+    }
+
+    /// <summary>
+    /// Zet een Outlook-categorie op een bericht. Bestaande categorieën worden vervangen.
+    /// </summary>
+    public async Task SetCategoriesAsync(string messageId, params string[] categories)
+    {
+        try
+        {
+            await _graphClient.Users[_mailbox]
+                .Messages[messageId]
+                .PatchAsync(new Message { Categories = categories.ToList() });
+
+            _logger.LogInformation("Email {MessageId} gemarkeerd met categorie(en) {Categorieen}",
+                messageId, string.Join(", ", categories));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij zetten van categorie op email {MessageId}", messageId);
+        }
+    }
+
+    private bool _masterCategoryEnsured;
+
+    /// <summary>
+    /// Zorgt dat een Outlook master-categorie bestaat met de gegeven kleur-preset.
+    /// Idempotent: doet niets als de categorie al bestaat. Kleur-preset bijv. "preset0" (rood).
+    /// </summary>
+    public async Task EnsureMasterCategoryAsync(string name, string colorPreset)
+    {
+        if (_masterCategoryEnsured) return;
+
+        try
+        {
+            var existing = await _graphClient.Users[_mailbox]
+                .Outlook
+                .MasterCategories
+                .GetAsync();
+
+            if (existing?.Value?.Any(c => string.Equals(c.DisplayName, name, StringComparison.OrdinalIgnoreCase)) == true)
+            {
+                _masterCategoryEnsured = true;
+                return;
+            }
+
+            await _graphClient.Users[_mailbox]
+                .Outlook
+                .MasterCategories
+                .PostAsync(new OutlookCategory
+                {
+                    DisplayName = name,
+                    Color = ParseCategoryColor(colorPreset)
+                });
+
+            _logger.LogInformation("Master-categorie '{Naam}' aangemaakt met kleur {Kleur}", name, colorPreset);
+            _masterCategoryEnsured = true;
+        }
+        catch (Exception ex)
+        {
+            // Master-categorie aanmaken kan falen door rechten; categorie op bericht zelf werkt
+            // dan nog steeds, alleen zonder gedefinieerde kleur in Outlook.
+            _logger.LogWarning(ex, "Kon master-categorie '{Naam}' niet borgen — categorie op bericht werkt wel", name);
+            _masterCategoryEnsured = true;
+        }
+    }
+
+    private static CategoryColor ParseCategoryColor(string preset)
+    {
+        return Enum.TryParse<CategoryColor>(preset, ignoreCase: true, out var color)
+            ? color
+            : CategoryColor.Preset0;
     }
 
     /// <summary>

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -141,26 +141,28 @@ public class EmailProcessorFunction
         log.LogInformation("Email {Id} geclassificeerd als {Type}, datum={Datum}",
             verwerkingId, classificatie.Type, classificatie.Datum);
 
-        string onderwerp;
-        string antwoordBody;
-
         if (classificatie.Type == VerzoekType.BuitenScope)
         {
-            // 4e. Buiten scope — standaard antwoord
-            (onderwerp, antwoordBody) = EmailResponseGenerator.BouwBuitenScopeAntwoord(email);
+            // 4e. Buiten scope — geen AI-antwoord versturen; coördinator handelt zelf af.
+            // Markeer met categorie 'Geen AI antwoord' (rood) en zet op gelezen.
             await UpdateStatusAsync(verwerkingId, EmailStatus.BuitenScope, null);
+            await graphService.EnsureMasterCategoryAsync("Geen AI antwoord", "preset0");
+            await graphService.SetCategoriesAsync(email.MessageId, "Geen AI antwoord");
+            await graphService.MarkAsReadAsync(email.MessageId);
+            log.LogInformation(
+                "Email {Id} buiten scope — gecategoriseerd 'Geen AI antwoord', geen reply verstuurd",
+                verwerkingId);
+            return;
         }
-        else
-        {
-            // 4f. Roep PlannerService aan op basis van classificatie
-            var plannerResponseJson = await VerwerkMetPlannerAsync(classificatie, log);
-            await UpdatePlannerResponseAsync(verwerkingId, plannerResponseJson);
-            await UpdateStatusAsync(verwerkingId, EmailStatus.Verwerkt, null);
 
-            // 4h. Bouw antwoord via templates (geen AI nodig)
-            (onderwerp, antwoordBody) = BouwTemplateAntwoord(
-                classificatie, plannerResponseJson, email);
-        }
+        // 4f. Roep PlannerService aan op basis van classificatie
+        var plannerResponseJson = await VerwerkMetPlannerAsync(classificatie, email, log);
+        await UpdatePlannerResponseAsync(verwerkingId, plannerResponseJson);
+        await UpdateStatusAsync(verwerkingId, EmailStatus.Verwerkt, null);
+
+        // 4h. Bouw antwoord via templates (geen AI nodig)
+        var (onderwerp, antwoordBody) = BouwTemplateAntwoord(
+            classificatie, plannerResponseJson, email);
 
         // 4j. Bepaal ontvanger (review mode vs productie)
         var reviewMode = Environment.GetEnvironmentVariable("EmailReviewMode");
@@ -337,6 +339,11 @@ public class EmailProcessorFunction
         if (string.IsNullOrWhiteSpace(teamNaam)) return teamNaam;
         var t = teamNaam.Trim();
 
+        // Slash tussen cijfers → streep (bijv. "JO17/3" → "JO17-3", "17/1" → "17-1").
+        // Trainers schrijven vaak "jo17/3" terwijl Sportlink "JO17-3" gebruikt; zonder
+        // deze normalisatie faalt de LIKE-zoekopdracht in FindMatchAsync.
+        t = System.Text.RegularExpressions.Regex.Replace(t, @"(\d)\s*/\s*(\d)", "$1-$2");
+
         // "Onder 13-1" → "JO13-1"
         if (t.StartsWith("Onder ", StringComparison.OrdinalIgnoreCase))
             t = "JO" + t[6..].Trim();
@@ -375,10 +382,27 @@ public class EmailProcessorFunction
     }
 
     /// <summary>
+    /// Bepaalt of een herplanverzoek vervroeging of verlating betreft, op basis van trefwoorden
+    /// in onderwerp en body. Geeft null terug als beide of geen van beide voorkomen — dan vallen
+    /// we terug op het standaardgedrag (alle slots, gesorteerd op nabijheid).
+    /// </summary>
+    private static string? DetecteerRichting(string onderwerp, string body)
+    {
+        var tekst = ((onderwerp ?? "") + " " + (body ?? "")).ToLowerInvariant();
+        bool vervroegen = tekst.Contains("vervroeg") || tekst.Contains("eerder")
+                       || tekst.Contains("naar voren");
+        bool verlaten = tekst.Contains("verlaat") || tekst.Contains("verlat")
+                     || tekst.Contains(" later") || tekst.Contains("naar achter");
+        if (vervroegen && !verlaten) return "vervroegen";
+        if (verlaten && !vervroegen) return "verlaten";
+        return null;
+    }
+
+    /// <summary>
     /// Vertaalt de AI-classificatie naar de juiste PlannerService-aanroep.
     /// </summary>
     private static async Task<string> VerwerkMetPlannerAsync(
-        EmailClassificatie classificatie, ILogger log)
+        EmailClassificatie classificatie, InkomendEmail email, ILogger log)
     {
         // Normaliseer leeftijdscategorie en teamnaam
         classificatie.LeeftijdsCategorie = NormaliseerLeeftijdsCategorie(classificatie.LeeftijdsCategorie);
@@ -460,11 +484,15 @@ public class EmailProcessorFunction
                                 return JsonConvert.SerializeObject(new { wedstrijd, gewensteDatum = classificatie.GewensteDatum, beschikbaarheid });
                             }
 
-                            // Geen gewenste datum → check alternatieven op huidige dag
+                            // Geen gewenste datum → check alternatieven op huidige dag.
+                            // Richtingdetectie op trefwoorden in onderwerp+body: trainers schrijven
+                            // expliciet "vervroegen"/"eerder" of "later"/"verlaten"; bij beide of
+                            // geen van beide blijft Richting null (default-gedrag, voor- én nakijken).
                             var herplanRequest = new HerplanCheckRequest
                             {
                                 Wedstrijdcode = wedstrijd.Wedstrijdcode,
-                                VoorkeurTijd = classificatie.AanvangsTijd
+                                VoorkeurTijd = classificatie.AanvangsTijd,
+                                Richting = DetecteerRichting(email.Onderwerp, email.Body)
                             };
                             var herplanResponse = await PlannerService.CheckRescheduleAvailabilityAsync(herplanRequest, log);
                             return JsonConvert.SerializeObject(new { wedstrijd, herplanOpties = herplanResponse });

--- a/FunctionApp/Planner/PlannerModels.cs
+++ b/FunctionApp/Planner/PlannerModels.cs
@@ -227,6 +227,8 @@ namespace SportlinkFunction.Planner
         public long Wedstrijdcode { get; set; }
         public string? VoorkeurTijd { get; set; }
         public string? Dagdeel { get; set; }
+        // "vervroegen" of "verlaten"; bepaalt of alternatieven vóór of na de huidige aanvangstijd vallen.
+        public string? Richting { get; set; }
     }
 
     public class HerplanCheckResponse

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -272,6 +272,63 @@ namespace SportlinkFunction.Planner
             return null;
         }
 
+        /// <summary>
+        /// Latest-fit scan per veld: zoekt het slot met de uiterst mogelijke aanvangstijd
+        /// die nog vóór <paramref name="upperBound"/> eindigt (eindtijd ≤ upperBound). Anders dan
+        /// FindAllSlots, dat van vroeg naar laat scant en het vroegste slot per gap pakt, scant
+        /// dit van laat naar vroeg in 5-minuten stappen — geschikt voor 'vervroegen' waarbij we
+        /// zo dicht mogelijk tegen de oorspronkelijke aanvangstijd of een volgende bezetting
+        /// willen plannen. Retourneert maximaal één slot per veld.
+        /// </summary>
+        private static List<CandidateSlot> FindLatestFitPerField(
+            List<VeldBeschikbaarheidInfo> availableFields,
+            List<BestaandeWedstrijd> occupations,
+            Dictionary<string, List<TeamRegel>> allTeamRules,
+            List<TeamRegel> requestingTeamRules,
+            decimal veldFractie, int duurMinuten,
+            TimeOnly upperBound, TimeOnly windowStart)
+        {
+            var result = new List<CandidateSlot>();
+
+            foreach (var field in availableFields)
+            {
+                var fieldOccupations = occupations.Where(o => o.VeldNummer == field.VeldNummer).ToList();
+                var effWindowStart = windowStart < field.BeschikbaarVanaf ? field.BeschikbaarVanaf : windowStart;
+                var effUpper = upperBound > field.BeschikbaarTot ? field.BeschikbaarTot : upperBound;
+
+                // Eerste bezetting op dit veld die start binnen [effWindowStart, effUpper).
+                // Onze eindtijd moet daarvóór vallen (buffer wordt door CanFitMatch afgedwongen).
+                var nextOcc = fieldOccupations
+                    .Where(o => o.AanvangsTijd >= effWindowStart && o.AanvangsTijd < effUpper)
+                    .OrderBy(o => o.AanvangsTijd)
+                    .FirstOrDefault();
+                var hardEnd = nextOcc != null && nextOcc.AanvangsTijd < effUpper ? nextOcc.AanvangsTijd : effUpper;
+
+                // Scan achterwaarts: laatste startwaarde waarbij start + duur ≤ hardEnd, dan terug
+                // in stappen van 5 min totdat een geldige fit gevonden wordt.
+                var latestStartCandidate = hardEnd.AddMinutes(-duurMinuten);
+                if (latestStartCandidate < effWindowStart) continue;
+
+                for (var time = latestStartCandidate; time >= effWindowStart; time = time.AddMinutes(-5))
+                {
+                    var endTime = time.AddMinutes(duurMinuten);
+                    if (CanFitMatch(time, endTime, veldFractie, field.VeldNummer,
+                                    fieldOccupations, allTeamRules, requestingTeamRules))
+                    {
+                        result.Add(new CandidateSlot
+                        {
+                            VeldNummer = field.VeldNummer,
+                            AanvangsTijd = time,
+                            EindTijd = endTime
+                        });
+                        break;
+                    }
+                }
+            }
+
+            return result;
+        }
+
         private static List<CandidateSlot> FindAllSlots(
             List<VeldBeschikbaarheidInfo> availableFields,
             List<BestaandeWedstrijd> occupations,
@@ -1248,14 +1305,48 @@ namespace SportlinkFunction.Planner
             candidates = candidates.Where(c =>
                 !(c.VeldNummer == matchVeldNummer && c.AanvangsTijd == matchStart)).ToList();
 
-            if (preferredTime.HasValue)
+            // Richtingfilter: bij 'vervroegen' alleen slots VÓÓR matchStart, bij 'verlaten' erna.
+            // Per veld het slot kiezen dat het dichtst tegen matchStart aanligt — dat is de
+            // 'natuurlijke' verschuiving die aansluit op de bestaande planning (latest-fit voor
+            // vervroegen, earliest-fit voor verlaten). Hierdoor blijft veld 5 zichtbaar als het
+            // de enige optie is, in plaats van weggesorteerd onder veld 1-4.
+            bool vervroegen = string.Equals(request.Richting, "vervroegen", StringComparison.OrdinalIgnoreCase);
+            bool verlaten = string.Equals(request.Richting, "verlaten", StringComparison.OrdinalIgnoreCase);
+            int neemAantal = response.Beschikbaar ? 2 : 3;
+
+            if (vervroegen)
+            {
+                // Latest-fit per veld: zo dicht mogelijk tegen matchStart óf tegen de eerstvolgende
+                // bezetting in de ochtend — dat is wat een trainer bij 'vervroegen' bedoelt
+                // (minste verstoring voor andere afspraken op die dag).
+                candidates = FindLatestFitPerField(
+                    availableFields, occupations, allTeamRules, teamRules,
+                    veldFractie, duurMinuten,
+                    upperBound: matchStart, windowStart: dagdeelVan);
+                candidates = candidates
+                    .Where(c => !(c.VeldNummer == matchVeldNummer && c.AanvangsTijd == matchStart))
+                    .OrderByDescending(c => c.AanvangsTijd)
+                    .ToList();
+                neemAantal = candidates.Count; // toon alle relevante velden
+            }
+            else if (verlaten)
+            {
+                candidates = candidates
+                    .Where(c => c.AanvangsTijd > matchStart)
+                    .GroupBy(c => c.VeldNummer)
+                    .Select(g => g.OrderBy(c => c.AanvangsTijd).First())
+                    .OrderBy(c => c.AanvangsTijd)
+                    .ToList();
+                neemAantal = candidates.Count;
+            }
+            else if (preferredTime.HasValue)
             {
                 candidates = candidates
                     .OrderBy(c => Math.Abs(c.AanvangsTijd.ToTimeSpan().TotalMinutes - preferredTime.Value.ToTimeSpan().TotalMinutes))
                     .ToList();
             }
 
-            foreach (var c in candidates.Take(response.Beschikbaar ? 2 : 3))
+            foreach (var c in candidates.Take(neemAantal))
             {
                 var slot = ToSlotToewijzing(date, c, duurMinuten, velden);
                 if (!response.Alternatieven.Any(a => a.AanvangsTijd == slot.AanvangsTijd && a.VeldNummer == slot.VeldNummer))


### PR DESCRIPTION
## Samenvatting

Drie samenhangende verbeteringen in de e-mailprocessor en herplanner, gevonden tijdens review van een vervroeg-verzoek dat met de huidige logica geen bruikbaar antwoord opleverde.

### 1. Slash naar streep in teamnaam-normalisatie
Trainers schrijven \"JO17/3\" of \"jo17/3\"; Sportlink slaat \"JO17-3\" op. \`NormaliseerTeamNaam\` zette een /-variant niet om, waardoor de \`LIKE '%VRC JO17/3%'\` in \`FindMatchAsync\` 0 rijen vond en de processor \"geen wedstrijd gevonden\" antwoordde.

**Fix**: regex die elk \`\d/\d\` patroon (eventueel met spaties rondom de slash) vervangt door \`\d-\d\` aan het begin van \`NormaliseerTeamNaam\`.

### 2. Vervroeg-richting in herplan
Bij een herplan-verzoek werden alle vrije slots op de dag teruggegeven, gesorteerd op nabijheid bij voorkeurstijd of veldnummer. Een verzoek tot vervroegen kreeg daardoor ook latere slots als alternatief, en \"verre\" velden (veld 5) werden weggesorteerd onder veld 1-4.

**Fix**:
- \`HerplanCheckRequest.Richting\` toegevoegd (\`\"vervroegen\"\` / \`\"verlaten\"\`).
- \`EmailProcessorFunction.DetecteerRichting\` leidt dit af uit trefwoorden in onderwerp+body (vervroeg/eerder/naar voren resp. verlaat/later/naar achter).
- Nieuwe helper \`FindLatestFitPerField\`: scant per veld **achterwaarts** vanaf de eerstvolgende bezetting (of \`matchStart\`) en levert het slot met de hoogst mogelijke aanvangstijd dat nog vóór die bezetting eindigt — dat is de natuurlijke vervroeging die het minst andere afspraken raakt.
- Bij \`Richting=verlaten\` spiegelbeeld: vroegste fit per veld na \`matchStart\`.

Voorbeeld: voor wedstrijd 20319485 (VRC JO17-3 - Valleivogels JO17-1, 30 mei 14:00, veld 3) gaf de oude logica 13:45 op veld 3 + twee latere opties; de nieuwe logica geeft als enige optie 09:10-10:30 op veld 5 (eindigt 15 min vóór VRC MO15-3 om 10:45).

### 3. BuitenScope: geen AI-reply, wel categorie
Verzoeken die buiten scope vallen kregen een AI-template-antwoord (\"Bedankt voor je bericht. Dit verzoek vereist handmatige afhandeling…\") dat naar de afzender gestuurd werd. De coördinator wil deze zelf afhandelen en alleen een visuele markering in de inbox.

**Fix**:
- BuitenScope-tak in \`VerwerkEmailAsync\` stopt na status-update; geen \`SendReplyAsync\`.
- Nieuwe \`EmailGraphService.SetCategoriesAsync\` zet de categorie \"Geen AI antwoord\" op het bericht.
- Nieuwe \`EmailGraphService.EnsureMasterCategoryAsync\` borgt de master-categorie met preset rood (idempotent, faalt graceful als de app-registratie geen \`MailboxSettings.ReadWrite\` heeft — categorie op bericht werkt dan nog steeds, alleen zonder kleur tot één keer handmatig in Outlook ingesteld).
- Bericht wordt vervolgens als gelezen gemarkeerd.

## Test plan

- [x] Lokaal: directe POST naar /api/planner/herplan-check met Wedstrijdcode=20319485 + Richting=vervroegen → 09:10 op veld 5
- [x] Lokaal: e-mail van trainer met \"jo17/3\" + \"vervroegen\" → wedstrijd correct gevonden, veld 5 09:10 als enig alternatief
- [x] Lokaal: BuitenScope e-mail → geen reply, categorie 'Geen AI antwoord' gezet, op gelezen
- [ ] Productie: master-categorie met rode kleur instellen in Outlook (eenmalig) zodra deployment live is
- [ ] Productie: Graph app-registratie eventueel uitbreiden met MailboxSettings.ReadWrite voor automatische kleurborging