### PR TITLE
fix(#119) + feat(#27): ClubCode EmailVerwerking + automatische schedule-restart

### DIFF
--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -19,12 +19,24 @@ public class AppSettingsDto
     public int? HerplanDeadlineDagen { get; set; }
     public int? BufferMinuten { get; set; }
     public string? EmailVoetnoot { get; set; }
+    public string? FetchScheduleLeesbaar { get; set; }
+    public List<string>? VolgendeMomenten { get; set; }
 }
 
 public class SettingsUpdateDto
 {
     public string? GewijzigdDoor { get; set; }
     public Dictionary<string, string?>? Velden { get; set; }
+}
+
+public class SettingsUpdateResultDto
+{
+    public string[]? GewijzigdeVelden { get; set; }
+    public bool HerstartVereist { get; set; }
+    public bool HerstartAutomatisch { get; set; }
+    public string? Opmerking { get; set; }
+    public string? FetchScheduleLeesbaar { get; set; }
+    public List<string>? VolgendeMomenten { get; set; }
 }
 
 public class SyncStatusDto

--- a/BlazorAdmin/Pages/Instellingen.razor
+++ b/BlazorAdmin/Pages/Instellingen.razor
@@ -79,9 +79,16 @@ else
             <div class="col-md-6 mb-3">
                 <label class="form-label">FetchSchedule (CRON)</label>
                 <input class="form-control" @bind="settings.FetchSchedule" />
-                <small class="form-text text-warning">
-                    Wijziging vereist herstart van de Azure Function App.
-                </small>
+                @if (!string.IsNullOrEmpty(settings.FetchScheduleLeesbaar))
+                {
+                    <small class="form-text text-muted">@settings.FetchScheduleLeesbaar</small>
+                }
+                @if (settings.VolgendeMomenten?.Count > 0)
+                {
+                    <small class="form-text text-muted">
+                        Volgende uitvoeringen (UTC): @string.Join(", ", settings.VolgendeMomenten)
+                    </small>
+                }
             </div>
             <div class="col-md-6 mb-3">
                 <label class="form-label">Laatste synchronisatie</label>
@@ -96,6 +103,10 @@ else
         @if (!string.IsNullOrEmpty(successMessage))
         {
             <div class="alert alert-success mt-3">@successMessage</div>
+        }
+        @if (!string.IsNullOrEmpty(herstartMessage))
+        {
+            <div class="alert alert-info mt-3">@herstartMessage</div>
         }
     </EditForm>
 
@@ -174,6 +185,7 @@ else
     private bool saving;
     private string? errorMessage;
     private string? successMessage;
+    private string? herstartMessage;
 
     private List<UitgeslotenEmailAdresDto> uitgeslotenEmails = new();
     private UitgeslotenEmailAdresDto? nieuwAdres;
@@ -232,6 +244,7 @@ else
         if (settings == null) return;
         saving = true;
         successMessage = null;
+        herstartMessage = null;
         errorMessage = null;
 
         var update = new SettingsUpdateDto
@@ -252,10 +265,27 @@ else
         };
 
         var r = await Api.UpdateSettingsAsync(update);
-        successMessage = r.Success
-            ? "Instellingen opgeslagen."
-            : null;
-        if (!r.Success) errorMessage = r.ErrorMessage;
+        if (r.Success)
+        {
+            successMessage = "Instellingen opgeslagen.";
+            if (r.Data?.HerstartAutomatisch == true)
+            {
+                herstartMessage = r.Data.Opmerking ?? "Het ophaalschema is bijgewerkt. De applicatie herstart automatisch en het nieuwe schema is actief na de herstart.";
+                // CRON-preview bijwerken in het scherm
+                if (r.Data.FetchScheduleLeesbaar != null)
+                    settings.FetchScheduleLeesbaar = r.Data.FetchScheduleLeesbaar;
+                if (r.Data.VolgendeMomenten != null)
+                    settings.VolgendeMomenten = r.Data.VolgendeMomenten;
+            }
+            else if (r.Data?.HerstartVereist == true)
+            {
+                herstartMessage = r.Data.Opmerking ?? "Het ophaalschema is opgeslagen. Herstart de Function App handmatig om het nieuwe schema actief te maken.";
+            }
+        }
+        else
+        {
+            errorMessage = r.ErrorMessage;
+        }
         saving = false;
     }
 }

