### PR TITLE
feat(#105,#106): GitHubIssueReporter — automatisch issues rapporteren bij exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ _Wijzigingen op `v2/develop` die nog niet zijn vrijgegeven._
 
 ### Added
 - **Automatische herstart bij schema-wijziging** (#27): wanneer een beheerder het ophaalschema wijzigt via de Instellingen-pagina, werkt de applicatie de Azure App Setting automatisch bij via de Azure Management API — de Function App herstart zichzelf zonder handmatige actie. CRON-expressies worden gevalideerd vóór opslaan. De Instellingen-pagina toont een leesbare omschrijving van het schema én de eerstvolgende drie uitvoertijden.
+- **Automatisch GitHub Issues bij exceptions** (#105, #106): onverwachte exceptions in de timer- en HTTP-triggers worden automatisch gerapporteerd als GitHub Issues. Deduplicatie op fingerprint: bestaand open issue krijgt een comment, nieuw issue wordt aangemaakt met labels `bug` en `type: bug`. Rate-limiting voorkomt dat hetzelfde issue meer dan één keer per 24 uur gerapporteerd wordt. Vereist configuratie van `GitHubPat`, `GitHubOwner` en `GitHubRepo` — als `GitHubPat` niet is ingesteld, wordt alles stil overgeslagen.
 
 ### Added
 - **Team-schedule endpoint** (#70): `GET /api/planner/team-schedule?team=VRC+JO11-1` geeft een overzicht van alle nog te spelen wedstrijden per team tot seizoenseinde, inclusief een gesorteerde zaterdag-lijst met status `vrij`/`oefenwedstrijd`/`bezet`. Ondersteunt `?format=html` voor een leesbaar HTML-rapport. Onbekend team → 404; ontbrekende parameter → 400.

--- a/FunctionApp/Function1.cs
+++ b/FunctionApp/Function1.cs
@@ -4,6 +4,7 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using SportlinkFunction.Infrastructure;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -43,6 +44,7 @@ namespace SportlinkFunction
             catch (Exception ex)
             {
                 log.LogError($"Error: {ex.Message}");
+                await GitHubIssueReporter.ReportAsync(ex, "FetchAndStoreApiData", log);
             }
         }
 
@@ -95,6 +97,7 @@ namespace SportlinkFunction
             catch (Exception ex)
             {
                 log.LogError($"Error: {ex.Message}");
+                await GitHubIssueReporter.ReportAsync(ex, "SyncMatchesHttp", log);
                 return new StatusCodeResult(500);
             }
         }

--- a/FunctionApp/Infrastructure/GitHubIssueReporter.cs
+++ b/FunctionApp/Infrastructure/GitHubIssueReporter.cs
@@ -1,0 +1,186 @@
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace SportlinkFunction.Infrastructure;
+
+/// <summary>
+/// Rapporteert onverwachte exceptions als GitHub Issues.
+/// Deduplicatie op fingerprint (zie SystemUtilities.ComputeFingerprint):
+///   - Bestaand open issue → voeg comment toe
+///   - Geen open issue → maak nieuw issue aan
+///   - Al gerapporteerd binnen 24u → overslaan (rate-limiting, issue #106)
+///
+/// Vereiste environment variables:
+///   GitHubPat   — fine-grained PAT met issues:write scope (zie #103)
+///   GitHubOwner — GitHub organisatie of gebruikersnaam (default: env GITHUB_REPOSITORY_OWNER)
+///   GitHubRepo  — repository naam (default: "Sportlink-wedstrijdzaken")
+///
+/// Wanneer GitHubPat niet geconfigureerd is, wordt alles stil overgeslagen.
+/// </summary>
+public static class GitHubIssueReporter
+{
+    private static readonly Dictionary<string, DateTime> _recentlyReported = new();
+    private static readonly object _lock = new();
+
+    private const int MaxStackTraceLines = 50;
+    private const int RateLimitHours = 24;
+
+    public static async Task ReportAsync(Exception ex, string functionName, ILogger log)
+    {
+        var pat = Environment.GetEnvironmentVariable("GitHubPat");
+        if (string.IsNullOrWhiteSpace(pat))
+        {
+            log.LogDebug("GitHubPat niet geconfigureerd — exception-reporting naar GitHub overgeslagen");
+            return;
+        }
+
+        var owner = Environment.GetEnvironmentVariable("GitHubOwner")
+                 ?? Environment.GetEnvironmentVariable("GITHUB_REPOSITORY_OWNER")
+                 ?? "";
+        var repo = Environment.GetEnvironmentVariable("GitHubRepo") ?? "Sportlink-wedstrijdzaken";
+
+        if (string.IsNullOrWhiteSpace(owner))
+        {
+            log.LogWarning("GitHubOwner niet geconfigureerd — issue-reporting overgeslagen");
+            return;
+        }
+
+        var fp = SystemUtilities.ComputeFingerprint(ex);
+
+        lock (_lock)
+        {
+            if (_recentlyReported.TryGetValue(fp, out var last)
+                && (DateTime.UtcNow - last).TotalHours < RateLimitHours)
+            {
+                log.LogInformation("Exception fp:{Fp} al gerapporteerd binnen {H}u — overgeslagen", fp, RateLimitHours);
+                return;
+            }
+            _recentlyReported[fp] = DateTime.UtcNow;
+        }
+
+        try
+        {
+            using var http = BuildHttpClient(pat);
+            var existing = await SearchIssueAsync(http, owner, repo, fp, log);
+
+            if (existing.HasValue)
+                await AddCommentAsync(http, owner, repo, existing.Value, ex, functionName, log);
+            else
+                await CreateIssueAsync(http, owner, repo, fp, ex, functionName, log);
+        }
+        catch (Exception reportEx)
+        {
+            log.LogWarning(reportEx, "GitHubIssueReporter: fout bij rapporteren van exception fp:{Fp}", fp);
+        }
+    }
+
+    private static HttpClient BuildHttpClient(string pat)
+    {
+        var http = new HttpClient();
+        http.DefaultRequestHeaders.UserAgent.ParseAdd("SportlinkFunction/2.0");
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", pat);
+        http.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+        http.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+        return http;
+    }
+
+    private static async Task<int?> SearchIssueAsync(
+        HttpClient http, string owner, string repo, string fp, ILogger log)
+    {
+        var query = Uri.EscapeDataString($"[fp:{fp}] in:title repo:{owner}/{repo} is:open");
+        var url = $"https://api.github.com/search/issues?q={query}&per_page=1";
+        var resp = await http.GetAsync(url);
+        if (!resp.IsSuccessStatusCode)
+        {
+            log.LogWarning("GitHub search API: HTTP {Status}", (int)resp.StatusCode);
+            return null;
+        }
+
+        var json = await resp.Content.ReadAsStringAsync();
+        dynamic result = JsonConvert.DeserializeObject<dynamic>(json)!;
+        int count = (int)result.total_count;
+        if (count > 0)
+        {
+            int number = (int)result.items[0].number;
+            log.LogInformation("Bestaand GitHub issue #{Nr} gevonden voor fp:{Fp}", number, fp);
+            return number;
+        }
+        return null;
+    }
+
+    private static async Task AddCommentAsync(
+        HttpClient http, string owner, string repo, int issueNumber,
+        Exception ex, string functionName, ILogger log)
+    {
+        var nlZone = TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time");
+        var nlTijd = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, nlZone);
+
+        var body = $"🔁 Opnieuw opgetreden op {nlTijd:dd-MM-yyyy HH:mm} in functie `{functionName}`\n\n"
+                 + $"**Exception:** `{ex.GetType().FullName}: {ex.Message}`\n\n"
+                 + $"**Stacktrace:**\n```\n{TruncateStackTrace(ex.StackTrace)}\n```";
+
+        var payload = JsonConvert.SerializeObject(new { body });
+        var url = $"https://api.github.com/repos/{owner}/{repo}/issues/{issueNumber}/comments";
+        var resp = await http.PostAsync(url, new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        if (resp.IsSuccessStatusCode)
+            log.LogInformation("Comment toegevoegd aan GitHub issue #{Nr}", issueNumber);
+        else
+            log.LogWarning("GitHub comment API: HTTP {Status}", (int)resp.StatusCode);
+    }
+
+    private static async Task CreateIssueAsync(
+        HttpClient http, string owner, string repo, string fp,
+        Exception ex, string functionName, ILogger log)
+    {
+        var nlZone = TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time");
+        var nlTijd = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, nlZone);
+
+        var title = $"[bug][fp:{fp}] {ex.GetType().Name}: {TruncateMessage(ex.Message)}";
+        var body = $"## Automatisch gerapporteerde exception\n\n"
+                 + $"**Tijdstip:** {nlTijd:dd-MM-yyyy HH:mm} (Europe/Amsterdam)\n"
+                 + $"**Functie:** `{functionName}`\n"
+                 + $"**Fingerprint:** `{fp}`\n\n"
+                 + $"**Exception:** `{ex.GetType().FullName}`\n"
+                 + $"**Bericht:** {ex.Message}\n\n"
+                 + $"**Stacktrace:**\n```\n{TruncateStackTrace(ex.StackTrace)}\n```\n\n"
+                 + $"*Automatisch aangemaakt door GitHubIssueReporter (v2.1 zelfherstellend systeem)*";
+
+        var payload = JsonConvert.SerializeObject(new
+        {
+            title,
+            body,
+            labels = new[] { "bug", "type: bug" }
+        });
+
+        var url = $"https://api.github.com/repos/{owner}/{repo}/issues";
+        var resp = await http.PostAsync(url, new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        if (resp.IsSuccessStatusCode)
+        {
+            var json = await resp.Content.ReadAsStringAsync();
+            dynamic created = JsonConvert.DeserializeObject<dynamic>(json)!;
+            log.LogInformation("GitHub issue #{Nr} aangemaakt voor fp:{Fp}", (int)created.number, fp);
+        }
+        else
+        {
+            log.LogWarning("GitHub issue aanmaken mislukt: HTTP {Status}", (int)resp.StatusCode);
+        }
+    }
+
+    private static string TruncateStackTrace(string? stackTrace)
+    {
+        if (string.IsNullOrEmpty(stackTrace)) return "(geen stacktrace)";
+        var lines = stackTrace.Split('\n');
+        if (lines.Length <= MaxStackTraceLines) return stackTrace.Trim();
+        return string.Join('\n', lines.Take(MaxStackTraceLines)) + $"\n... ({lines.Length - MaxStackTraceLines} regels weggelaten)";
+    }
+
+    private static string TruncateMessage(string message)
+    {
+        if (message.Length <= 120) return message;
+        return message[..117] + "...";
+    }
+}

--- a/FunctionApp/local.settings.template.json
+++ b/FunctionApp/local.settings.template.json
@@ -20,6 +20,9 @@
     "EMAIL_POLL_SCHEDULE": "0 0 * * * *",
     "AzureSubscriptionId": "",
     "AzureResourceGroupName": "",
-    "AzureFunctionAppName": ""
+    "AzureFunctionAppName": "",
+    "GitHubPat": "",
+    "GitHubOwner": "",
+    "GitHubRepo": "Sportlink-wedstrijdzaken"
   }
 }


