### PR TITLE
feat: Teambegeleiding contacten importeren vanuit Sportlink CSV naar SQL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 
 env:
-  AZURE_FUNCTIONAPP_NAME: func-vrc-sportlink
   AZURE_FUNCTIONAPP_PACKAGE_PATH: FunctionApp
   DOTNET_VERSION: '9.0.x'
 
@@ -36,7 +35,7 @@ jobs:
       - name: Function App deployen naar Azure
         uses: Azure/functions-action@v1
         with:
-          app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+          app-name: ${{ vars.AZURE_FUNCTIONAPP_NAME }}
           package: ./output
 
   test:
@@ -45,7 +44,7 @@ jobs:
     steps:
       - name: "Smoke test: function app bereikbaar (health → 200)"
         run: |
-          URL="https://${{ env.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/health?code=${{ secrets.AZURE_FUNCTION_KEY }}"
+          URL="https://${{ vars.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/health?code=${{ secrets.AZURE_FUNCTION_KEY }}"
           MAX=6
           WAIT=20
           for i in $(seq 1 $MAX); do
@@ -60,7 +59,7 @@ jobs:
       - name: "Smoke test: admin endpoint beveiligd (function key → 401)"
         run: |
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 \
-            "https://${{ env.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/sync-matches?code=${{ secrets.AZURE_FUNCTION_KEY }}")
+            "https://${{ vars.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/sync-matches?code=${{ secrets.AZURE_FUNCTION_KEY }}")
           echo "sync-matches: $STATUS"
           if [ "$STATUS" != "401" ]; then echo "FOUT: verwacht 401, kreeg $STATUS"; exit 1; fi
 
@@ -68,7 +67,7 @@ jobs:
         continue-on-error: true
         run: |
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 60 -X POST \
-            "https://${{ env.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/planner/check-availability?code=${{ secrets.AZURE_FUNCTION_KEY }}" \
+            "https://${{ vars.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/planner/check-availability?code=${{ secrets.AZURE_FUNCTION_KEY }}" \
             -H "Content-Type: application/json" \
             -d '{"datum":"2026-12-01","leeftijdsCategorie":"JO13"}')
           echo "check-availability: $STATUS"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -2,13 +2,18 @@ name: Security Scan
 
 on:
   push:
-    branches: [main]
+    branches: ['**']
   pull_request:
     branches: [main]
 
 permissions:
   contents: read
   security-events: write
+
+# ══════════════════════════════════════════════════════════════════════════════
+# BELANGRIJK: Als één of meer jobs hieronder falen, blokkeert de security-gate
+# job automatisch de merge. Zie SECURITY.md voor het protocol bij een fout.
+# ══════════════════════════════════════════════════════════════════════════════
 
 jobs:
   # ── 1. Gitleaks: secrets en tokens in git-geschiedenis ─────────────────────
@@ -19,7 +24,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - name: Checkout
+      - name: Checkout (volledige geschiedenis)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -28,6 +33,14 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_SUMMARY: true
+
+      - name: Resultaat samenvatting
+        if: failure()
+        run: |
+          echo "::error::🚨 GITLEAKS: SECRET OF TOKEN GEVONDEN IN CODE"
+          echo "::error::Verwijder het secret direct en roteer het — ook als het al gepusht is."
+          echo "::error::Zie SECURITY.md § 'Wat te doen bij een gefaalde check'."
 
   # ── 2. Databestanden in repository ─────────────────────────────────────────
   pii-files:
@@ -37,21 +50,21 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Check for data files with potential PII
+      - name: Controleer op databestanden met persoonsgegevens
         run: |
-          echo "Checking for CSV/Excel files in repository..."
+          echo "Zoeken naar CSV/Excel bestanden in repository..."
           DATA_FILES=$(find . -not -path "./.git/*" \
             \( -name "*.csv" -o -name "*.xlsx" -o -name "*.xls" -o -name "*.xlsm" \) \
             | sort)
           if [ -n "$DATA_FILES" ]; then
-            echo "BLOCKED: Data files found in repository:"
+            echo "::error::🚨 PERSOONSGEGEVENS: DATABESTAND(EN) GEVONDEN IN REPOSITORY"
             echo "$DATA_FILES"
-            echo ""
-            echo "CSV/Excel files may contain personal data (AVG/GDPR)."
-            echo "Remove them from git tracking and add to .gitignore."
+            echo "::error::CSV/Excel bestanden mogen NOOIT in git staan (AVG/GDPR)."
+            echo "::error::Verwijder ze direct en voeg toe aan .gitignore."
+            echo "::error::Zie SECURITY.md § 'Wat te doen bij een gefaalde check'."
             exit 1
           fi
-          echo "OK: No CSV/Excel files tracked in repository."
+          echo "✅ Geen databestanden met persoonsgegevens gevonden."
 
   # ── 3. Nederlandse telefoonnummers en e-mails in code ──────────────────────
   pii-patterns:
@@ -61,10 +74,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Scan for Dutch PII patterns
+      - name: Scan op Nederlandse PII-patronen
         run: |
           FOUND=0
-          # Scan only tracked text files, exclude binary and known-safe files
           FILES=$(git ls-files | grep -vE "\.(png|jpg|jpeg|gif|ico|woff|ttf|eot|svg|pdf|zip|dll|exe|pdb|nupkg)$" || true)
 
           check_pattern() {
@@ -73,25 +85,24 @@ jobs:
             local matches
             matches=$(echo "$FILES" | xargs grep -lP "$pattern" 2>/dev/null || true)
             if [ -n "$matches" ]; then
-              echo "WARN: $desc found in:"
-              echo "$matches" | while read f; do echo "  $f"; done
+              echo "::error::🚨 PII GEVONDEN — $desc"
+              echo "$matches" | while read f; do echo "::error::  Bestand: $f"; done
               FOUND=1
             fi
           }
 
-          check_pattern "Dutch mobile numbers"     "06[-\s]?[0-9]{8}"
-          check_pattern "Dutch mobile (+31)"       "\+316[0-9]{8}"
-          check_pattern "Hotmail addresses"        "[a-z0-9._%+\-]+@hotmail\.(com|nl)"
-          check_pattern "Consumer email addresses" "[a-z0-9._%+\-]+@(gmail\.com|outlook\.(com|nl)|ziggo\.nl|kpnmail\.nl|casema\.nl|home\.nl)"
-          check_pattern "Sportlink member codes"   "BCZ[A-Z][A-Z0-9]{5}"
+          check_pattern "Nederlandse mobiele nummers"  "06[-\s]?[0-9]{8}"
+          check_pattern "Nederlandse mobiele nummers (+31)" "\+316[0-9]{8}"
+          check_pattern "Hotmail-adressen"             "[a-z0-9._%+\-]+@hotmail\.(com|nl)"
+          check_pattern "Persoonlijke e-mailadressen"  "[a-z0-9._%+\-]+@(gmail\.com|outlook\.(com|nl)|ziggo\.nl|kpnmail\.nl|casema\.nl|home\.nl)"
+          check_pattern "Sportlink ledencodesn"        "BCZ[A-Z][A-Z0-9]{5}"
 
           if [ "$FOUND" -eq 1 ]; then
-            echo ""
-            echo "Personal data (AVG/GDPR) detected in tracked files."
-            echo "Review the files above and remove personal data."
+            echo "::error::Verwijder de persoonsgegevens uit de bestanden hierboven."
+            echo "::error::Zie SECURITY.md § 'Wat te doen bij een gefaalde check'."
             exit 1
           fi
-          echo "OK: No PII patterns detected in tracked files."
+          echo "✅ Geen PII-patronen gevonden in getrackte bestanden."
 
   # ── 4. Dependency vulnerability scan (Trivy) ───────────────────────────────
   dependency-scan:
@@ -111,9 +122,39 @@ jobs:
           severity: HIGH,CRITICAL
           exit-code: 0
 
-      - name: Upload Trivy results to GitHub Security
+      - name: Upload Trivy results naar GitHub Security
         uses: github/codeql-action/upload-sarif@v3
         if: always()
         with:
           sarif_file: trivy-results.sarif
         continue-on-error: true
