### PR TITLE
feat(#70,#104): team-schedule endpoint + error fingerprinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ _Wijzigingen op `v2/develop` die nog niet zijn vrijgegeven._
 - **Automatische herstart bij schema-wijziging** (#27): wanneer een beheerder het ophaalschema wijzigt via de Instellingen-pagina, werkt de applicatie de Azure App Setting automatisch bij via de Azure Management API — de Function App herstart zichzelf zonder handmatige actie. CRON-expressies worden gevalideerd vóór opslaan. De Instellingen-pagina toont een leesbare omschrijving van het schema én de eerstvolgende drie uitvoertijden.
 
 ### Added
+- **Team-schedule endpoint** (#70): `GET /api/planner/team-schedule?team=VRC+JO11-1` geeft een overzicht van alle nog te spelen wedstrijden per team tot seizoenseinde, inclusief een gesorteerde zaterdag-lijst met status `vrij`/`oefenwedstrijd`/`bezet`. Ondersteunt `?format=html` voor een leesbaar HTML-rapport. Onbekend team → 404; ontbrekende parameter → 400.
+- **Error fingerprinting** (#104): `SystemUtilities.ComputeFingerprint(Exception)` berekent een deterministische 12-karakter hex fingerprint per exception (type + genormaliseerd bericht + callsite in SportlinkFunction-namespace). Basis voor deduplicatie van GitHub Issues in v2.1.
 - **Unit tests voor BerichtPipeline** (#51): xUnit test project `FunctionApp.Tests` toegevoegd aan de solution. 13 tests voor `BerichtPipeline.ValideerDagDatum` — datums in onderwerp, body, dag-naam correctie, prioriteitsregels en randgevallen.
 
 ### Changed

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -586,5 +586,127 @@ namespace SportlinkFunction.Planner
                 return Convert.ToDateTime(result);
             return null;
         }
+
+        // ── Team-schedule (#70) ──
+
+        public static async Task<bool> TeamExistsAsync(string team)
+        {
+            using var conn = new SqlConnection(ConnectionString);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(
+                "SELECT COUNT(1) FROM [his].[teams] WHERE UPPER([teamnaam]) = UPPER(@team)", conn);
+            cmd.Parameters.AddWithValue("@team", team);
+            var count = (int)(await cmd.ExecuteScalarAsync())!;
+            return count > 0;
+        }
+
+        public static async Task<List<TeamScheduleWedstrijd>> GetFutureMatchesForTeamAsync(
+            string team, DateOnly van, DateOnly tot)
+        {
+            var results = new List<TeamScheduleWedstrijd>();
+            using var conn = new SqlConnection(ConnectionString);
+            await conn.OpenAsync();
+
+            // his.matches: competitie- en bekerwedstrijden (thuis en uit)
+            using (var cmd = new SqlCommand(@"
+                SELECT
+                    CAST(m.[kaledatum] AS DATE) AS Datum,
+                    m.[aanvangstijd],
+                    m.[thuisteam],
+                    m.[uitteam],
+                    m.[competitiesoort],
+                    m.[veld],
+                    CAST(m.[wedstrijdcode] AS BIGINT) AS Wedstrijdcode
+                FROM [his].[matches] m
+                WHERE CAST(m.[kaledatum] AS DATE) BETWEEN @van AND @tot
+                  AND m.[status] <> 'Afgelast'
+                  AND (UPPER(m.[teamnaam]) = UPPER(@team))
+                ORDER BY m.[kaledatum], m.[aanvangstijd]
+            ", conn))
+            {
+                cmd.Parameters.AddWithValue("@van", van.ToDateTime(TimeOnly.MinValue));
+                cmd.Parameters.AddWithValue("@tot", tot.ToDateTime(TimeOnly.MinValue));
+                cmd.Parameters.AddWithValue("@team", team);
+
+                using var reader = await cmd.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    var datum = DateOnly.FromDateTime(reader.GetDateTime(0));
+                    var aanvang = reader.GetString(1).Trim();
+                    var thuisTeam = reader.IsDBNull(2) ? "" : reader.GetString(2).Trim();
+                    var uitTeam = reader.IsDBNull(3) ? "" : reader.GetString(3).Trim();
+                    var competitiesoort = reader.IsDBNull(4) ? "" : reader.GetString(4).Trim();
+                    var veld = reader.IsDBNull(5) ? null : reader.GetString(5).Trim();
+                    var wedstrijdcode = reader.GetInt64(6);
+
+                    bool isThuis = thuisTeam.Equals(team, StringComparison.OrdinalIgnoreCase);
+                    var tegenstander = isThuis ? uitTeam : thuisTeam;
+                    var type = DetermineMatchType(competitiesoort);
+
+                    results.Add(new TeamScheduleWedstrijd
+                    {
+                        Datum = datum.ToString("yyyy-MM-dd"),
+                        AanvangsTijd = aanvang,
+                        ThuisUit = isThuis ? "thuis" : "uit",
+                        Tegenstander = tegenstander,
+                        Type = type,
+                        Veld = veld,
+                        Wedstrijdcode = wedstrijdcode
+                    });
+                }
+            }
+
+            // planner.GeplandeWedstrijden: geplande oefenwedstrijden (altijd thuis)
+            using (var cmd2 = new SqlCommand(@"
+                SELECT
+                    gw.[Datum],
+                    CONVERT(VARCHAR(8), gw.[AanvangsTijd], 108) AS AanvangsTijd,
+                    gw.[Tegenstander],
+                    v.[VeldNaam]
+                FROM [planner].[GeplandeWedstrijden] gw
+                LEFT JOIN [dbo].[Velden] v ON v.[VeldNummer] = gw.[VeldNummer]
+                WHERE gw.[Datum] BETWEEN @van AND @tot
+                  AND gw.[Status] <> 'Geannuleerd'
+                  AND UPPER(gw.[TeamNaam]) = UPPER(@team)
+                ORDER BY gw.[Datum], gw.[AanvangsTijd]
+            ", conn))
+            {
+                cmd2.Parameters.AddWithValue("@van", van.ToDateTime(TimeOnly.MinValue));
+                cmd2.Parameters.AddWithValue("@tot", tot.ToDateTime(TimeOnly.MinValue));
+                cmd2.Parameters.AddWithValue("@team", team);
+
+                using var reader2 = await cmd2.ExecuteReaderAsync();
+                while (await reader2.ReadAsync())
+                {
+                    var datum = DateOnly.FromDateTime(reader2.GetDateTime(0));
+                    results.Add(new TeamScheduleWedstrijd
+                    {
+                        Datum = datum.ToString("yyyy-MM-dd"),
+                        AanvangsTijd = reader2.GetString(1),
+                        ThuisUit = "thuis",
+                        Tegenstander = reader2.IsDBNull(2) ? "" : reader2.GetString(2),
+                        Type = "oefenwedstrijd",
+                        Veld = reader2.IsDBNull(3) ? null : reader2.GetString(3),
+                        Wedstrijdcode = null
+                    });
+                }
+            }
+
+            results.Sort((a, b) =>
+            {
+                var cmp = string.Compare(a.Datum, b.Datum, StringComparison.Ordinal);
+                return cmp != 0 ? cmp : string.Compare(a.AanvangsTijd, b.AanvangsTijd, StringComparison.Ordinal);
+            });
+            return results;
+        }
+
+        private static string DetermineMatchType(string competitiesoort)
+        {
+            if (string.IsNullOrWhiteSpace(competitiesoort)) return "competitie";
+            var lower = competitiesoort.ToLowerInvariant();
+            if (lower.Contains("oefen")) return "oefenwedstrijd";
+            if (lower.Contains("beker")) return "beker";
+            return "competitie";
+        }
     }
 }

--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -332,5 +332,42 @@ namespace SportlinkFunction.Planner
                 return new ObjectResult(new { error = "Verzoek mislukt" }) { StatusCode = 500 };
             }
         }
+
+        [Function("GetTeamSchedule")]
+        public static async Task<IActionResult> GetTeamSchedule(
+            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "planner/team-schedule")] HttpRequest req,
+            FunctionContext context)
+        {
+            var log = context.GetLogger("GetTeamSchedule");
+            try
+            {
+                var team = req.Query["team"].ToString();
+                if (string.IsNullOrWhiteSpace(team))
+                    return new BadRequestObjectResult(new { error = "Query parameter 'team' is verplicht." });
+
+                var format = req.Query["format"].ToString().ToLowerInvariant();
+
+                await SystemUtilities.WaitForDatabaseAsync(log);
+
+                log.LogInformation("GetTeamSchedule: team={Team}, format={Format}", team, format);
+
+                var schedule = await PlannerService.GetTeamScheduleAsync(team);
+                if (schedule == null)
+                    return new NotFoundObjectResult(new { error = $"Team '{team}' niet gevonden." });
+
+                if (format == "html")
+                {
+                    var html = TeamScheduleHtmlRenderer.Render(schedule);
+                    return new ContentResult { Content = html, ContentType = "text/html; charset=utf-8", StatusCode = 200 };
+                }
+
+                return new OkObjectResult(schedule);
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "GetTeamSchedule failed");
+                return new ObjectResult(new { error = "Verzoek mislukt" }) { StatusCode = 500 };
+            }
+        }
     }
 }