### PR DESCRIPTION
## Samenvatting

- **#105** — `GitHubIssueReporter` klasse in `FunctionApp/Infrastructure/`: rapporteert onverwachte exceptions als GitHub Issues via de GitHub REST API
- **#106** — 24-uurs rate-limiting per fingerprint: hetzelfde issue wordt maximaal één keer per dag gerapporteerd

## Werking

1. Exception treedt op in `FetchAndStoreApiData` of `SyncMatchesHttp`
2. Fingerprint berekend via `SystemUtilities.ComputeFingerprint(ex)` (#104)
3. Zoekt naar bestaand open issue met `[fp:XXX]` in de titel (GitHub Search API)
4. Gevonden: comment toegevoegd — Niet gevonden: nieuw issue aangemaakt met labels `bug` en `type: bug`
5. Als `GitHubPat` niet is ingesteld → stil overgeslagen (geen breaking change voor bestaande installaties)

## Configuratie (nieuw in local.settings.template.json)

| Setting | Beschrijving |
|---|---|
| `GitHubPat` | Fine-grained PAT met `issues:write` scope (zie #103) |
| `GitHubOwner` | GitHub gebruikersnaam of organisatie |
| `GitHubRepo` | Repository naam (default: `Sportlink-wedstrijdzaken`) |

## Test plan

- [ ] Build groen (`dotnet build`)
- [ ] `GitHubPat` leeg → geen exceptions, geen GitHub API calls
- [ ] Security Gate groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)