+
+  # ── 5. Security gate — blokkeert merge als bovenstaande checks falen ────────
+  security-gate:
+    name: "Security Gate — blokkeert merge bij fout"
+    runs-on: ubuntu-latest
+    needs: [gitleaks, pii-files, pii-patterns]
+    if: always()
+    steps:
+      - name: Controleer alle verplichte security checks
+        run: |
+          FAILED=""
+          [ "${{ needs.gitleaks.result }}"    != "success" ] && FAILED="${FAILED}\n  ❌ Secret Detection (gitleaks): ${{ needs.gitleaks.result }}"
+          [ "${{ needs.pii-files.result }}"   != "success" ] && FAILED="${FAILED}\n  ❌ PII File Detection:           ${{ needs.pii-files.result }}"
+          [ "${{ needs.pii-patterns.result }}" != "success" ] && FAILED="${FAILED}\n  ❌ PII Pattern Scan:             ${{ needs.pii-patterns.result }}"
+
+          if [ -n "$FAILED" ]; then
+            echo "::error::════════════════════════════════════════════════════"
+            echo "::error::🚨  SECURITY CHECKS GEFAALD — MERGE GEBLOKKEERD  🚨"
+            echo "::error::════════════════════════════════════════════════════"
+            printf "::error::Gefaalde checks:${FAILED}\n"
+            echo "::error::"
+            echo "::error::Geen enkele wijziging gaat naar main totdat ALLE"
+            echo "::error::security checks slagen. Zie SECURITY.md."
+            echo "::error::════════════════════════════════════════════════════"
+            exit 1
+          fi
+
+          echo "════════════════════════════════════════════════════"
+          echo "✅  Alle security checks geslaagd — merge toegestaan"
+          echo "════════════════════════════════════════════════════"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -15,6 +15,9 @@ jobs:
   gitleaks:
     name: Secret Detection (gitleaks)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,13 @@ debug-output.log
 sp_create_current.txt
 sp_merge_current.txt
 