--- a/BlazorAdmin/Services/AdminApiClient.cs
+++ b/BlazorAdmin/Services/AdminApiClient.cs
@@ -24,8 +24,8 @@ public class AdminApiClient
     public async Task<ApiResult<AppSettingsDto>> GetSettingsAsync()
         => await GetAsync<AppSettingsDto>("api/beheer/settings");
 
-    public async Task<ApiResult<object>> UpdateSettingsAsync(SettingsUpdateDto dto)
-        => await PutAsync<object>("api/beheer/settings", dto);
+    public async Task<ApiResult<SettingsUpdateResultDto>> UpdateSettingsAsync(SettingsUpdateDto dto)
+        => await PutAsync<SettingsUpdateResultDto>("api/beheer/settings", dto);
 
     // ── Sync ──
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 _Wijzigingen op `v2/develop` die nog niet zijn vrijgegeven._
 
+### Fixed
+- **Email-log isolatie** (#119): `planner.EmailVerwerking` had als enige v2-tabel geen `ClubCode` kolom. Beheerders van club A konden daardoor de email-log van club B zien. Kolom toegevoegd; bestaande rijen krijgen standaardwaarde via migratie.
+
+### Added
+- **Automatische herstart bij schema-wijziging** (#27): wanneer een beheerder het ophaalschema wijzigt via de Instellingen-pagina, werkt de applicatie de Azure App Setting automatisch bij via de Azure Management API — de Function App herstart zichzelf zonder handmatige actie. CRON-expressies worden gevalideerd vóór opslaan. De Instellingen-pagina toont een leesbare omschrijving van het schema én de eerstvolgende drie uitvoertijden.
+
 ---
 
 ## [2.0.0] — 2026-05-17

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -383,6 +383,11 @@ BEGIN
 END
 GO
 
+-- v2 — #119: ClubCode toevoegen aan planner.EmailVerwerking (multi-club isolatie email-log)
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('planner.EmailVerwerking') AND name = 'ClubCode')
+    ALTER TABLE [planner].[EmailVerwerking] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_EmailVerwerking_ClubCode] DEFAULT 'VRC';
+GO
+
 -- v2 — #84: EmailTemplateInstellingen
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.EmailTemplateInstellingen'))
 BEGIN

--- a/Database/planner/Tables/EmailVerwerking.sql
+++ b/Database/planner/Tables/EmailVerwerking.sql
@@ -13,6 +13,7 @@ CREATE TABLE [planner].[EmailVerwerking] (
     [VerstuurdNaar]         NVARCHAR(200)   NULL,
     [Status]                NVARCHAR(30)    NOT NULL CONSTRAINT [DF_EmailVerwerking_Status] DEFAULT 'Ontvangen',
     [FoutMelding]           NVARCHAR(1000)  NULL,
+    [ClubCode]              NVARCHAR(20)    NOT NULL CONSTRAINT [DF_EmailVerwerking_ClubCode] DEFAULT 'VRC',
     [mta_inserted]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Ins] DEFAULT GETDATE(),
     [mta_modified]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Mod] DEFAULT GETDATE(),
     CONSTRAINT [PK_EmailVerwerking] PRIMARY KEY CLUSTERED ([Id] ASC),

--- a/FunctionApp/Admin/AdminEmailLogFunction.cs
+++ b/FunctionApp/Admin/AdminEmailLogFunction.cs
@@ -28,6 +28,9 @@ public static class AdminEmailLogFunction
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
 
+            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
+                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+
             DateTime? vanaf = null, tot = null;
             if (DateTime.TryParse(req.Query["vanaf"].ToString(), out var vd)) vanaf = vd.Date;
             if (DateTime.TryParse(req.Query["tot"].ToString(), out var td)) tot = td.Date.AddDays(1);
@@ -44,7 +47,7 @@ public static class AdminEmailLogFunction
                                [OntvangstDatum], [VerzoekType], [Status], [VerstuurdNaar],
                                [FoutMelding], [mta_inserted], [mta_modified]
                         FROM [planner].[EmailVerwerking]
-                        WHERE 1 = 1";
+                        WHERE [ClubCode] = @ClubCode";
             if (vanaf.HasValue) sql += " AND [OntvangstDatum] >= @Vanaf";
             if (tot.HasValue) sql += " AND [OntvangstDatum] < @Tot";
             if (!string.IsNullOrWhiteSpace(statusFilter)) sql += " AND [Status] = @Status";
@@ -52,6 +55,7 @@ public static class AdminEmailLogFunction
 
             using var command = new SqlCommand(sql, connection);
             command.Parameters.AddWithValue("@Limit", limit);