--- a/FunctionApp/Planner/PlannerModels.cs
+++ b/FunctionApp/Planner/PlannerModels.cs
@@ -258,4 +258,32 @@ namespace SportlinkFunction.Planner
         public int? GewenstVeldNummer { get; set; }
         public string Status { get; set; } = string.Empty;
     }
+
+    // ── Team schedule modellen (#70) ──
+
+    public class TeamScheduleWedstrijd
+    {
+        public string Datum { get; set; } = string.Empty;
+        public string AanvangsTijd { get; set; } = string.Empty;
+        public string ThuisUit { get; set; } = string.Empty;  // "thuis" | "uit"
+        public string Tegenstander { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;      // "competitie" | "beker" | "oefenwedstrijd"
+        public string? Veld { get; set; }
+        public long? Wedstrijdcode { get; set; }
+    }
+
+    public class TeamScheduleZaterdag
+    {
+        public string Datum { get; set; } = string.Empty;
+        public string Status { get; set; } = string.Empty;    // "vrij" | "oefenwedstrijd" | "bezet"
+        public TeamScheduleWedstrijd? BezetDoor { get; set; }
+    }
+
+    public class TeamScheduleResponse
+    {
+        public string Team { get; set; } = string.Empty;
+        public string SeizoenEinde { get; set; } = string.Empty;
+        public List<TeamScheduleZaterdag> Zaterdagen { get; set; } = new();
+        public List<TeamScheduleWedstrijd> Wedstrijden { get; set; } = new();
+    }
 }

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -1373,5 +1373,69 @@ namespace SportlinkFunction.Planner
                 waarschuwingen.Add($"{date.ToString("dddd", NL)}: alleen veld 5 beschikbaar (veld 1-4 training).");
             }
         }
