### PR TITLE
Fix: database retry timeout verlengen voor serverless auto-resume

### DIFF
--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -528,8 +528,12 @@ public class EmailProcessorFunction
                  + "De email-processor is automatisch GEPAUZEERD. Er worden geen herhaalde meldingen verstuurd.\n"
                  + "De processor hervat automatisch zodra de database weer bereikbaar is.\n\n"
                  + "De emails blijven ongelezen in de inbox en worden automatisch verwerkt zodra de database weer beschikbaar is.\n\n"
-                 + "Mogelijke oorzaak: Azure SQL free tier maandlimiet bereikt.\n"
-                 + "Actie: Azure Portal → SQL database → Compute and Storage → \"Continue using database with additional charges\"";
+                 + "Meest waarschijnlijke oorzaak: Azure SQL Serverless database was gepauzeerd (auto-pause) en kon niet op tijd opstarten.\n"
+                 + "De processor probeert 10× met 15 seconden tussentijd (max. 150 seconden). Als de database langer nodig heeft om te starten, verschijnt deze melding.\n\n"
+                 + "Controleer in Azure Portal:\n"
+                 + "  • myfreesqldbserver-vrc → myFreeDB → Overzicht → Status (moet 'Online' zijn)\n"
+                 + "  • Compute + storage → Free monthly vCore amount (maandlimiet bereikt?)\n\n"
+                 + "Als de maandlimiet bereikt is: Azure Portal → SQL database → Compute and Storage → \"Continue using database with additional charges\"";
 
         try
         {

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -83,8 +83,8 @@ namespace SportlinkFunction
         {
             bool isDatabaseAvailable = false;
             int retryCount = 0;
-            int maxRetries = 5;
-            int delayBetweenRetries = 5000; // 5 seconds
+            int maxRetries = 10;
+            int delayBetweenRetries = 15000; // 15 seconds — Azure SQL Serverless auto-resume takes 30-90s
 
             while (!isDatabaseAvailable && retryCount < maxRetries)
             {
@@ -101,7 +101,8 @@ namespace SportlinkFunction
                 {
                     retryCount++;
                     log.LogWarning($"Database connection failed. Retry {retryCount}/{maxRetries}. Error: {ex.Message}");
-                    await Task.Delay(delayBetweenRetries);
+                    if (retryCount < maxRetries)
+                        await Task.Delay(delayBetweenRetries);
                 }
             }
 


### PR DESCRIPTION
## Beschrijving

Fixes #81

Op 12-05-2026 stuurde de email processor een noodmail omdat de database na 5 pogingen niet bereikbaar was. De werkelijke oorzaak was dat de Azure SQL Serverless database gepauzeerd was en 30-90 seconden nodig heeft om te auto-resumemen. De oude retry-logica gaf slechts 25 seconden (5x5s), te weinig voor het opstarten.

## Wijzigingen

### `Utilities.cs` — `WaitForDatabaseAsync`
- Retries: 5 → **10**
- Vertraging: 5s → **15s** per poging
- Totale maximale wachttijd: 25s → **150s**

### `EmailProcessorFunction.cs` — `StuurDatabaseNoodmailAsync`
- Vervangt de misleidende hardcoded tekst "Mogelijke oorzaak: Azure SQL free tier maandlimiet bereikt" door een accurate beschrijving
- Noemt auto-resume als primaire oorzaak
- Geeft concrete controlestappen in Azure Portal (status + maandlimiet)

## Test plan

- [x] Build geslaagd zonder warnings of errors
- [ ] Bij volgende database auto-resume: processor verbindt succesvol zonder noodmail
- [ ] Als database écht niet bereikbaar is: noodmail bevat nu juiste diagnose en controlestappen

🤖 Generated with [Claude Code](https://claude.com/claude-code)