+            command.Parameters.AddWithValue("@ClubCode", clubCode);
             if (vanaf.HasValue) command.Parameters.AddWithValue("@Vanaf", vanaf.Value);
             if (tot.HasValue) command.Parameters.AddWithValue("@Tot", tot.Value);
             if (!string.IsNullOrWhiteSpace(statusFilter))

--- a/FunctionApp/Admin/AdminSettingsFunction.cs
+++ b/FunctionApp/Admin/AdminSettingsFunction.cs
@@ -1,10 +1,15 @@
-using System.Net;
+using Azure.Core;
+using Azure.Identity;
+using Cronos;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Net.Http.Headers;
+using System.Text;
 
 namespace SportlinkFunction.Admin;
 
@@ -19,6 +24,13 @@ namespace SportlinkFunction.Admin;
 ///   - AuthorizationLevel.Function (in productie via SWA proxying veilig)
 ///   - SportlinkClientId en Graph secrets worden NOOIT in responses gezet
 ///   - Alle wijzigingen worden vastgelegd in dbo.AppSettingsAudit (CISO-eis)
+///
+/// Schedule-restart (#27):
+///   - Bij FetchSchedule-wijziging wordt FETCH_SCHEDULE Azure App Setting bijgewerkt
+///     via Azure Management API → Function App herstart automatisch
+///   - Vereiste env vars: AzureSubscriptionId, AzureResourceGroupName, AzureFunctionAppName
+///   - Managed Identity van de Function App heeft Website Contributor rol nodig op de Function App resource
+///   - Als env vars ontbreken (bijv. lokaal): herstartVereist=true in response, handmatige herstart nodig
 /// </summary>
 public static class AdminSettingsFunction
 {
@@ -30,6 +42,8 @@ public static class AdminSettingsFunction
         "PlannerAfzenderNaam", "CoordinatorNaam", "CoordinatorFunctie", "PlannerEmailAdres",
         "Accommodatie", "FetchSchedule", "EmailVoetnoot"
     };
+
+    private const string ManagementApiVersion = "2022-03-01";
 
     [Function("AdminSettingsGet")]
     public static async Task<IActionResult> Get(
@@ -65,6 +79,13 @@ public static class AdminSettingsFunction
                 result[name] = raw is DateTime dt ? DateTime.SpecifyKind(dt, DateTimeKind.Utc) : raw;
             }
 
+            // Voeg CRON-preview toe als FetchSchedule aanwezig is
+            if (result.TryGetValue("FetchSchedule", out var sched) && sched is string schedStr && !string.IsNullOrWhiteSpace(schedStr))
+            {
+                result["fetchScheduleLeesbaar"] = VertaalCronNaarLeesbaar(schedStr);
+                result["volgendeMomenten"] = BerekenVolgendeMomenten(schedStr, 3);
+            }
+
             return new OkObjectResult(result);
         }
         catch (Exception ex)
@@ -95,7 +116,7 @@ public static class AdminSettingsFunction
             if (string.IsNullOrWhiteSpace(gewijzigdDoor)) gewijzigdDoor = "onbekend";
 
             // Pluk alleen de toegestane velden — alles erbuiten wordt genegeerd