+
+        // ── Team schedule (#70) ──
+
+        public static async Task<TeamScheduleResponse?> GetTeamScheduleAsync(string team)
+        {
+            if (!await PlannerDataAccess.TeamExistsAsync(team))
+                return null;
+
+            var seizoenEinde = await PlannerDataAccess.GetSeasonEndDateAsync() ?? DateOnly.FromDateTime(DateTime.Today.AddMonths(3));
+            var vandaag = DateOnly.FromDateTime(DateTime.Today);
+            var wedstrijden = await PlannerDataAccess.GetFutureMatchesForTeamAsync(team, vandaag, seizoenEinde);
+
+            // Alle zaterdagen van vandaag t/m seizoenseinde
+            var zaterdagen = new List<TeamScheduleZaterdag>();
+            var zaterdag = vandaag;
+            while (zaterdag.DayOfWeek != DayOfWeek.Saturday)
+                zaterdag = zaterdag.AddDays(1);
+
+            while (zaterdag <= seizoenEinde)
+            {
+                var zatStr = zaterdag.ToString("yyyy-MM-dd");
+                var opDeDag = wedstrijden.Where(w => w.Datum == zatStr).ToList();
+
+                string status;
+                TeamScheduleWedstrijd? bezetDoor = null;
+
+                var bezet = opDeDag.FirstOrDefault(w => w.Type == "competitie" || w.Type == "beker");
+                if (bezet != null)
+                {
+                    status = "bezet";
+                    bezetDoor = bezet;
+                }
+                else
+                {
+                    var oefen = opDeDag.FirstOrDefault(w => w.Type == "oefenwedstrijd");
+                    if (oefen != null)
+                    {
+                        status = "oefenwedstrijd";
+                        bezetDoor = oefen;
+                    }
+                    else
+                    {
+                        status = "vrij";
+                    }
+                }
+
+                zaterdagen.Add(new TeamScheduleZaterdag
+                {
+                    Datum = zatStr,
+                    Status = status,
+                    BezetDoor = bezetDoor
+                });
+
+                zaterdag = zaterdag.AddDays(7);
+            }
+
+            return new TeamScheduleResponse
+            {
+                Team = team,
+                SeizoenEinde = seizoenEinde.ToString("yyyy-MM-dd"),
+                Zaterdagen = zaterdagen,
+                Wedstrijden = wedstrijden
+            };
+        }
     }
 }