-# ── Claude Code local settings ────────────────────────────────────────────────
-**/.claude/settings.local.json
+# ── Claude Code local settings en memory ─────────────────────────────────────
+# settings.local.json bevat machine-specifieke permissies.
+# memory/ bevat conversatiecontext die persoonlijke info kan bevatten.
+.claude/
+
+# ── Build artifacts ───────────────────────────────────────────────────────────
+*.lscache
 
 # ── Gegenereerde bestanden ────────────────────────────────────────────────────
 **/voorbeeld-*.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,13 +101,12 @@ De `exports/` map bevat **scripts** voor data-exports. De databestanden zelf (CS
 - `exports/*.csv` en `exports/*.xlsx` bevatten persoonsgegevens (namen, e-mails, telefoonnummers, geboortedatums van clubleden)
 - **NOOIT een CSV of Excel-bestand committen of pushen** — `.gitignore` blokkeert dit, maar controleer altijd
 - De databestanden staan alleen lokaal en zijn alleen beschikbaar voor de applicatie zelf
-- Alleen `.ps1` scripts en `README.md` mogen in git
+- Alleen `.ps1` scripts, `README.md` en `HANDLEIDING-teambegeleiding-export.md` mogen in git
 
 **Scripts in exports/:**
-- `sync-teambegeleiding.ps1` — verwerkt de lokale CSV naar de applicatie
-- `test-sportlink-api-login.ps1` — test Sportlink API-verbinding
+- `import-teambegeleiding-to-sql.ps1` — importeert CSV naar `avg.Teambegeleiding` in SQL Server (TRUNCATE + bulk insert)
 
 **Workflow:**
-1. Download CSV via club.sportlink.com (zie memory voor exacte stappen)
-2. Sla op als `exports/teambegeleiding.csv` — lokaal only, nooit committen
-3. De applicatie leest de CSV direct van het lokale bestandssysteem
+1. Download CSV via club.sportlink.com (zie `exports/HANDLEIDING-teambegeleiding-export.md` voor exacte stappen)
+2. Sla op in de lokale `exports/` map — nooit committen
+3. Voer `.\exports\import-teambegeleiding-to-sql.ps1` uit om de data in SQL te laden

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,20 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Absolute veiligheidsregels — nooit omzeilen
+
+Deze regels gelden altijd, zonder uitzondering:
+
+1. **Na elke push of commit: CI-status controleren.** Nooit aan de gebruiker melden dat iets klaar of succesvol is zonder eerst te verifiëren dat alle GitHub Actions checks geslaagd zijn (`gh pr checks <nr>` of `gh run list`).
+
+2. **Bij een gefaalde of onduidelijke check: direct stoppen en melden.** Niet stilzwijgend doorgaan, niet zelf "oplossen" zonder de gebruiker te informeren. Elke falende security check is een alarmsignaal.
+
+3. **Persoonsgegevens, wachtwoorden en tokens nooit in bestanden schrijven.** Ook niet tijdelijk, ook niet in commentaar, ook niet in documentatie. Bij twijfel: het gaat niet in git.
+
+4. **De Security Gate job is leidend.** Zolang `Security Gate — blokkeert merge bij fout` rood is, mag er niets gemerged worden — ook al zijn andere checks groen.
+
+Zie [SECURITY.md](SECURITY.md) voor het volledige protocol.
+
 ## Build & Run
 
 ```bash

--- a/Database/Schemas/avg.sql
+++ b/Database/Schemas/avg.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA avg

--- a/Database/SportlinkSqlDb.sqlproj
+++ b/Database/SportlinkSqlDb.sqlproj
@@ -75,6 +75,8 @@
     <Folder Include="planner" />
     <Folder Include="planner\Tables" />
     <Folder Include="planner\Views" />
+    <Folder Include="avg" />
+    <Folder Include="avg\Tables" />
   </ItemGroup>
   <ItemGroup>
     <Build Include="Schemas\stg.sql" />
@@ -109,6 +111,9 @@
     <Build Include="planner\Views\AlleWedstrijdenOpVeld.sql" />
     <Build Include="planner\Tables\HerplanVerzoeken.sql" />
     <Build Include="planner\Tables\EmailVerwerking.sql" />
+    <Build Include="Schemas\avg.sql" />
+    <Build Include="avg\Tables\Teambegeleiding.sql" />
+    <Build Include="avg\Tables\ImportLog.sql" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Script1.sql" />

--- a/Database/avg/Tables/ImportLog.sql
+++ b/Database/avg/Tables/ImportLog.sql
@@ -1,0 +1,9 @@
+CREATE TABLE [avg].[ImportLog] (
+    [Id]               INT            IDENTITY (1, 1) NOT NULL,
+    [ImportDatum]      DATETIME       CONSTRAINT [DF_avg_ImportLog_ImportDatum] DEFAULT (GETDATE()) NOT NULL,
+    [AantalRijen]      INT            NOT NULL,
+    [CsvBestand]       NVARCHAR (500) NULL,
+    [ImporterendeDoor] NVARCHAR (200) NULL,
+    [Duur_ms]          INT            NULL,
+    CONSTRAINT [PK_avg_ImportLog] PRIMARY KEY CLUSTERED ([Id] ASC)
+);

--- a/Database/avg/Tables/Teambegeleiding.sql
+++ b/Database/avg/Tables/Teambegeleiding.sql
@@ -1,0 +1,15 @@
+-- Bevat alleen de functioneel essentiële velden uit de Sportlink teambegeleiding export.
+-- Naam is een samengesteld veld: Roepnaam [Tussenvoegsel] Achternaam.
+-- Telefoonnummer = Mobiel nummer als gevuld, anders Telefoonnummer.
+-- 🚨 AVG/GDPR: beperk SELECT-rechten tot bevoegde gebruikers en rollen.
+CREATE TABLE [avg].[Teambegeleiding] (
+    [Id]                     INT            IDENTITY (1, 1) NOT NULL,
+    [Team]                   NVARCHAR (100) NULL,
+    [LeeftijdscategorieTeam] NVARCHAR (50)  NULL,
+    [Teamrol]                NVARCHAR (100) NULL,
+    [Naam]                   NVARCHAR (300) NULL,
+    [Emailadres]             NVARCHAR (200) NULL,
+    [Telefoonnummer]         NVARCHAR (50)  NULL,
+    [mta_imported]           DATETIME       CONSTRAINT [DF_avg_Teambegeleiding_mta_imported] DEFAULT (GETDATE()) NOT NULL,
+    CONSTRAINT [PK_avg_Teambegeleiding] PRIMARY KEY CLUSTERED ([Id] ASC)
+);

--- a/FunctionApp/CLAUDE.md
+++ b/FunctionApp/CLAUDE.md
@@ -220,8 +220,8 @@ Fetched live from `https://data.sportlink.com/programma?clientId=YOUR_CLIENT_ID`
 | `wedstrijdcode` | int | Unique match ID | `19816434` |
 | `wedstrijdnummer` | int | Match number | `19780` |
 | `teamnaam` | string | Own team name | `VRC 8` |
-| `thuisteamclubrelatiecode` | string | Home club code | `BBBZ26B` |
-| `uitteamclubrelatiecode` | string | Away club code | `BBBZ77R` |
+| `thuisteamclubrelatiecode` | string | Home club code | `BBBZXXXX` |
+| `uitteamclubrelatiecode` | string | Away club code | `BBBZYYY` |
 | `thuisteamid` | int | Home team ID | `99007` |
 | `thuisteam` | string | Home team name | `VRC 8` |
 | `thuisteamlogo` | string | Home team logo URL | `https://binaries.sportlink.com/...` |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,111 @@
+# Security protocol
+
+## Regel: bij twijfel gaat er niets naar git
+
+**Een gefaalde of onduidelijke security check betekent: STOP.**  
+Geen commit, geen push, geen merge — totdat de oorzaak volledig is onderzocht en opgelost.
+
+Dit is geen aanbeveling. Dit is een harde eis.
+
+---
+
+## Automatische security checks
+
+Bij elke push en bij elke pull request naar `main` worden de volgende checks uitgevoerd:
+
+| Check | Wat wordt gecontroleerd | Blokkeert merge? |
+|---|---|---|
+| **Secret Detection (gitleaks)** | Wachtwoorden, tokens, API-sleutels, connectiestrings in code en git-geschiedenis | ✅ Ja |
+| **PII File Detection** | CSV- en Excel-bestanden die persoonsgegevens kunnen bevatten | ✅ Ja |
+| **PII Pattern Scan** | Nederlandse telefoonnummers, persoonlijke e-mailadressen, ledencodesn in code | ✅ Ja |
+| **Dependency Vulnerability Scan** | Bekende kwetsbaarheden in gebruikte packages (HIGH/CRITICAL) | Waarschuwing |
+| **Security Gate** | Samenvatting: faalt als één van bovenstaande verplichte checks faalt | ✅ Ja |
+
+De **Security Gate** is de poortwachter. Zolang die rood is, is merge geblokkeerd — ook als de andere checks groen zijn.
+
+---
+
+## Wat te doen bij een gefaalde check
+
+### 1. Secret Detection gefaald (gitleaks)
+
+Een wachtwoord, token of sleutel is gevonden in de code of git-geschiedenis.
+
+**Direct te doen — geen uitstel:**
+1. **Roteer het secret onmiddellijk** — ga er vanuit dat het al gezien is
+   - GitHub PAT: github.com → Settings → Developer settings → Personal access tokens
+   - Azure credentials: Azure Portal → App registrations of Key Vault
+   - Sportlink wachtwoord: club.sportlink.com → Account instellingen
+2. Verwijder het secret uit de code
+3. Als het al in git-geschiedenis staat: neem contact op met de repo-eigenaar — de git-geschiedenis moet herschreven worden of de repo moet als gecompromitteerd worden beschouwd
+4. Maak een nieuw secret aan en sla het op in 1Password of Azure Key Vault
+
+**Nooit** een secret in plain text in code, comments, of documentatie plaatsen.
+
+### 2. PII File Detection gefaald
+
+Een CSV- of Excel-bestand staat in de repository.
+
+1. Verwijder het bestand uit git tracking: `git rm --cached bestandsnaam.csv`
+2. Voeg het toe aan `.gitignore`
+3. Controleer of het bestand al gepusht is — als ja, neem contact op met de repo-eigenaar
+4. Verwijder het lokale bestand of sla het op buiten de repository
+
+### 3. PII Pattern Scan gefaald
+
+Persoonsgegevens (telefoonnummer, e-mailadres, ledencode) zijn gevonden in getrackte bestanden.
+
+1. Open het genoemde bestand en zoek de gevonden waarde
+2. Verwijder of vervang het door een placeholder (bijv. `<TELEFOONNUMMER>`)
+3. Controleer of het al gepusht is — als ja, zie stap 3 hierboven
+
+### 4. Check gefaald maar reden onduidelijk
+
+Als een check faalt en de oorzaak niet direct duidelijk is:
+- **Ga niet verder** — niet committen, niet pushen
+- Bekijk de volledige logs via GitHub Actions
+- Vraag om hulp
+
+---
+
+## GitHub branch protection instellen (eenmalig)
+
+Om te garanderen dat de Security Gate altijd actief is, stel je branch protection in op `main`:
+
+1. Ga naar de repository op GitHub
+2. Settings → Branches → Add rule
+3. Branch name pattern: `main`
+4. Vink aan:
+   - ✅ **Require status checks to pass before merging**
+   - ✅ Zoek op en selecteer: `Security Gate — blokkeert merge bij fout`
+   - ✅ **Require branches to be up to date before merging**
+   - ✅ **Do not allow bypassing the above settings**
+5. Sla op
+
+Hierna is merge naar `main` technisch onmogelijk zolang de Security Gate rood is — ook voor repo-eigenaren.
+
+---
+
+## Wat nooit in git mag
+
+| Type | Voorbeelden |
+|---|---|
+| Wachtwoorden | Sportlink wachtwoord, database wachtwoorden |
+| Tokens en sleutels | GitHub PAT, Azure credentials, API keys |
+| Persoonsgegevens | Namen, e-mailadressen, telefoonnummers, geboortedatums |
+| Databestanden | `*.csv`, `*.xlsx` met ledendata |
+| Verbindingsstrings met credentials | `Server=...;Password=...` |
+| Lokale paden met gebruikersnaam | `C:\Users\<naam>\...` |
+
+Bij twijfel: het gaat niet in git.
+
+---
+
+## Voor Claude Code
+
+Bij elke commit of push geldt:
+
+1. **Altijd** de CI-status controleren na een push — nooit rapporteren dat iets klaar is zonder dit te doen
+2. Als een check faalt of de status onduidelijk is: **direct melden aan de gebruiker**, nooit stilzwijgend doorgaan
+3. Persoonsgegevens, wachtwoorden en tokens worden **nooit** in bestanden geschreven, ook niet tijdelijk
+4. Bij twijfel over of iets gevoelig is: behandel het als gevoelig

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,111 +1,176 @@
 # Security protocol
 
-## Regel: bij twijfel gaat er niets naar git
+## Kernregel: bij twijfel gaat er niets naar git
 
 **Een gefaalde of onduidelijke security check betekent: STOP.**  
 Geen commit, geen push, geen merge — totdat de oorzaak volledig is onderzocht en opgelost.
 
-Dit is geen aanbeveling. Dit is een harde eis.
+Dit is geen aanbeveling. Dit is een harde eis zonder uitzonderingen.
 
 ---
 
-## Automatische security checks
+## Achtergrond: wat er in dit project op het spel staat
 
-Bij elke push en bij elke pull request naar `main` worden de volgende checks uitgevoerd:
+Deze repository koppelt aan Sportlink Club en verwerkt persoonsgegevens van leden van voetbalverenigingen: namen, e-mailadressen, telefoonnummers en geboortedatums van trainers, leiders en overige stafleden. Dit zijn bijzondere gegevens onder de AVG/GDPR.
+
+Een datalek in deze repository kan betekenen:
+- Persoonsgegevens van tientallen tot honderden clubleden komen openbaar op internet
+- De vereniging is meldplichtig bij de Autoriteit Persoonsgegevens (binnen 72 uur)
+- Reputatieschade voor de vereniging en betrokken personen
+- Mogelijk boetes tot 4% van de jaaromzet (AVG artikel 83)
+
+Elke beveiligingsmaatregel in dit document is er om dit te voorkomen.
+
+---
+
+## Beveiligingslagen: meerdere controles, elk onafhankelijk
+
+De beveiliging werkt in lagen. Elke laag is een onafhankelijke blokkade. Als één laag faalt, vangen de andere op — maar alle lagen moeten werken.
+
+### Laag 1 — Lokale git hooks (op de ontwikkelmachine)
+
+Bij elke `git commit` en `git push` draaien automatisch:
+- **PII-scan**: zoekt naar telefoonnummers, e-mailadressen en ledencodesn in de staged bestanden
+- **Gitleaks** (indien geïnstalleerd): diepere scan op wachtwoorden en tokens
+
+Instellen (eenmalig per machine):
+```bash
+git config core.hooksPath .githooks
+cp .githooks/sensitive-patterns.template.txt .githooks/sensitive-patterns.txt
+```
+
+Gitleaks installeren (optioneel maar sterk aanbevolen):
+- Windows: `winget install gitleaks`
+- macOS: `brew install gitleaks`
+
+### Laag 2 — GitHub Actions (in de cloud, bij elke push)
+
+Bij elke push naar elke branch en bij elke pull request naar `main`:
 
 | Check | Wat wordt gecontroleerd | Blokkeert merge? |
 |---|---|---|
-| **Secret Detection (gitleaks)** | Wachtwoorden, tokens, API-sleutels, connectiestrings in code en git-geschiedenis | ✅ Ja |
-| **PII File Detection** | CSV- en Excel-bestanden die persoonsgegevens kunnen bevatten | ✅ Ja |
-| **PII Pattern Scan** | Nederlandse telefoonnummers, persoonlijke e-mailadressen, ledencodesn in code | ✅ Ja |
-| **Dependency Vulnerability Scan** | Bekende kwetsbaarheden in gebruikte packages (HIGH/CRITICAL) | Waarschuwing |
-| **Security Gate** | Samenvatting: faalt als één van bovenstaande verplichte checks faalt | ✅ Ja |
+| **Secret Detection (gitleaks)** | Wachtwoorden, tokens, API-sleutels in code én volledige git-geschiedenis | ✅ Ja |
+| **PII File Detection** | CSV- en Excel-bestanden met mogelijke persoonsgegevens | ✅ Ja |
+| **PII Pattern Scan** | Nederlandse telefoonnummers, persoonlijke e-mailadressen, ledencodesn | ✅ Ja |
+| **Dependency Vulnerability Scan** | Bekende kwetsbaarheden in packages (HIGH/CRITICAL) | Waarschuwing |
+| **Security Gate** | Faalt als één van de bovenstaande verplichte checks faalt | ✅ Ja |
 
-De **Security Gate** is de poortwachter. Zolang die rood is, is merge geblokkeerd — ook als de andere checks groen zijn.
+De **Security Gate** is de finale poortwachter. Zolang die rood is, is merge naar `main` geblokkeerd.
+
+### Laag 3 — .gitignore (passieve blokkade)
+
+Bepaalde bestandstypen worden nooit getrackt door git, ongeacht wat er gedaan wordt:
+- `exports/*.csv` en `exports/*.xlsx` — Sportlink ledenexports
+- `FunctionApp/local.settings.json` — lokale verbindingsstrings
+- `*.env` — environment-bestanden
+
+### Laag 4 — SQL-database (data at rest)
+
+Persoonsgegevens worden opgeslagen in de lokale SQL Server (`avg.Teambegeleiding`), niet in bestanden. De `avg`-schema is bedoeld voor AVG-beschermde data en de toegang moet beperkt zijn tot bevoegde gebruikers.
 
 ---
 
 ## Wat te doen bij een gefaalde check
 
-### 1. Secret Detection gefaald (gitleaks)
+### Secret Detection gefaald (gitleaks)
 
-Een wachtwoord, token of sleutel is gevonden in de code of git-geschiedenis.
+Een wachtwoord, token of sleutel is gevonden in code of git-geschiedenis.
 
-**Direct te doen — geen uitstel:**
-1. **Roteer het secret onmiddellijk** — ga er vanuit dat het al gezien is
-   - GitHub PAT: github.com → Settings → Developer settings → Personal access tokens
-   - Azure credentials: Azure Portal → App registrations of Key Vault
-   - Sportlink wachtwoord: club.sportlink.com → Account instellingen
-2. Verwijder het secret uit de code
-3. Als het al in git-geschiedenis staat: neem contact op met de repo-eigenaar — de git-geschiedenis moet herschreven worden of de repo moet als gecompromitteerd worden beschouwd
-4. Maak een nieuw secret aan en sla het op in 1Password of Azure Key Vault
+**Direct handelen — geen uitstel:**
 
-**Nooit** een secret in plain text in code, comments, of documentatie plaatsen.
+1. **Roteer het secret onmiddellijk** — ga er van uit dat het al gezien is, ook als de push net gebeurd is
 
-### 2. PII File Detection gefaald
+   | Secret type | Waar roteren |
+   |---|---|
+   | GitHub PAT | github.com → Settings → Developer settings → Personal access tokens |
+   | Azure credentials | Azure Portal → App registrations of Key Vault |
+   | Sportlink wachtwoord | club.sportlink.com → Accountinstellingen |
+   | Database wachtwoord | SQL Server Management Studio → Security → Logins |
+   | 1Password TOTP-seed | Verwijder en herregistreer 2FA in de betreffende applicatie |
+
+2. Verwijder het secret uit de code en vervang door een omgevingsvariabele of Key Vault-referentie
+
+3. Als het secret al in git-geschiedenis staat (al gepusht):
+   - De git-geschiedenis moet herschreven worden (`git filter-branch` of BFG Repo Cleaner)
+   - Of de repository moet als gecompromitteerd worden beschouwd en opnieuw worden opgezet
+   - Neem altijd contact op met de repo-eigenaar — dit is niet iets om zelf stil op te lossen
+
+4. Maak een nieuw secret aan en sla het op in **1Password** (persoonlijk account `my.1password.com`, item `Sportlink` of vergelijkbaar) of **Azure Key Vault**
+
+**Wat nooit mag:** een secret in plain text in code, commentaar, commit-bericht, of documentatie plaatsen — ook niet tijdelijk.
+
+### PII File Detection gefaald
 
 Een CSV- of Excel-bestand staat in de repository.
 
-1. Verwijder het bestand uit git tracking: `git rm --cached bestandsnaam.csv`
+1. Verwijder het bestand uit git-tracking (maar bewaar het lokaal):
+   ```bash
+   git rm --cached exports/bestandsnaam.csv
+   ```
 2. Voeg het toe aan `.gitignore`
-3. Controleer of het bestand al gepusht is — als ja, neem contact op met de repo-eigenaar
-4. Verwijder het lokale bestand of sla het op buiten de repository
+3. Als het bestand al gepusht is: de bestandsinhoud staat in de git-geschiedenis en is zichtbaar voor iedereen met toegang tot de repo. Zie stap 3 hierboven.
+4. Sla persoonsgegevens uitsluitend op in de beveiligde SQL-database (`avg.Teambegeleiding`)
 
-### 3. PII Pattern Scan gefaald
+### PII Pattern Scan gefaald
 
-Persoonsgegevens (telefoonnummer, e-mailadres, ledencode) zijn gevonden in getrackte bestanden.
+Persoonsgegevens zijn gevonden in getrackte bestanden (telefoonnummer, e-mailadres, ledencode).
 
-1. Open het genoemde bestand en zoek de gevonden waarde
-2. Verwijder of vervang het door een placeholder (bijv. `<TELEFOONNUMMER>`)
-3. Controleer of het al gepusht is — als ja, zie stap 3 hierboven
+1. Open het genoemde bestand en zoek de exacte waarde
+2. Vervang door een placeholder: `<TELEFOONNUMMER>`, `<EMAIL>`, `<LEDENCODE>`
+3. Als het al gepusht is: zie "als het secret al in git-geschiedenis staat" hierboven
+4. Controleer of vergelijkbare waarden ook in andere bestanden staan
 
-### 4. Check gefaald maar reden onduidelijk
+### Check gefaald maar reden onduidelijk
 
 Als een check faalt en de oorzaak niet direct duidelijk is:
-- **Ga niet verder** — niet committen, niet pushen
-- Bekijk de volledige logs via GitHub Actions
-- Vraag om hulp
-
----
-
-## GitHub branch protection instellen (eenmalig)
-
-Om te garanderen dat de Security Gate altijd actief is, stel je branch protection in op `main`:
-
-1. Ga naar de repository op GitHub
-2. Settings → Branches → Add rule
-3. Branch name pattern: `main`
-4. Vink aan:
-   - ✅ **Require status checks to pass before merging**
-   - ✅ Zoek op en selecteer: `Security Gate — blokkeert merge bij fout`
-   - ✅ **Require branches to be up to date before merging**
-   - ✅ **Do not allow bypassing the above settings**
-5. Sla op
-
-Hierna is merge naar `main` technisch onmogelijk zolang de Security Gate rood is — ook voor repo-eigenaren.
+- **Ga niet verder** — niet committen, niet pushen, geen merge
+- Bekijk de volledige logs via GitHub Actions (niet alleen de samenvatting)
+- Vraag om hulp — onduidelijkheid = stop
 
 ---
 
 ## Wat nooit in git mag
 
-| Type | Voorbeelden |
-|---|---|
-| Wachtwoorden | Sportlink wachtwoord, database wachtwoorden |
-| Tokens en sleutels | GitHub PAT, Azure credentials, API keys |
-| Persoonsgegevens | Namen, e-mailadressen, telefoonnummers, geboortedatums |
-| Databestanden | `*.csv`, `*.xlsx` met ledendata |
-| Verbindingsstrings met credentials | `Server=...;Password=...` |
-| Lokale paden met gebruikersnaam | `C:\Users\<naam>\...` |
+| Categorie | Voorbeelden | Alternatief |
+|---|---|---|
+| Wachtwoorden | Sportlink, database, Azure | 1Password of Azure Key Vault |
+| Tokens en sleutels | GitHub PAT, Azure credentials, API keys | GitHub Secrets of Key Vault |
+| Persoonsgegevens | Namen, e-mails, telefoonnummers, geboortedatums | SQL-database (`avg` schema) |
+| Databestanden | `*.csv`, `*.xlsx` met ledendata | Lokaal of in SQL-database |
+| Verbindingsstrings met credentials | `Server=...;Password=...` | `local.settings.json` (in .gitignore) |
+| Lokale paden met gebruikersnaam | `C:\Users\<naam>\...` | Relatieve paden of omgevingsvariabelen |
+| TOTP-seeds | `otpauth://totp/...?secret=...` | Alleen in authenticator-app of 1Password |
 
 Bij twijfel: het gaat niet in git.
 
 ---
 
-## Voor Claude Code
+## GitHub branch protection instellen (eenmalig, verplicht)
 
-Bij elke commit of push geldt:
+Om te garanderen dat de Security Gate altijd actief is en niet omzeild kan worden:
 
-1. **Altijd** de CI-status controleren na een push — nooit rapporteren dat iets klaar is zonder dit te doen
-2. Als een check faalt of de status onduidelijk is: **direct melden aan de gebruiker**, nooit stilzwijgend doorgaan
-3. Persoonsgegevens, wachtwoorden en tokens worden **nooit** in bestanden geschreven, ook niet tijdelijk
-4. Bij twijfel over of iets gevoelig is: behandel het als gevoelig
+1. Ga naar de repository op GitHub
+2. **Settings → Branches → Add branch protection rule**
+3. Branch name pattern: `main`
+4. Vink aan:
+   - ✅ **Require a pull request before merging**
+   - ✅ **Require status checks to pass before merging**
+   - ✅ Zoek op en voeg toe: **`Security Gate — blokkeert merge bij fout`**
+   - ✅ **Require branches to be up to date before merging**
+   - ✅ **Do not allow bypassing the above settings**
+5. Sla op
+
+Hierna is directe push naar `main` en merge met een rode Security Gate technisch onmogelijk — ook voor repo-eigenaren.
+
+---
+
+## Gedeelde verantwoordelijkheid
+
+Iedereen die aan deze repository werkt — mens of AI-assistent — is verantwoordelijk voor het naleven van dit protocol.
+
+**Voor Claude Code geldt specifiek:**
+1. Na elke `git push`: CI-status controleren via `gh pr checks <nr>` of `gh run list` vóór wordt gemeld dat iets klaar is
+2. Als een check faalt of de status onduidelijk is: direct stoppen en de gebruiker informeren — nooit stilzwijgend doorgaan
+3. Persoonsgegevens, wachtwoorden en tokens worden nooit in bestanden geschreven, ook niet tijdelijk of in commentaar
+4. Bij elke twijfel of iets gevoelig is: behandel het als gevoelig en vraag eerst
+5. Nooit een merge of push bevestigen zonder geverifieerde groene Security Gate

--- a/exports/HANDLEIDING-teambegeleiding-export.md
+++ b/exports/HANDLEIDING-teambegeleiding-export.md
@@ -1,0 +1,114 @@
+# Handleiding: Teambegeleiding export uit Sportlink Club
+
+Deze handleiding legt stap voor stap uit hoe je de lijst met teambegeleiders (trainers, leiders, coaches) exporteert uit Sportlink Club. Je hebt hier geen technische kennis voor nodig.
+
+---
+
+## Wat heb je nodig?
+
+- Toegang tot [club.sportlink.com](https://club.sportlink.com) met een beheerdersaccount
+- Je gebruikersnaam en wachtwoord voor Sportlink
+
+---
+
+## Stap 1 — Inloggen op Sportlink Club
+
+1. Ga naar [https://club.sportlink.com/member/search](https://club.sportlink.com/member/search)
+2. Je wordt doorgestuurd naar de loginpagina
+3. Vul je **e-mailadres** en **wachtwoord** in
+4. Klik op **Inloggen**
+5. Als er een verificatiecode gevraagd wordt, vul deze dan in (je ontvangt die via de authenticator-app)
+
+> Als je al ingelogd bent, ga je direct naar stap 2.
+
+---
+
+## Stap 2 — Filter instellen: alleen teambegeleiding
+
+Je ziet nu de ledenzoekopdracht. We filteren zodat alleen begeleiders zichtbaar zijn en geen spelers.
+
+1. Klik op de knop **Teams** in de filterbalk bovenaan de pagina
+
+2. Klik in het uitklapmenu op **Rol binnen team**
+
+3. Je ziet een lijst met rollen en aangevinkte checkboxes. Verwijder het vinkje bij de volgende vier rollen door er één voor één op te klikken:
+
+   - **Teamspeler / Aanvaller**
+   - **Teamspeler / Keeper**
+   - **Teamspeler / Middenvelder**
+   - **Teamspeler / Verdediger**
+
+   > Controleer dat deze vier rollen **niet** aangevinkt zijn. Alle andere rollen zoals trainer, leider en coach mogen aangevinkt blijven.
+
+4. Klik op de knop **Zoek**
+
+5. Wacht even — dit duurt soms 5 tot 10 seconden. Je ziet daarna het resultaat verschijnen. Verwacht **ongeveer 420 personen gevonden**.
+
+---
+
+## Stap 3 — De lijst exporteren
+
+1. Kijk in de grijze balk direct boven de lijst met resultaten. Aan de rechterkant van die balk staan een paar kleine icoontjes.
+
+2. Klik op het **exporteer-icoontje** — dit ziet eruit als een tabel met een pijl naar beneden.
+
+3. Er verschijnt een klein venster. Klik daarin op **Download**.
+
+4. Het bestand wordt nu gedownload naar je **Downloadmap**.
+
+---
+
+## Stap 4 — Bestand importeren naar de database
+
+Nu het bestand gedownload is, voer je het importscript uit zodat de gegevens in de database worden bijgewerkt.
+
+1. Open **PowerShell** (zoek via het Startmenu op "PowerShell")
+
+2. Navigeer naar de projectmap (vervang `<PROJECTMAP>` door het pad naar jouw lokale repo):
+
+   ```powershell
+   cd <PROJECTMAP>
+   ```
+
+3. Voer het importscript uit:
+
+   ```powershell
+   .\exports\import-teambegeleiding-to-sql.ps1
+   ```
+
+4. Het script importeert het bestand automatisch en laat aan het einde zien hoeveel personen verwerkt zijn.
+
+> **Let op:** het bestand bevat persoonsgegevens van clubleden. Na de import kun je de CSV verwijderen door het script uit te voeren met `-DeleteCsvAfterImport $true`.
+
+---
+
+## Controleren of het gelukt is
+
+Na het uitvoeren van het script zie je een samenvatting zoals:
+
+```
+Klaar!
+  Geïmporteerd : 420 personen
+  Tabel        : avg.Teambegeleiding
+  Duur         : 522 ms
+  Datum        : 2026-05-19 08:12
+```
+
+Klopt het aantal (verwacht ~420)? Dan is alles goed gegaan.
+
+---
+
+## Hoe vaak moet dit?
+
+Deze export wordt **wekelijks** uitgevoerd, bij voorkeur op **maandagochtend**. Zo is de lijst altijd actueel met nieuwe leden, gewijzigde rollen en vertrokken begeleiders.
+
+---
+
+## Problemen?
+
+| Probleem | Mogelijke oorzaak | Oplossing |
+|---|---|---|
+| Minder dan 400 personen gevonden | Filter niet goed ingesteld | Herhaal stap 2 en controleer of de 4 Teamspeler-rollen uitgevinkt zijn |
+| Geen exportknop zichtbaar | Onvoldoende rechten | Vraag een beheerder om de export uit te voeren |
+| Script geeft een fout | Geen bestand gevonden | Controleer of de download in stap 3 geslaagd is en het bestand in de Downloadmap staat |
+| Verificatiecode werkt niet | Code verlopen | Wacht tot de authenticator-app een nieuwe code toont en probeer opnieuw |

--- a/exports/README.md
+++ b/exports/README.md
@@ -23,8 +23,7 @@ BCC is hier niet alleen etiquette maar ook **AVG-conform vereist**. Artikel 5(1)
 ```sql
 SELECT Naam, Emailadres
 FROM   [avg].[Teambegeleiding]
-WHERE  Team    = @team
-  AND  Teamrol IN ('Lokale staf', 'Technische staf')
+WHERE  Team      = @team
   AND  Emailadres IS NOT NULL
 ```
 

--- a/exports/README.md
+++ b/exports/README.md
@@ -1,0 +1,206 @@
+# exports/ — Teambegeleiding import
+
+Deze map bevat scripts voor het importeren van de **teambegeleiding export** vanuit Sportlink Club naar de lokale SQL Server database. De geïmporteerde data wordt gebruikt door de planner om automatisch de juiste contactpersonen (leider, trainer) te bereiken bij wedstrijdwijzigingen.
+
+## Waarom SQL en niet een CSV in git?
+
+De export van Sportlink bevat persoonsgegevens (namen, e-mailadressen, telefoonnummers). Om te voldoen aan de AVG/GDPR:
+
+- `exports/*.csv` worden **nooit** naar git gepusht — dit staat geblokkeerd in `.gitignore`
+- De data wordt opgeslagen in de beveiligde lokale SQL Server (`avg.Teambegeleiding`)
+- De CSV is alleen tijdelijk aanwezig op de lokale machine van de beheerder
+
+---
+
+## Hoe de data wordt gebruikt: wedstrijd verplaatsverzoeken
+
+Wanneer een tegenstander vraagt om een wedstrijd te verplaatsen, stuurt de planner automatisch een antwoord-e-mail met de leider en trainer van het betreffende team in **BCC**.
+
+**Waarom BCC en niet CC of TO?**  
+BCC is hier niet alleen etiquette maar ook **AVG-conform vereist**. Artikel 5(1)(c) schrijft dataminimalisatie voor: persoonsgegevens van clubleden mogen niet onnodig gedeeld worden met derden (de tegenstander). Via BCC ontvangen leider en trainer een kopie van de e-mail en kunnen zelf contact opnemen — zonder dat de tegenstander hun gegevens ziet.
+
+**SQL die de planner gebruikt:**
+```sql
+SELECT Naam, Emailadres
+FROM   [avg].[Teambegeleiding]
+WHERE  Team    = @team
+  AND  Teamrol IN ('Lokale staf', 'Technische staf')
+  AND  Emailadres IS NOT NULL
+```
+
+---
+
+## Workflow
+
+### Stap 1 — CSV exporteren vanuit Sportlink Club
+
+#### Handmatig downloaden (universeel, werkt voor alle clubs)
+
+1. Ga naar [club.sportlink.com](https://club.sportlink.com) en log in met je verenigingsaccount
+2. Navigeer naar **Leden → Ledenlijst** (of ga direct naar `/member/search`)
+3. Klik op de filter **Teams**
+4. Klik op **Rol binnen team**
+5. Klik op **Alles geselecteerd** — nu staan alle rollen aangevinkt
+6. Vink de volgende vier opties **uit** (dit zijn de spelers):
+   - `Teamspeler / Aanvaller`
+   - `Teamspeler / Keeper`
+   - `Teamspeler / Middenvelder`
+   - `Teamspeler / Verdediger`
+7. Klik op **Zoeken** — dit duurt even (grotere clubs: 10–30 seconden)
+8. Het resultaat toont alleen begeleidingsleden (leiders, trainers, verzorgers, managers)
+9. Klik op het kleine **"Exporteer tabel"** icoon rechts boven de resultatenlijst (pijl-omlaag icoon)
+10. Klik in de popup op **Download**
+11. De CSV wordt opgeslagen in je standaard downloadmap
+
+> **Tip:** de bestandsnaam die Sportlink meegeeft bevat het aantal gevonden personen, bijv. `Teams 420 personen gevonden.csv`. Dit is normaal.
+
+---
+
+### Stap 2 — CSV importeren naar SQL
+
+```powershell
+# Vanuit de projectroot — detecteert automatisch BegeleidingTeams.csv of teambegeleiding.csv
+.\exports\import-teambegeleiding-to-sql.ps1
+
+# Met verwijdering van de CSV na succesvolle import (aanbevolen voor AVG)
+.\exports\import-teambegeleiding-to-sql.ps1 -DeleteCsvAfterImport $true
+
+# Met een CSV op een andere locatie
+.\exports\import-teambegeleiding-to-sql.ps1 -CsvPath "C:\pad\naar\BegeleidingTeams.csv"
+```
+
+Het script:
+1. Leest `SqlConnectionString` uit `FunctionApp/local.settings.json`
+2. Detecteert automatisch welke kolommen aanwezig zijn in de CSV (zie aliassen hieronder)
+3. Valideert dat de verplichte kolommen beschikbaar zijn — geeft duidelijke fout als iets ontbreekt
+4. Leegt `avg.Teambegeleiding` volledig (TRUNCATE) en importeert alle rijen opnieuw
+5. Schrijft een auditregel naar `avg.ImportLog` (datum, aantal rijen, Windows-gebruikersnaam, duur)
+
+**Controleren na import:**
+```sql
+SELECT COUNT(*)  FROM avg.Teambegeleiding
+SELECT TOP 1 *   FROM avg.ImportLog ORDER BY ImportDatum DESC
+```
+
+---
+
+## Verplichte CSV-kolommen
+
+Het script herkent kolomnamen **hoofdletterongevoelig** en accepteert meerdere varianten. De volgende kolommen zijn **verplicht** aanwezig in de CSV:
+
+| Veld in database        | Geaccepteerde kolomnamen in CSV                               |
+|-------------------------|---------------------------------------------------------------|
+| `Team`                  | `Team`, `Teamnaam`, `Team naam`                               |
+| `Teamrol`               | `Teamrol`, `Rol`, `Rol in team`, `Rol team`                   |
+| `Naam` *(samengesteld)* | `Roepnaam` **en** `Achternaam` (beide verplicht)              |
+| `Emailadres`            | `E-mailadres`, `Email`, `E-mail`, `Emailadres`, `Mailadres`   |
+
+> De `Naam`-kolom wordt samengesteld als: **Roepnaam + Tussenvoegsel + Achternaam**  
+> Voorbeeld: `Nico` + `van` + `Ginkel` → `Nico van Ginkel`
+
+### Optionele kolommen (worden meegenomen als aanwezig)
+
+| Veld in database         | Geaccepteerde kolomnamen in CSV                                |
+|--------------------------|----------------------------------------------------------------|
+| `LeeftijdscategorieTeam` | `Leeftijdscategorie team`, `Leeftijdscategorie`                |
+| Tussenvoegsel (voor Naam)| `Tussenvoegsel(s)`, `Tussenvoegsel`, `Infix`                   |
+| `Telefoonnummer`         | `Mobiel nummer` *(voorkeur)* of `Telefoonnummer`, `Telefoon`   |
+
+> **Telefoonnummer-logica:** als `Mobiel nummer` gevuld is, wordt dat gebruikt. Anders `Telefoonnummer`. Als geen van beide aanwezig is, wordt het veld `NULL`.
+
+### Wat doet het script bij ontbrekende verplichte kolommen?
+
+```
+  FOUT: de volgende vereiste kolommen zijn niet gevonden in de CSV:
+    - Emailadres  (verwacht één van: E-mailadres, Email, E-mail, Emailadres, Mailadres)
+
+  Aanwezige CSV-kolommen:
+    * Team
+    * Teamrol
+    * Naam
+    ...
+```
+
+---
+
+## Database tabellen
+
+### `avg.Teambegeleiding` — contactpersonen per team
+
+| Kolom                    | Type           | Omschrijving                                           |
+|--------------------------|----------------|--------------------------------------------------------|
+| `Id`                     | INT IDENTITY   | Primaire sleutel                                       |
+| `Team`                   | NVARCHAR(100)  | Teamnaam zoals in Sportlink (bijv. `JO15-1`)           |
+| `LeeftijdscategorieTeam` | NVARCHAR(50)   | Leeftijdsgroep (bijv. `Onder 15`, `Senioren`)          |
+| `Teamrol`                | NVARCHAR(100)  | `Technische staf`, `Lokale staf`, `Overige staf`, etc. |
+| `Naam`                   | NVARCHAR(300)  | Volledige naam: Roepnaam [Tussenvoegsel] Achternaam    |
+| `Emailadres`             | NVARCHAR(200)  | E-mailadres van de persoon                             |
+| `Telefoonnummer`         | NVARCHAR(50)   | Mobiel nummer (voorkeur) of vaste lijn                 |
+| `mta_imported`           | DATETIME       | Tijdstip van de laatste import                         |
+
+### `avg.ImportLog` — audittrail
+
+| Kolom              | Type           | Omschrijving                           |
+|--------------------|----------------|----------------------------------------|
+| `Id`               | INT IDENTITY   | Primaire sleutel                       |
+| `ImportDatum`      | DATETIME       | Tijdstip van import                    |
+| `AantalRijen`      | INT            | Aantal geïmporteerde personen          |
+| `CsvBestand`       | NVARCHAR(500)  | Volledig pad naar de gebruikte CSV     |
+| `ImporterendeDoor` | NVARCHAR(200)  | Windows-gebruikersnaam (`SYSTEM_USER`) |
+| `Duur_ms`          | INT            | Duur van de import in milliseconden    |
+
+---
+
+## Andere clubs: aanpassen voor jouw vereniging
+
+Deze repository is ontworpen om herbruikbaar te zijn voor meerdere clubs. Aanpassingen per club:
+
+**1. Verbindingsstring**  
+Pas `SqlConnectionString` aan in `FunctionApp/local.settings.json`:
+```json
+"SqlConnectionString": "Server=JOUW-SERVER;Database=SportlinkSqlDb;Integrated Security=True;TrustServerCertificate=True;"
+```
+
+**2. CSV-bestandsnaam**  
+Het script detecteert automatisch `BegeleidingTeams.csv` en `teambegeleiding.csv`. Andere namen geef je mee via `-CsvPath`.
+
+**3. Kolomnamen aanpassen**  
+Als jouw Sportlink-export andere kolomnamen heeft, voeg ze toe aan de `$columnAliases`-map bovenin `import-teambegeleiding-to-sql.ps1`:
+```powershell
+$columnAliases = [ordered]@{
+    "Team"       = @("Team", "Teamnaam", "Team naam", "Jouw kolomnaam")
+    "Emailadres" = @("E-mailadres", "Email", "Jouw variant")
+    # ...
+}
+```
+
+**4. Teamrol-waarden controleren**  
+De Sportlink-export gebruikt standaard `Lokale staf` en `Technische staf` voor begeleidingsleden. Controleer de waarden in jouw export:
+```sql
+SELECT DISTINCT Teamrol, COUNT(*) AS Aantal
+FROM avg.Teambegeleiding
+GROUP BY Teamrol
+ORDER BY Aantal DESC
+```
+
+
+---
+
+## Git-regels voor deze map
+
+Wijzigingen in `exports/` gaan **altijd rechtstreeks naar `main`** — nooit via een feature branch of pull request:
+
+- Dit zijn operationele updates, geen codewijzigingen
+- **Laat open PR's en development branches volledig met rust** bij het uitvoeren van een export-update
+- `exports/*.csv` en `exports/*.xlsx` zijn uitgesloten van git via `.gitignore` — commit deze nooit
+
+---
+
+## AVG/GDPR-regels
+
+- De CSV mag alleen **tijdelijk lokaal** staan op de machine van de beheerder
+- Gebruik `-DeleteCsvAfterImport $true` om de CSV direct na import te verwijderen
+- Beperk `SELECT`-rechten op `avg.Teambegeleiding` tot bevoegde SQL-gebruikers en rollen
+- Overweeg SQL Server **TDE** (Transparent Data Encryption) voor versleuteling van data at rest
+- E-mailadressen van leden worden uitsluitend via **BCC** gedeeld bij wedstrijdcommunicatie — nooit in TO of CC naar externe partijen
+- Raadpleeg bij twijfel het privacybeleid van de vereniging of de Functionaris Gegevensbescherming (FG)

--- a/exports/import-teambegeleiding-to-sql.ps1
+++ b/exports/import-teambegeleiding-to-sql.ps1
@@ -1,0 +1,252 @@
+# import-teambegeleiding-to-sql.ps1
+# Importeert de lokale teambegeleiding CSV naar avg.Teambegeleiding in SQL Server.
+# Strategie: TRUNCATE TABLE + volledige bulk-insert — altijd de laatste CSV als bron.
+#
+# Flexibel: het script detecteert automatisch de aanwezige CSV-kolommen via een alias-map.
+# Ontbrekende vereiste kolommen worden gemeld; extra kolommen worden genegeerd.
+#
+# Samengestelde velden:
+#   Naam           = Roepnaam [Tussenvoegsel] Achternaam
+#   Telefoonnummer = Mobiel nummer als gevuld, anders Telefoonnummer
+#
+# 🚨 AVG/GDPR: avg.Teambegeleiding bevat persoonsgegevens.
+#              Beperk SELECT-rechten tot bevoegde gebruikers en rollen.
+#
+# Gebruik:
+#   .\exports\import-teambegeleiding-to-sql.ps1
+#   .\exports\import-teambegeleiding-to-sql.ps1 -CsvPath "C:\pad\naar\bestand.csv"
+#   .\exports\import-teambegeleiding-to-sql.ps1 -DeleteCsvAfterImport $true
+
+param (
+    [string] $CsvPath              = "",
+    [bool]   $DeleteCsvAfterImport = $false
+)
+
+$ErrorActionPreference = "Stop"
+$stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+$repoRoot  = Split-Path -Parent $PSScriptRoot
+
+# Alias-map: canonieke veldnaam → mogelijke CSV-kolomnamen (case-insensitief)
+# Voeg hier varianten toe als andere clubs andere kolomnamen gebruiken.
+$columnAliases = [ordered]@{
+    # Vereiste velden
+    "Team"                   = @("Team", "Teamnaam", "Team naam")
+    "Teamrol"                = @("Teamrol", "Rol", "Rol in team", "Rol team")
+    "Roepnaam"               = @("Roepnaam", "Voornaam", "First name")
+    "Achternaam"             = @("Achternaam", "Familienaam", "Last name")
+    "Emailadres"             = @("E-mailadres", "Email", "E-mail", "Emailadres", "Mailadres")
+    # Optionele maar aanbevolen velden
+    "LeeftijdscategorieTeam" = @("Leeftijdscategorie team", "Leeftijdscategorie", "Age category")
+    "Tussenvoegsel"          = @("Tussenvoegsel(s)", "Tussenvoegsel", "Infix", "Tussenv.")
+    "MobielNummer"           = @("Mobiel nummer", "Mobiel", "Mobiele telefoon", "Mobile")
+    "TelefoonnummerKolom"    = @("Telefoonnummer", "Telefoon", "Vaste telefoon", "Phone")
+}
+
+# Velden die verplicht aanwezig moeten zijn in de CSV
+$vereist = @("Team", "Teamrol", "Roepnaam", "Achternaam", "Emailadres")
+
+Write-Host "`n=== Teambegeleiding CSV → SQL import ===" -ForegroundColor Cyan
+Write-Host (Get-Date -Format "yyyy-MM-dd HH:mm:ss") -ForegroundColor Gray
+
+# ── Stap 1: CSV-bestand bepalen ───────────────────────────────────────────────
+Write-Host "`n[1/5] CSV-bestand zoeken..." -ForegroundColor Yellow
+
+if (-not $CsvPath) {
+    $candidates = @(
+        "$repoRoot\exports\BegeleidingTeams.csv",
+        "$repoRoot\exports\teambegeleiding.csv"
+    )
+    foreach ($c in $candidates) {
+        if (Test-Path $c) { $CsvPath = $c; break }
+    }
+}
+
+if (-not $CsvPath -or -not (Test-Path $CsvPath)) {
+    Write-Host "  FOUT: geen CSV gevonden. Download eerst via club.sportlink.com of via:" -ForegroundColor Red
+    Write-Host "  .\exports\sync-teambegeleiding.ps1" -ForegroundColor Yellow
+    exit 1
+}
+
+Write-Host "  Bestand: $CsvPath" -ForegroundColor Green
+
+# ── Stap 2: Verbindingsstring ophalen uit local.settings.json ─────────────────
+Write-Host "`n[2/5] SQL-verbindingsstring ophalen..." -ForegroundColor Yellow
+
+$settingsPath = "$repoRoot\FunctionApp\local.settings.json"
+if (-not (Test-Path $settingsPath)) {
+    Write-Host "  FOUT: $settingsPath niet gevonden." -ForegroundColor Red
+    Write-Host "  Kopieer local.settings.template.json naar local.settings.json en vul SqlConnectionString in." -ForegroundColor Yellow
+    exit 1
+}
+
+$connectionStr = (Get-Content $settingsPath -Raw | ConvertFrom-Json).Values.SqlConnectionString
+if (-not $connectionStr) {
+    Write-Host "  FOUT: SqlConnectionString ontbreekt in local.settings.json." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "  Verbindingsstring gevonden." -ForegroundColor Green
+
+# ── Stap 3: CSV inlezen en kolomdetectie ──────────────────────────────────────
+Write-Host "`n[3/5] CSV inlezen en kolomdetectie..." -ForegroundColor Yellow
+
+$csvRows = Import-Csv -Path $CsvPath -Delimiter ";" -Encoding UTF8
+
+if ($csvRows.Count -eq 0) {
+    Write-Host "  FOUT: CSV bevat geen gegevensrijen." -ForegroundColor Red
+    exit 1
+}
+
+# Detecteer aanwezige CSV-headers (case-insensitief)
+$csvHeaders = $csvRows[0].PSObject.Properties.Name
+
+function Find-CsvColumn([string[]]$aliases, [string[]]$headers) {
+    $headersNorm = $headers | ForEach-Object { $_.Trim().ToLower() }
+    foreach ($alias in $aliases) {
+        $idx = [array]::IndexOf($headersNorm, $alias.Trim().ToLower())
+        if ($idx -ge 0) { return $headers[$idx] }
+    }
+    return $null
+}
+
+# Bouw mapping: canonieke naam → werkelijke CSV-kolomnaam (of $null)
+$resolved = @{}
+foreach ($canonical in $columnAliases.Keys) {
+    $resolved[$canonical] = Find-CsvColumn $columnAliases[$canonical] $csvHeaders
+}
+
+# Valideer vereiste velden
+$ontbrekend = $vereist | Where-Object { -not $resolved[$_] }
+if ($ontbrekend) {
+    Write-Host "  FOUT: de volgende vereiste kolommen zijn niet gevonden in de CSV:" -ForegroundColor Red
+    foreach ($v in $ontbrekend) {
+        Write-Host "    - $v  (verwacht één van: $($columnAliases[$v] -join ', '))" -ForegroundColor Red
+    }
+    Write-Host "`n  Aanwezige CSV-kolommen:" -ForegroundColor Yellow
+    $csvHeaders | ForEach-Object { Write-Host "    * $_" -ForegroundColor Gray }
+    exit 1
+}
+
+# Toon kolomresolutie
+Write-Host "  Gevonden kolommen:" -ForegroundColor Green
+foreach ($canonical in $resolved.Keys) {
+    if ($resolved[$canonical]) {
+        Write-Host "    $canonical → '$($resolved[$canonical])'" -ForegroundColor Gray
+    }
+}
+
+$heeftTussenvoegsel = $null -ne $resolved["Tussenvoegsel"]
+$heeftMobiel        = $null -ne $resolved["MobielNummer"]
+$heeftTelefoon      = $null -ne $resolved["TelefoonnummerKolom"]
+
+if (-not $heeftMobiel -and -not $heeftTelefoon) {
+    Write-Host "  WAARSCHUWING: geen telefoonnummer-kolom gevonden — Telefoonnummer wordt NULL." -ForegroundColor Yellow
+}
+if (-not $resolved["LeeftijdscategorieTeam"]) {
+    Write-Host "  WAARSCHUWING: kolom 'Leeftijdscategorie team' niet gevonden — wordt NULL." -ForegroundColor Yellow
+}
+
+# ── DataTable vullen ───────────────────────────────────────────────────────────
+$table = New-Object System.Data.DataTable
+$null  = $table.Columns.Add("Team",                   [object])
+$null  = $table.Columns.Add("LeeftijdscategorieTeam", [object])
+$null  = $table.Columns.Add("Teamrol",                [object])
+$null  = $table.Columns.Add("Naam",                   [object])
+$null  = $table.Columns.Add("Emailadres",             [object])
+$null  = $table.Columns.Add("Telefoonnummer",         [object])
+
+function Get-CsvValue([object]$row, [string]$col) {
+    if (-not $col) { return [DBNull]::Value }
+    $v = $row.$col
+    if ([string]::IsNullOrWhiteSpace($v)) { return [DBNull]::Value }
+    return $v.Trim()
+}
+
+foreach ($row in $csvRows) {
+    # Naam aggregeren: Roepnaam [Tussenvoegsel] Achternaam
+    $delen = @(
+        ($row.($resolved["Roepnaam"])).Trim(),
+        $(if ($heeftTussenvoegsel) { ($row.($resolved["Tussenvoegsel"])).Trim() } else { "" }),
+        ($row.($resolved["Achternaam"])).Trim()
+    ) | Where-Object { $_ -ne "" }
+    $naam = if ($delen) { $delen -join " " } else { [DBNull]::Value }
+
+    # Telefoonnummer: Mobiel als gevuld, anders vaste telefoon
+    $telefoon = [DBNull]::Value
+    if ($heeftMobiel) {
+        $m = ($row.($resolved["MobielNummer"])).Trim()
+        if ($m) { $telefoon = $m }
+    }
+    if ($telefoon -eq [DBNull]::Value -and $heeftTelefoon) {
+        $t = ($row.($resolved["TelefoonnummerKolom"])).Trim()
+        if ($t) { $telefoon = $t }
+    }
+
+    $r = $table.NewRow()
+    $r["Team"]                   = Get-CsvValue $row $resolved["Team"]
+    $r["LeeftijdscategorieTeam"] = Get-CsvValue $row $resolved["LeeftijdscategorieTeam"]
+    $r["Teamrol"]                = Get-CsvValue $row $resolved["Teamrol"]
+    $r["Naam"]                   = $naam
+    $r["Emailadres"]             = Get-CsvValue $row $resolved["Emailadres"]
+    $r["Telefoonnummer"]         = $telefoon
+    $table.Rows.Add($r)
+}
+
+Write-Host "  $($table.Rows.Count) rijen verwerkt." -ForegroundColor Green
+
+# ── Stap 4: TRUNCATE + SqlBulkCopy ────────────────────────────────────────────
+Write-Host "`n[4/5] Importeren naar SQL Server..." -ForegroundColor Yellow
+
+$conn = New-Object System.Data.SqlClient.SqlConnection($connectionStr)
+$conn.Open()
+
+try {
+    $cmd             = $conn.CreateCommand()
+    $cmd.CommandText = "TRUNCATE TABLE [avg].[Teambegeleiding]"
+    $cmd.ExecuteNonQuery() | Out-Null
+    Write-Host "  avg.Teambegeleiding leeggemaakt (TRUNCATE)." -ForegroundColor Gray
+
+    $bulk                      = New-Object System.Data.SqlClient.SqlBulkCopy($conn)
+    $bulk.DestinationTableName = "[avg].[Teambegeleiding]"
+    $bulk.BulkCopyTimeout      = 60
+    foreach ($col in $table.Columns) {
+        $null = $bulk.ColumnMappings.Add($col.ColumnName, $col.ColumnName)
+    }
+    $bulk.WriteToServer($table)
+    $bulk.Close()
+    Write-Host "  $($table.Rows.Count) rijen geïmporteerd naar avg.Teambegeleiding." -ForegroundColor Green
+
+    $stopwatch.Stop()
+    $cmdLog             = $conn.CreateCommand()
+    $cmdLog.CommandText = @"
+INSERT INTO [avg].[ImportLog] (AantalRijen, CsvBestand, ImporterendeDoor, Duur_ms)
+VALUES (@rijen, @csv, SYSTEM_USER, @duur)
+"@
+    $null = $cmdLog.Parameters.AddWithValue("@rijen", $table.Rows.Count)
+    $null = $cmdLog.Parameters.AddWithValue("@csv",   $CsvPath)
+    $null = $cmdLog.Parameters.AddWithValue("@duur",  [int]$stopwatch.ElapsedMilliseconds)
+    $cmdLog.ExecuteNonQuery() | Out-Null
+    Write-Host "  Importlog weggeschreven (avg.ImportLog)." -ForegroundColor Gray
+}
+finally {
+    $conn.Close()
+}
+
+# ── Stap 5: Optioneel CSV verwijderen ─────────────────────────────────────────
+Write-Host "`n[5/5] Afronden..." -ForegroundColor Yellow
+
+if ($DeleteCsvAfterImport) {
+    Remove-Item -Path $CsvPath -Force
+    Write-Host "  CSV verwijderd na succesvolle import: $CsvPath" -ForegroundColor Green
+} else {
+    Write-Host "  CSV bewaard lokaal. Gebruik -DeleteCsvAfterImport `$true om te verwijderen na import." -ForegroundColor Gray
+}
+
+# ── Rapport ───────────────────────────────────────────────────────────────────
+Write-Host "`nKlaar!" -ForegroundColor Cyan
+Write-Host "  Geïmporteerd : $($table.Rows.Count) personen" -ForegroundColor White
+Write-Host "  Tabel        : avg.Teambegeleiding" -ForegroundColor White
+Write-Host "  Duur         : $($stopwatch.ElapsedMilliseconds) ms" -ForegroundColor White
+Write-Host "  Datum        : $(Get-Date -Format 'yyyy-MM-dd HH:mm')" -ForegroundColor White
+Write-Host "`n  ⚠️  avg.Teambegeleiding bevat AVG/GDPR-persoonsgegevens." -ForegroundColor Yellow
+Write-Host "     Beperk SELECT-rechten tot bevoegde gebruikers en rollen.`n" -ForegroundColor Yellow


### PR DESCRIPTION
## Samenvatting

- Nieuw `avg` schema met tabel `Teambegeleiding` voor contactpersonen (leider, trainer) per team
- Tabel `ImportLog` houdt bij wanneer en door wie een import is uitgevoerd
- PowerShell script `import-teambegeleiding-to-sql.ps1` leest een Sportlink CSV-export in en bulk-importeert naar SQL
- Naam wordt samengesteld uit Roepnaam + Tussenvoegsel + Achternaam
- Telefoonnummer: mobiel als gevuld, anders vaste lijn
- Flexibele kolomdetectie via alias-map — werkt met exportvarianten van verschillende clubs

## Achtergrond

De planner moet bij wedstrijdwijzigingen de leider en trainer van het betreffende team kunnen bereiken. Deze tabel levert de contactgegevens op basis van een periodieke CSV-export vanuit Sportlink Club.

Query die de planner gebruikt:
```sql
SELECT Naam, Emailadres
FROM   [avg].[Teambegeleiding]
WHERE  Team    = @team
  AND  Teamrol IN ('Lokale staf', 'Technische staf')
  AND  Emailadres IS NOT NULL
```

## Testplan

- [ ] Database project deployen of tabellen handmatig aanmaken via de SQL-bestanden in `Database/avg/`
- [ ] `.\exports\import-teambegeleiding-to-sql.ps1` uitvoeren met een Sportlink CSV-export
- [ ] `SELECT COUNT(*) FROM avg.Teambegeleiding` toont het verwachte aantal personen
- [ ] `SELECT TOP 1 * FROM avg.ImportLog ORDER BY ImportDatum DESC` toont de laatste importregel
- [ ] Query op teamnaam retourneert de juiste namen en e-mailadressen

🤖 Generated with [Claude Code](https://claude.com/claude-code)