-            var changes = new Dictionary<string, string?>();
+            var changes = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
             if (updateRequest.Velden != null)
             {
                 foreach (var (key, value) in updateRequest.Velden)
@@ -110,6 +131,13 @@ public static class AdminSettingsFunction
             if (changes.Count == 0)
                 return new BadRequestObjectResult(new { error = "Geen toegestane velden in request" });
 
+            // Valideer CRON-expressie vóór opslaan
+            if (changes.TryGetValue("FetchSchedule", out var nieuweSchedule) && nieuweSchedule != null)
+            {
+                if (!CronExpression.TryParse(nieuweSchedule, CronFormat.IncludeSeconds, out _))
+                    return new BadRequestObjectResult(new { error = $"Ongeldige CRON-expressie: '{nieuweSchedule}'. Verwacht 6 velden (seconden minuten uren dag maand weekdag)." });
+            }
+
             await SystemUtilities.WaitForDatabaseAsync(log);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
@@ -118,7 +146,7 @@ public static class AdminSettingsFunction
 
             try
             {
-                    var currentValues = await ReadCurrentValuesAsync(connection, (SqlTransaction)transaction, changes.Keys);
+                var currentValues = await ReadCurrentValuesAsync(connection, (SqlTransaction)transaction, changes.Keys);
 
                 foreach (var (veld, nieuweWaarde) in changes)
                 {
@@ -154,16 +182,35 @@ public static class AdminSettingsFunction
 
             await SystemUtilities.AppSettings.LoadSettingsAsync(log);
 
-            var fetchScheduleChanged = changes.Keys.Any(k =>
-                string.Equals(k, "FetchSchedule", StringComparison.OrdinalIgnoreCase));
+            var fetchScheduleChanged = changes.ContainsKey("FetchSchedule");
+            string? herstartOpmerking = null;
+            bool herstartAutomatisch = false;
+
+            if (fetchScheduleChanged && nieuweSchedule != null)
+            {
+                var restartResult = await TriggerFunctionAppRestartAsync(nieuweSchedule, log);
+                if (restartResult != null)
+                {
+                    herstartAutomatisch = true;
+                    herstartOpmerking = restartResult;
+                }
+                else
+                {
+                    herstartOpmerking = "FetchSchedule gewijzigd — herstart van de Function App vereist om effect te laten gelden. " +
+                                        "Configureer AzureSubscriptionId, AzureResourceGroupName en AzureFunctionAppName voor automatische herstart.";
+                }
+            }
 
             return new OkObjectResult(new
             {
                 gewijzigdeVelden = changes.Keys.ToArray(),
-                herstartVereist = fetchScheduleChanged,
-                opmerking = fetchScheduleChanged
-                    ? "FetchSchedule gewijzigd — herstart van de Function App vereist om effect te laten gelden"
-                    : null
+                herstartVereist = fetchScheduleChanged && !herstartAutomatisch,
+                herstartAutomatisch,
+                opmerking = herstartOpmerking,
+                fetchScheduleLeesbaar = fetchScheduleChanged && nieuweSchedule != null
+                    ? VertaalCronNaarLeesbaar(nieuweSchedule) : null,
+                volgendeMomenten = fetchScheduleChanged && nieuweSchedule != null
+                    ? BerekenVolgendeMomenten(nieuweSchedule, 3) : null
             });
         }
         catch (Exception ex)
@@ -171,6 +218,129 @@ public static class AdminSettingsFunction
             log.LogError(ex, "Fout bij opslaan AppSettings");
             return new ObjectResult(new { error = "Opslaan mislukt" }) { StatusCode = 500 };
         }
+    }
+
+    /// <summary>
+    /// Werkt de FETCH_SCHEDULE Azure App Setting bij via de Azure Management API.
+    /// Azure herstart de Function App automatisch bij app setting wijziging.
+    /// Vereist: AzureSubscriptionId, AzureResourceGroupName, AzureFunctionAppName env vars
+    ///          en Managed Identity met Website Contributor rol op de Function App.
+    /// Geeft null terug als de env vars niet geconfigureerd zijn (lokale omgeving).
+    /// </summary>
+    private static async Task<string?> TriggerFunctionAppRestartAsync(string nieuweSchedule, ILogger log)
+    {
+        var subscriptionId = Environment.GetEnvironmentVariable("AzureSubscriptionId");
+        var resourceGroup  = Environment.GetEnvironmentVariable("AzureResourceGroupName");
+        var functionAppName = Environment.GetEnvironmentVariable("AzureFunctionAppName");
+
+        if (string.IsNullOrWhiteSpace(subscriptionId) ||
+            string.IsNullOrWhiteSpace(resourceGroup) ||
+            string.IsNullOrWhiteSpace(functionAppName))
+        {
+            log.LogWarning("Azure Management env vars niet geconfigureerd (AzureSubscriptionId / AzureResourceGroupName / AzureFunctionAppName) — automatische herstart overgeslagen");
+            return null;
+        }
+
+        try
+        {
+            var credential = new DefaultAzureCredential();
+            var tokenContext = new TokenRequestContext(["https://management.azure.com/.default"]);
+            var token = await credential.GetTokenAsync(tokenContext);
+
+            using var http = new HttpClient();
+            http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token.Token);
+
+            var baseUrl = $"https://management.azure.com/subscriptions/{subscriptionId}" +
+                          $"/resourceGroups/{resourceGroup}" +
+                          $"/providers/Microsoft.Web/sites/{functionAppName}";
+
+            // Haal huidige app settings op (POST .../config/appsettings/list)
+            var listResponse = await http.PostAsync($"{baseUrl}/config/appsettings/list?api-version={ManagementApiVersion}", null);
+            listResponse.EnsureSuccessStatusCode();
+            var listJson = await listResponse.Content.ReadAsStringAsync();
+            var listObj = JObject.Parse(listJson);
+
+            var properties = new Dictionary<string, string?>();
+            var existingProps = listObj["properties"] as JObject;
+            if (existingProps != null)
+            {
+                foreach (var prop in existingProps.Properties())
+                    properties[prop.Name] = prop.Value.ToString();
+            }
+
+            // Bijwerken FETCH_SCHEDULE
+            properties["FETCH_SCHEDULE"] = nieuweSchedule;
+
+            var putBody = JsonConvert.SerializeObject(new { properties });
+            var putResponse = await http.PutAsync(
+                $"{baseUrl}/config/appsettings?api-version={ManagementApiVersion}",
+                new StringContent(putBody, Encoding.UTF8, "application/json"));
+            putResponse.EnsureSuccessStatusCode();
+
+            log.LogInformation("FETCH_SCHEDULE bijgewerkt naar '{Schedule}' via Azure Management API — Function App herstart automatisch", nieuweSchedule);
+            return "FetchSchedule bijgewerkt. De Function App herstart automatisch en het nieuwe ophaalschema is actief na de herstart.";
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij aanroepen Azure Management API voor herstart");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Vertaalt veelgebruikte CRON-expressies naar leesbare Nederlandse tekst.
+    /// Valt terug op de ruwe expressie als het patroon niet herkend wordt.
+    /// </summary>
+    internal static string VertaalCronNaarLeesbaar(string cron)
+    {
+        if (string.IsNullOrWhiteSpace(cron)) return cron;
+        var parts = cron.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length != 6) return cron;
+
+        var (sec, min, uur, dag, maand, week) = (parts[0], parts[1], parts[2], parts[3], parts[4], parts[5]);
+
+        // Dagelijks op vaste tijd: "0 MM HH * * *"
+        if (sec == "0" && dag == "*" && maand == "*" && week == "*"
+            && int.TryParse(min, out var m) && int.TryParse(uur, out var h))
+            return $"Elke dag om {h:D2}:{m:D2}";
+
+        // Elk uur op vaste minuut: "0 MM * * * *"
+        if (sec == "0" && uur == "*" && dag == "*" && maand == "*" && week == "*"
+            && int.TryParse(min, out var hmin))
+            return $"Elk uur op minuut :{hmin:D2}";
+
+        // Elke N minuten: "0 */N * * * *"
+        if (sec == "0" && uur == "*" && dag == "*" && maand == "*" && week == "*"
+            && min.StartsWith("*/") && int.TryParse(min[2..], out var interval))
+            return $"Elke {interval} minuten";
+
+        // Maandelijks op vaste dag+tijd: "0 MM HH D * *"
+        if (sec == "0" && maand == "*" && week == "*"
+            && int.TryParse(min, out var mm) && int.TryParse(uur, out var hh) && int.TryParse(dag, out var dd))
+            return $"Maandelijks op dag {dd} om {hh:D2}:{mm:D2}";
+
+        return cron;
+    }
+
+    /// <summary>
+    /// Berekent de eerstvolgende N uitvoertijden voor een CRON-expressie (6-veld Azure-formaat).
+    /// Geeft een lege lijst als de expressie ongeldig is.
+    /// </summary>
+    internal static List<string> BerekenVolgendeMomenten(string cron, int aantal)
+    {
+        var resultaten = new List<string>();
+        if (!CronExpression.TryParse(cron, CronFormat.IncludeSeconds, out var expr)) return resultaten;
+
+        var nu = DateTime.UtcNow;
+        var volgende = nu;
+        for (int i = 0; i < aantal; i++)
+        {
+            var next = expr.GetNextOccurrence(volgende, TimeZoneInfo.Utc);
+            if (next == null) break;
+            resultaten.Add(next.Value.ToString("yyyy-MM-ddTHH:mm:ss"));
+            volgende = next.Value;
+        }
+        return resultaten;
     }
 
     private static async Task<Dictionary<string, string?>> ReadCurrentValuesAsync(

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -731,13 +731,16 @@ public class EmailProcessorFunction
 
     private static async Task<int> InsertEmailVerwerkingAsync(InkomendBericht email)
     {
+        var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
+            ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+
         using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
         await connection.OpenAsync();
         using var command = new SqlCommand(@"
             INSERT INTO [planner].[EmailVerwerking]
-                ([MessageId], [ConversationId], [Afzender], [Onderwerp], [OntvangstDatum], [EmailBody], [VerzoekType], [Status])
+                ([MessageId], [ConversationId], [Afzender], [Onderwerp], [OntvangstDatum], [EmailBody], [VerzoekType], [Status], [ClubCode])
             VALUES
-                (@MessageId, @ConversationId, @Afzender, @Onderwerp, @OntvangstDatum, @EmailBody, 'Onbekend', 'Ontvangen');
+                (@MessageId, @ConversationId, @Afzender, @Onderwerp, @OntvangstDatum, @EmailBody, 'Onbekend', 'Ontvangen', @ClubCode);
             SELECT CAST(SCOPE_IDENTITY() AS INT);", connection);
 
         command.Parameters.AddWithValue("@MessageId", email.MessageId);
@@ -746,6 +749,7 @@ public class EmailProcessorFunction
         command.Parameters.AddWithValue("@Onderwerp", email.Onderwerp);
         command.Parameters.AddWithValue("@OntvangstDatum", email.OntvangstDatum);
         command.Parameters.AddWithValue("@EmailBody", (object?)email.Body ?? DBNull.Value);
+        command.Parameters.AddWithValue("@ClubCode", clubCode);
 
         return (int)(await command.ExecuteScalarAsync())!;
     }

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Cronos" Version="0.8.4" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />

--- a/FunctionApp/local.settings.template.json
+++ b/FunctionApp/local.settings.template.json
@@ -17,6 +17,9 @@
     "EmailProcessorEnabled": "false",
     "EmailReviewMode": "true",
     "EmailReviewRecipient": "",
-    "EMAIL_POLL_SCHEDULE": "0 0 * * * *"
+    "EMAIL_POLL_SCHEDULE": "0 0 * * * *",
+    "AzureSubscriptionId": "",
+    "AzureResourceGroupName": "",
+    "AzureFunctionAppName": ""
   }
 }