--- a/FunctionApp/Planner/TeamScheduleHtmlRenderer.cs
+++ b/FunctionApp/Planner/TeamScheduleHtmlRenderer.cs
@@ -1,0 +1,91 @@
+using System.Text;
+
+namespace SportlinkFunction.Planner;
+
+public static class TeamScheduleHtmlRenderer
+{
+    private static readonly System.Globalization.CultureInfo NL = new("nl-NL");
+
+    public static string Render(TeamScheduleResponse schedule)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<!DOCTYPE html><html lang=\"nl\"><head><meta charset=\"UTF-8\">");
+        sb.AppendLine("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">");
+        sb.AppendLine($"<title>Teamschema {System.Net.WebUtility.HtmlEncode(schedule.Team)}</title>");
+        sb.AppendLine("<style>");
+        sb.AppendLine("body{font-family:Arial,sans-serif;margin:24px;background:#f5f5f5;}");
+        sb.AppendLine("h1{color:#2c3e50;}");
+        sb.AppendLine(".kalender{display:flex;flex-wrap:wrap;gap:6px;margin:16px 0;}");
+        sb.AppendLine(".dag{width:90px;text-align:center;padding:6px 4px;border-radius:6px;font-size:12px;font-weight:600;}");
+        sb.AppendLine(".vrij{background:#27ae60;color:#fff;}");
+        sb.AppendLine(".oefenwedstrijd{background:#e67e22;color:#fff;}");
+        sb.AppendLine(".bezet{background:#e74c3c;color:#fff;}");
+        sb.AppendLine("table{border-collapse:collapse;width:100%;background:#fff;border-radius:8px;overflow:hidden;}");
+        sb.AppendLine("th{background:#2c3e50;color:#fff;padding:8px 12px;text-align:left;}");
+        sb.AppendLine("td{padding:8px 12px;border-bottom:1px solid #eee;}");
+        sb.AppendLine(".badge{display:inline-block;padding:2px 8px;border-radius:10px;font-size:11px;font-weight:600;}");
+        sb.AppendLine(".badge-competitie{background:#2980b9;color:#fff;}");
+        sb.AppendLine(".badge-beker{background:#8e44ad;color:#fff;}");
+        sb.AppendLine(".badge-oefenwedstrijd{background:#e67e22;color:#fff;}");
+        sb.AppendLine(".thuis{color:#27ae60;font-weight:600;}");
+        sb.AppendLine(".uit{color:#e74c3c;font-weight:600;}");
+        sb.AppendLine("</style></head><body>");
+
+        sb.AppendLine($"<h1>Teamschema — {System.Net.WebUtility.HtmlEncode(schedule.Team)}</h1>");
+        sb.AppendLine($"<p>Seizoen loopt tot: <strong>{schedule.SeizoenEinde}</strong></p>");
+
+        // Legenda
+        sb.AppendLine("<p><span style=\"display:inline-block;width:14px;height:14px;background:#27ae60;border-radius:3px;margin-right:4px;\"></span>Vrij &nbsp;");
+        sb.AppendLine("<span style=\"display:inline-block;width:14px;height:14px;background:#e67e22;border-radius:3px;margin-right:4px;\"></span>Oefenwedstrijd &nbsp;");
+        sb.AppendLine("<span style=\"display:inline-block;width:14px;height:14px;background:#e74c3c;border-radius:3px;margin-right:4px;\"></span>Bezet (competitie/beker)</p>");
+
+        // Kalender-strook
+        sb.AppendLine("<div class=\"kalender\">");
+        foreach (var zat in schedule.Zaterdagen)
+        {
+            var d = DateOnly.Parse(zat.Datum);
+            var label = d.ToString("d MMM", NL);
+            var cls = zat.Status switch
+            {
+                "bezet" => "dag bezet",
+                "oefenwedstrijd" => "dag oefenwedstrijd",
+                _ => "dag vrij"
+            };
+            sb.AppendLine($"<div class=\"{cls}\" title=\"{System.Net.WebUtility.HtmlEncode(zat.Status)}\">{System.Net.WebUtility.HtmlEncode(label)}</div>");
+        }
+        sb.AppendLine("</div>");
+
+        // Wedstrijdenlijst
+        if (schedule.Wedstrijden.Count == 0)
+        {
+            sb.AppendLine("<p><em>Geen wedstrijden gevonden in de komende periode.</em></p>");
+        }
+        else
+        {
+            sb.AppendLine("<h2>Wedstrijden</h2>");
+            sb.AppendLine("<table><thead><tr><th>Datum</th><th>Aanvang</th><th>Thuis/Uit</th><th>Tegenstander</th><th>Type</th><th>Veld</th></tr></thead><tbody>");
+            foreach (var w in schedule.Wedstrijden)
+            {
+                var d = DateOnly.Parse(w.Datum);
+                var datumLabel = d.ToString("ddd d MMM yyyy", NL);
+                var thuisUitClass = w.ThuisUit == "thuis" ? "thuis" : "uit";
+                var badgeClass = w.Type switch
+                {
+                    "beker" => "badge badge-beker",
+                    "oefenwedstrijd" => "badge badge-oefenwedstrijd",
+                    _ => "badge badge-competitie"
+                };
+                sb.AppendLine($"<tr><td>{System.Net.WebUtility.HtmlEncode(datumLabel)}</td>" +
+                    $"<td>{System.Net.WebUtility.HtmlEncode(w.AanvangsTijd)}</td>" +
+                    $"<td><span class=\"{thuisUitClass}\">{System.Net.WebUtility.HtmlEncode(w.ThuisUit)}</span></td>" +
+                    $"<td>{System.Net.WebUtility.HtmlEncode(w.Tegenstander)}</td>" +
+                    $"<td><span class=\"{badgeClass}\">{System.Net.WebUtility.HtmlEncode(w.Type)}</span></td>" +
+                    $"<td>{System.Net.WebUtility.HtmlEncode(w.Veld ?? "")}</td></tr>");
+            }
+            sb.AppendLine("</tbody></table>");
+        }
+
+        sb.AppendLine("</body></html>");
+        return sb.ToString();
+    }
+}

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -128,6 +128,42 @@ namespace SportlinkFunction
             }
         }
 