### PR DESCRIPTION
## Summary

- **#119** (fix/arch-debt): `planner.EmailVerwerking` had als enige v2-tabel geen `ClubCode` kolom. Bij multi-club onboarding zou de email-log van alle clubs zichtbaar zijn voor elke admin. Kolom toegevoegd + migratie + ClubCode-filter in `AdminEmailLogFunction`.
- **#27** (feat/fase-3): `AdminSettingsFunction` meldt nu niet alleen `herstartVereist=true` maar belt ook écht de Azure Management API om `FETCH_SCHEDULE` bij te werken → Function App herstart automatisch. Fallback als Azure env vars ontbreken.

## Wijzigingen

### Database
- `planner.EmailVerwerking`: `[ClubCode] NVARCHAR(20) NOT NULL DEFAULT 'VRC'`
- `Script.PostDeployment1.sql`: idempotente migratie toegevoegd

### FunctionApp
- `EmailProcessorFunction.InsertEmailVerwerkingAsync`: schrijft ClubCode bij insert
- `AdminEmailLogFunction.Get`: `WHERE [ClubCode] = @ClubCode` filter toegevoegd
- `AdminSettingsFunction`: volledige implementatie #27 — CRON-validatie (Cronos), Azure Management API call, CRON-preview (`fetchScheduleLeesbaar` + `volgendeMomenten`)
- NuGet: `Cronos 0.8.4` toegevoegd
- `local.settings.template.json`: `AzureSubscriptionId`, `AzureResourceGroupName`, `AzureFunctionAppName`

### BlazorAdmin
- `Instellingen.razor`: CRON-leesbaar + volgende momenten tonen; herstart-bevestiging na opslaan
- `AdminModels.cs`: `SettingsUpdateResultDto` + CRON-preview velden op `AppSettingsDto`
- `AdminApiClient.cs`: `UpdateSettingsAsync` retourneert nu `SettingsUpdateResultDto`

## Test plan

- [x] `dotnet build FunctionApp` → groen (0 errors)
- [x] `dotnet build BlazorAdmin` → groen (0 errors)
- [x] `Test-App.ps1` → 28/28 checks geslaagd
- [x] Health endpoint 200 na `func start`
- [ ] Productie: Azure Management vars instellen + Managed Identity Website Contributor toewijzen (zie issue #27)

## CISO

- ClubCode DEFAULT 'VRC' zorgt voor backwards-compatible migratie van bestaande EmailVerwerking rijen
- Azure Management API token via DefaultAzureCredential (Managed Identity) — geen secrets in code
- Graceful degradation als env vars ontbreken: `herstartVereist=true` ipv crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)