+        /// <summary>
+        /// Berekent een deterministische 12-karakter hex fingerprint voor een exception.
+        /// Identieke fouten (zelfde type, genormaliseerd bericht, zelfde callsite) geven altijd
+        /// dezelfde fingerprint — essentieel voor deduplicatie van GitHub Issues.
+        /// </summary>
+        public static string ComputeFingerprint(Exception ex)
+        {
+            var raw = $"{ex.GetType().FullName}|{NormalizeMessage(ex.Message)}|{GetCallerFrame(ex)}";
+            using var sha = System.Security.Cryptography.SHA256.Create();
+            var bytes = sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(raw));
+            return Convert.ToHexString(bytes)[..12].ToLower();
+        }
+
+        private static string NormalizeMessage(string message)
+        {
+            if (string.IsNullOrEmpty(message)) return "";
+            // Verwijder variabele delen zodat dezelfde fout altijd dezelfde fingerprint geeft
+            var s = message;
+            s = System.Text.RegularExpressions.Regex.Replace(s, @"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b", "<guid>");
+            s = System.Text.RegularExpressions.Regex.Replace(s, @"\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2})?", "<date>");
+            s = System.Text.RegularExpressions.Regex.Replace(s, @"\b\d+\b", "<n>");
+            return s.Trim();
+        }
+
+        private static string GetCallerFrame(Exception ex)
+        {
+            if (ex.StackTrace == null) return "unknown";
+            foreach (var line in ex.StackTrace.Split('\n'))
+            {
+                var trimmed = line.Trim();
+                if (trimmed.StartsWith("at SportlinkFunction.", StringComparison.Ordinal))
+                    return trimmed.Split('(')[0].Replace("at ", "").Trim();
+            }
+            return "external";
+        }
+
         public static class SeasonHelper
         {
             /// <summary>


### PR DESCRIPTION
## Summary

### #104 — Error fingerprinting
- `SystemUtilities.ComputeFingerprint(Exception)` toegevoegd aan `Utilities.cs`
- Deterministische 12-karakter hex hash van exception type + genormaliseerd bericht + SportlinkFunction callsite
- `NormalizeMessage` verwijdert variabele GUIDs, datums en getallen; identieke fouten → identieke fingerprint
- Basis voor deduplicatie in de v2.1 zelfherstellende GitHub Issues pipeline

### #70 — Team-schedule endpoint
- `GET /api/planner/team-schedule?team=VRC+JO11-1` → toekomstige wedstrijden t/m seizoenseinde
- Zaterdag-overzicht met status `vrij` / `oefenwedstrijd` / `bezet`
- Bronnen: `his.matches` (competitie + beker) en `planner.GeplandeWedstrijden` (oefenwedstrijden)
- `?format=html` rendert een gekleurd rapport
- Onbekend team → 404; ontbrekende parameter → 400
- Nieuwe bestanden: `TeamScheduleHtmlRenderer.cs`, uitbreidingen in `PlannerModels`, `PlannerDataAccess`, `PlannerService`, `PlannerFunction`

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 13/13 passed
- [x] Health + `Test-App.ps1` — 28/28 checks geslaagd
- [x] Team-schedule smoke test: 200 OK, 404 onbekend team, 400 geen team

Closes #70, #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)