### PR TITLE
feat(#129): Intelligente Feedback Widget — FEEDBACK-knop + AI-gestuurde GitHub Issue aanmaak

### DIFF
--- a/BlazorAdmin/Layout/MainLayout.razor
+++ b/BlazorAdmin/Layout/MainLayout.razor
@@ -6,8 +6,9 @@
     </div>
 
     <main>
-        <div class="top-row px-4">
+        <div class="top-row px-4 d-flex align-items-center justify-content-end">
             <span class="text-muted small me-3">v@(Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "?")</span>
+            <FeedbackWidget />
             <a href="https://github.com/Jaapbeus/Sportlink-wedstrijdzaken" target="_blank">About</a>
         </div>
 

--- a/BlazorAdmin/Models/FeedbackModels.cs
+++ b/BlazorAdmin/Models/FeedbackModels.cs
@@ -1,0 +1,35 @@
+namespace BlazorAdmin.Models;
+
+public class FeedbackContext
+{
+    public string Pagina { get; set; } = "";
+    public string Versie { get; set; } = "";
+    public string Rol { get; set; } = "";
+    public string Browser { get; set; } = "";
+}
+
+public class FeedbackVraagAntwoord
+{
+    public string Vraag { get; set; } = "";
+    public string Antwoord { get; set; } = "";
+}
+
+public class FeedbackValidateRequest
+{
+    public string Type { get; set; } = "";
+    public string Beschrijving { get; set; } = "";
+    public List<FeedbackVraagAntwoord> VragenAntwoorden { get; set; } = [];
+    public FeedbackContext? Context { get; set; }
+}
+
+public class FeedbackValidateResponse
+{
+    public bool Volledig { get; set; }
+    public List<string> Vragen { get; set; } = [];
+}
+
+public class FeedbackSubmitResponse
+{
+    public int IssueNummer { get; set; }
+    public string IssueUrl { get; set; } = "";
+}

--- a/BlazorAdmin/Services/AdminApiClient.cs
+++ b/BlazorAdmin/Services/AdminApiClient.cs
@@ -107,6 +107,14 @@ public class AdminApiClient
     public async Task<ApiResult<TestEmailResponse>> TestEmailAsync(TestEmailRequest dto)
         => await PostAsync<TestEmailResponse>("api/test/email", dto);
 
+    // ── Feedback widget ──
+
+    public async Task<ApiResult<FeedbackValidateResponse>> ValidateFeedbackAsync(FeedbackValidateRequest dto)
+        => await PostAsync<FeedbackValidateResponse>("api/feedback/validate", dto);
+
+    public async Task<ApiResult<FeedbackSubmitResponse>> SubmitFeedbackAsync(FeedbackValidateRequest dto)
+        => await PostAsync<FeedbackSubmitResponse>("api/feedback/submit", dto);
+
     // ── HTTP-helpers ──
 
     private async Task<ApiResult<T>> GetAsync<T>(string path)

--- a/BlazorAdmin/Shared/FeedbackWidget.razor
+++ b/BlazorAdmin/Shared/FeedbackWidget.razor
@@ -1,0 +1,269 @@
+@using System.Reflection
+@inject AdminApiClient Api
+@inject IJSRuntime JS
+@inject IAuthService Auth
+
+<button class="btn btn-warning btn-sm me-3" @onclick="OpenAsync">FEEDBACK</button>
+
+@if (_isOpen)
+{
+    <div class="modal fade show d-block" tabindex="-1" style="background:rgba(0,0,0,.45)" @onclick="SluitAlsAchtergrond">
+        <div class="modal-dialog" @onclick:stopPropagation="true">
+            <div class="modal-content">
+
+                @if (_stap == Stap.Formulier)
+                {
+                    <div class="modal-header">
+                        <h5 class="modal-title">Feedback geven</h5>
+                        <button type="button" class="btn-close" @onclick="Sluit"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label fw-semibold">Wat wil je melden?</label>
+                            <div class="btn-group w-100" role="group">
+                                @foreach (var optie in new[] { "Fout", "Verzoek", "Vraag" })
+                                {
+                                    <input type="radio" class="btn-check" id="type-@optie"
+                                           name="feedbackType" value="@optie"
+                                           checked="@(_type == optie)"
+                                           @onchange="() => { _type = optie; _vragen.Clear(); _antwoorden.Clear(); }" />
+                                    <label class="btn btn-outline-secondary" for="type-@optie">@optie</label>
+                                }
+                            </div>
+                        </div>
+
+                        <div class="mb-3">
+                            <label class="form-label fw-semibold">Omschrijving</label>
+                            <textarea class="form-control" rows="4" placeholder="Beschrijf in eigen woorden wat er mis gaat of wat je wilt kunnen doen…"
+                                      @bind="_beschrijving"></textarea>
+                        </div>
+
+                        @if (_vragen.Count > 0)
+                        {
+                            <div class="alert alert-info py-2 mb-3">
+                                <small>We hebben nog wat extra informatie nodig:</small>
+                            </div>
+                            @for (var i = 0; i < _vragen.Count; i++)
+                            {
+                                var idx = i;
+                                <div class="mb-3">
+                                    <label class="form-label small">@_vragen[idx]</label>
+                                    <input type="text" class="form-control form-control-sm"
+                                           value="@(_antwoorden.Count > idx ? _antwoorden[idx] : "")"
+                                           @oninput="e => ZetAntwoord(idx, e.Value?.ToString() ?? string.Empty)" />
+                                </div>
+                            }
+                        }
+
+                        @if (_foutmelding != null)
+                        {
+                            <div class="alert alert-danger py-2 mt-2">@_foutmelding</div>
+                        }
+                    </div>
+                    <div class="modal-footer">
+                        <button class="btn btn-secondary" @onclick="Sluit">Annuleren</button>
+                        <button class="btn btn-primary" disabled="@_bezig" @onclick="ControlerenAsync">
+                            @if (_bezig)
+                            { <span class="spinner-border spinner-border-sm me-1"></span> }
+                            @(_vragen.Count > 0 ? "Opnieuw controleren" : "Controleren")
+                        </button>
+                    </div>
+                }
+
+                else if (_stap == Stap.Overzicht)
+                {
+                    <div class="modal-header">
+                        <h5 class="modal-title">Overzicht</h5>
+                        <button type="button" class="btn-close" @onclick="Sluit"></button>
+                    </div>
+                    <div class="modal-body">
+                        <p class="text-muted small mb-3">
+                            Dit wordt als melding doorgestuurd naar de ontwikkelaar als GitHub issue.
+                        </p>
+                        <dl class="row mb-0 small">
+                            <dt class="col-4">Type</dt>
+                            <dd class="col-8">@_type</dd>
+                            <dt class="col-4">Pagina</dt>
+                            <dd class="col-8">@(_context?.Pagina ?? "—")</dd>
+                            <dt class="col-4">Versie</dt>
+                            <dd class="col-8">@(_context?.Versie ?? "?")</dd>
+                        </dl>
+                        <hr class="my-2" />
+                        <p class="small mb-0"><em>@_beschrijving</em></p>
+                        @if (_vragen.Count > 0)
+                        {
+                            <ul class="list-unstyled mt-2 mb-0 small">
+                                @for (var i = 0; i < _vragen.Count; i++)
+                                {
+                                    <li><strong>@_vragen[i]</strong><br />@(_antwoorden.Count > i ? _antwoorden[i] : "—")</li>
+                                }
+                            </ul>
+                        }
+                        @if (_foutmelding != null)
+                        {
+                            <div class="alert alert-danger py-2 mt-2">@_foutmelding</div>
+                        }
+                    </div>
+                    <div class="modal-footer">
+                        <button class="btn btn-secondary" @onclick="() => { _stap = Stap.Formulier; _foutmelding = null; }">← Terug</button>
+                        <button class="btn btn-success" disabled="@_bezig" @onclick="VersturenAsync">
+                            @if (_bezig)
+                            { <span class="spinner-border spinner-border-sm me-1"></span> }
+                            Versturen
+                        </button>
+                    </div>
+                }
+
+                else if (_stap == Stap.Bevestiging)
+                {
+                    <div class="modal-header border-0">
+                        <h5 class="modal-title text-success">Bedankt!</h5>
+                        <button type="button" class="btn-close" @onclick="Sluit"></button>
+                    </div>
+                    <div class="modal-body text-center py-4">
+                        <div class="fs-1 mb-2">✅</div>
+                        <p>Je melding is ontvangen en staat klaar voor de ontwikkelaar.</p>
+                        <a href="@_issueUrl" target="_blank" rel="noopener" class="btn btn-outline-primary btn-sm">
+                            Issue #@_issueNummer bekijken
+                        </a>
+                    </div>
+                    <div class="modal-footer border-0">
+                        <button class="btn btn-secondary" @onclick="Sluit">Sluiten</button>
+                    </div>
+                }
+
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private bool _isOpen;
+    private bool _bezig;
+    private string? _foutmelding;
+    private Stap _stap = Stap.Formulier;
+
+    private string _type = "Fout";
+    private string _beschrijving = "";
+    private List<string> _vragen = [];
+    private List<string> _antwoorden = [];
+    private FeedbackContext? _context;
+
+    private int _issueNummer;
+    private string _issueUrl = "";
+
+    private enum Stap { Formulier, Overzicht, Bevestiging }
+
+    private async Task OpenAsync()
+    {
+        _isOpen = true;
+        _stap = Stap.Formulier;
+        _beschrijving = "";
+        _type = "Fout";
+        _vragen = [];
+        _antwoorden = [];
+        _foutmelding = null;
+
+        var pagina = await JS.InvokeAsync<string>("eval", "window.location.pathname");
+        var browser = await JS.InvokeAsync<string>("eval", "navigator.userAgent");
+        var versie = typeof(FeedbackWidget).Assembly.GetName().Version?.ToString(3) ?? "?";
+        var rol = Auth.IsAdmin ? "admin" : "gebruiker";
+
+        _context = new FeedbackContext
+        {
+            Pagina = pagina,
+            Versie = versie,
+            Rol = rol,
+            Browser = browser.Length > 120 ? browser[..120] : browser
+        };
+    }
+
+    private void Sluit()
+    {
+        _isOpen = false;
+        _foutmelding = null;
+    }
+
+    private void SluitAlsAchtergrond() => Sluit();
+
+    private void ZetAntwoord(int index, string waarde)
+    {
+        while (_antwoorden.Count <= index)
+            _antwoorden.Add("");
+        _antwoorden[index] = waarde;
+    }
+
+    private async Task ControlerenAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_beschrijving) || _beschrijving.Trim().Length < 10)
+        {
+            _foutmelding = "Vul een beschrijving in van minimaal 10 tekens.";
+            return;
+        }
+
+        _bezig = true;
+        _foutmelding = null;
+
+        var request = BouwRequest();
+        var result = await Api.ValidateFeedbackAsync(request);
+
+        _bezig = false;
+
+        if (!result.Success)
+        {
+            _foutmelding = result.ErrorMessage ?? "Controleren mislukt. Probeer het opnieuw.";
+            return;
+        }
+
+        if (result.Data!.Volledig)
+        {
+            _stap = Stap.Overzicht;
+        }
+        else
+        {
+            _vragen = result.Data.Vragen ?? [];
+            _antwoorden = new List<string>(new string[_vragen.Count]);
+        }
+    }
+
+    private async Task VersturenAsync()
+    {
+        _bezig = true;
+        _foutmelding = null;
+
+        var request = BouwRequest();
+        var result = await Api.SubmitFeedbackAsync(request);
+
+        _bezig = false;
+
+        if (!result.Success)
+        {
+            _foutmelding = result.ErrorMessage ?? "Indienen mislukt. Probeer het opnieuw.";
+            return;
+        }
+
+        _issueNummer = result.Data!.IssueNummer;
+        _issueUrl = result.Data.IssueUrl;
+        _stap = Stap.Bevestiging;
+    }
+
+    private FeedbackValidateRequest BouwRequest()
+    {
+        var qa = _vragen
+            .Select((v, i) => new FeedbackVraagAntwoord
+            {
+                Vraag = v,
+                Antwoord = _antwoorden.Count > i ? _antwoorden[i] : ""
+            })
+            .Where(x => !string.IsNullOrWhiteSpace(x.Antwoord))
+            .ToList();
+
+        return new FeedbackValidateRequest
+        {
+            Type = _type,
+            Beschrijving = _beschrijving.Trim(),
+            VragenAntwoorden = qa,
+            Context = _context
+        };
+    }
+}

--- a/BlazorAdmin/_Imports.razor
+++ b/BlazorAdmin/_Imports.razor
@@ -10,3 +10,4 @@
 @using BlazorAdmin.Layout
 @using BlazorAdmin.Models
 @using BlazorAdmin.Services
+@using BlazorAdmin.Shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 _Wijzigingen op `v2/develop` die nog niet zijn vrijgegeven._
 
+### Added
+- **Intelligente Feedback Widget** (#129): Beheerders kunnen rechtsboven in de Admin GUI op **FEEDBACK** klikken om een fout of wens te melden. Na invullen valideert GPT-4o-mini automatisch of de beschrijving volledig genoeg is — als dat zo is gaat de melding direct door, anders verschijnen gericht aanvulvragen (max 3). De uiteindelijke beschrijving wordt door de AI omgezet naar een gestructureerd GitHub issue met acceptatiecriteria, dat Claude Code autonoom kan oppakken.
+
 ### Fixed
 - **Email-log isolatie** (#119): `planner.EmailVerwerking` had als enige v2-tabel geen `ClubCode` kolom. Beheerders van club A konden daardoor de email-log van club B zien. Kolom toegevoegd; bestaande rijen krijgen standaardwaarde via migratie.
 

--- a/FunctionApp/Feedback/FeedbackFunction.cs
+++ b/FunctionApp/Feedback/FeedbackFunction.cs
@@ -1,0 +1,405 @@
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OpenAI.Chat;
+
+namespace SportlinkFunction.Feedback;
+
+/// <summary>
+/// Feedback widget API — issue #129.
+///
+/// POST /api/feedback/validate
+///   Valideert of de gebruikersbeschrijving voldoende informatie bevat.
+///   Geeft gerichte aanvulvragen terug als er gaten zijn.
+///   Geen rate limiting — validatie is goedkoop en gebruiksvriendelijk.
+///
+/// POST /api/feedback/submit
+///   Structureert de feedback met GPT-4o-mini en maakt een GitHub Issue aan.
+///   Rate limiting: max 5 per 10 minuten (globaal).
+/// </summary>
+public static class FeedbackFunction
+{
+    private const int MaxSubmissiesPerVenster = 5;
+    private static readonly TimeSpan RateLimitVenster = TimeSpan.FromMinutes(10);
+    private static readonly ConcurrentQueue<DateTime> _submits = new();
+    private static readonly object _rateLock = new();
+
+    // ── Validate ──────────────────────────────────────────────────────────────
+
+    [Function("FeedbackValidate")]
+    public static async Task<IActionResult> Validate(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "feedback/validate")] HttpRequest req,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("FeedbackValidate");
+        try
+        {
+            var body = await new StreamReader(req.Body).ReadToEndAsync();
+            var dto = JsonConvert.DeserializeObject<FeedbackRequest>(body);
+            if (dto == null || string.IsNullOrWhiteSpace(dto.Beschrijving))
+                return new BadRequestObjectResult(new { error = "Type en beschrijving zijn verplicht." });
+
+            var apiKey = Environment.GetEnvironmentVariable("OpenAiApiKey")
+                ?? throw new InvalidOperationException("OpenAiApiKey niet geconfigureerd");
+
+            var chatClient = new ChatClient("gpt-4o-mini", apiKey);
+            var result = await ValideerVolledigheid(chatClient, dto, log);
+
+            return new OkObjectResult(result);
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij feedback validatie");
+            return new ObjectResult(new { error = "Validatie tijdelijk niet beschikbaar." }) { StatusCode = 500 };
+        }
+    }
+
+    // ── Submit ─────────────────────────────────────────────────────────────────
+
+    [Function("FeedbackSubmit")]
+    public static async Task<IActionResult> Submit(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "feedback/submit")] HttpRequest req,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("FeedbackSubmit");
+
+        if (!TryAcquireSubmitSlot())
+            return new ObjectResult(new { error = $"Limiet bereikt: maximaal {MaxSubmissiesPerVenster} meldingen per 10 minuten." }) { StatusCode = 429 };
+
+        try
+        {
+            var body = await new StreamReader(req.Body).ReadToEndAsync();
+            var dto = JsonConvert.DeserializeObject<FeedbackRequest>(body);
+            if (dto == null || string.IsNullOrWhiteSpace(dto.Beschrijving))
+                return new BadRequestObjectResult(new { error = "Beschrijving is verplicht." });
+
+            var pat = Environment.GetEnvironmentVariable("GitHubPat");
+            var owner = Environment.GetEnvironmentVariable("GitHubOwner")
+                     ?? Environment.GetEnvironmentVariable("GITHUB_REPOSITORY_OWNER") ?? "";
+            var repo = Environment.GetEnvironmentVariable("GitHubRepo") ?? "Sportlink-wedstrijdzaken";
+
+            if (string.IsNullOrWhiteSpace(pat) || string.IsNullOrWhiteSpace(owner))
+            {
+                log.LogWarning("GitHubPat/GitHubOwner niet geconfigureerd — feedback-submit niet mogelijk");
+                return new ObjectResult(new { error = "GitHub-integratie niet geconfigureerd. Neem contact op met de beheerder." }) { StatusCode = 503 };
+            }
+
+            var apiKey = Environment.GetEnvironmentVariable("OpenAiApiKey")
+                ?? throw new InvalidOperationException("OpenAiApiKey niet geconfigureerd");
+
+            var chatClient = new ChatClient("gpt-4o-mini", apiKey);
+            var structured = await StructureerIssue(chatClient, dto, log);
+
+            var issueBody = BouwIssueBody(dto, structured);
+            var labels = KiesLabels(dto.Type);
+            var title = Sanitize(structured.Title, 80);
+
+            var (issueNummer, issueUrl) = await MaakGitHubIssueAsync(pat, owner, repo, title, issueBody, labels, log);
+
+            return new OkObjectResult(new { issueNummer, issueUrl });
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij feedback submit");
+            return new ObjectResult(new { error = "Indienen mislukt. Probeer het opnieuw." }) { StatusCode = 500 };
+        }
+    }
+
+    // ── AI: volledigheid valideren ─────────────────────────────────────────────
+
+    private static async Task<ValidateResponse> ValideerVolledigheid(
+        ChatClient chatClient, FeedbackRequest dto, ILogger log)
+    {
+        var beschrijving = Sanitize(dto.Beschrijving, 2000);
+        var paginaInfo = string.IsNullOrWhiteSpace(dto.Context?.Pagina) ? "" : $"Pagina: {dto.Context.Pagina}\n";
+        var qaBlok = BouwQaBlok(dto.VragenAntwoorden);
+
+        var systemPrompt = """
+            Je beoordeelt of feedback van een clubbeheerder voldoende informatie bevat om te worden opgelost.
+
+            Regels per type:
+            - 'Fout': minimaal vereist — wat gaat er mis, en wat werd verwacht.
+            - 'Verzoek': minimaal vereist — wat wil men bereiken.
+            - 'Vraag': bijna altijd voldoende tenzij compleet onduidelijk.
+
+            Geef uitsluitend JSON in dit formaat:
+            { "volledig": true/false, "vragen": ["..."] }
+
+            Als volledig: lege vragen-array.
+            Als niet volledig: max 3 korte, vriendelijke aanvulvragen in begrijpelijk Nederlands.
+            Nooit technisch jargon. Nooit vragen naar dingen die al beantwoord zijn.
+            """;
+
+        var userPrompt = $"""
+            Type: {dto.Type}
+            {paginaInfo}Beschrijving: "{beschrijving}"
+            {qaBlok}
+            """;
+
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage(systemPrompt),
+            new UserChatMessage(userPrompt)
+        };
+
+        var options = new ChatCompletionOptions
+        {
+            Temperature = 0.1f,
+            ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat()
+        };
+
+        var completion = await chatClient.CompleteChatAsync(messages, options);
+        var json = completion.Value.Content[0].Text;
+        log.LogDebug("Validate AI response: {Json}", json);
+
+        var parsed = JObject.Parse(json);
+        var volledig = parsed["volledig"]?.Value<bool>() ?? false;
+        var vragen = parsed["vragen"]?.ToObject<List<string>>() ?? [];
+
+        return new ValidateResponse(volledig, vragen);
+    }
+
+    // ── AI: issue structureren ─────────────────────────────────────────────────
+
+    private static async Task<StructuredIssue> StructureerIssue(
+        ChatClient chatClient, FeedbackRequest dto, ILogger log)
+    {
+        var beschrijving = Sanitize(dto.Beschrijving, 2000);
+        var qaBlok = BouwQaBlok(dto.VragenAntwoorden);
+
+        var systemPrompt = """
+            Je vertaalt gebruikersfeedback van een clubbeheerder naar een gestructureerd GitHub issue voor een developer.
+
+            Geef uitsluitend JSON in dit formaat:
+            {
+              "title": "korte issue titel, max 70 tekens",
+              "samenvatting": "1-2 zinnen die het probleem of verzoek beschrijven voor de developer",
+              "acceptatiecriteria": ["concreet testbaar criterium", "criterium 2"]
+            }
+
+            Voor een bug:
+            - Titel: beschrijft wat er mis gaat (niet 'gebruiker meldt...')
+            - Samenvatting: wat de gebruiker deed, wat er fout ging, wat verwacht werd
+            - Criteria: testbare verbeteringen (elk < 80 tekens, max 5 stuks)
+
+            Voor een verzoek:
+            - Titel: "Voeg X toe" of "Maak X mogelijk"
+            - Samenvatting: gewenste gedrag en reden
+            - Criteria: implementatiestappen als checkbox
+
+            Schrijf technisch, voor een developer, niet voor de gebruiker.
+            """;
+
+        var userPrompt = $"""
+            Type: {dto.Type}
+            Pagina: {dto.Context?.Pagina ?? "onbekend"}
+            Versie: {dto.Context?.Versie ?? "?"}
+
+            Beschrijving gebruiker: "{beschrijving}"
+            {qaBlok}
+            """;
+
+        var messages = new List<ChatMessage>
+        {
+            new SystemChatMessage(systemPrompt),
+            new UserChatMessage(userPrompt)
+        };
+
+        var options = new ChatCompletionOptions
+        {
+            Temperature = 0.2f,
+            ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat()
+        };
+
+        var completion = await chatClient.CompleteChatAsync(messages, options);
+        var json = completion.Value.Content[0].Text;
+        log.LogDebug("Submit AI response: {Json}", json);
+
+        var parsed = JObject.Parse(json);
+        return new StructuredIssue(
+            parsed["title"]?.Value<string>() ?? $"[{dto.Type}] Gebruikersmelding",
+            parsed["samenvatting"]?.Value<string>() ?? "",
+            parsed["acceptatiecriteria"]?.ToObject<List<string>>() ?? []
+        );
+    }
+
+    // ── GitHub Issue aanmaken ──────────────────────────────────────────────────
+
+    private static async Task<(int nummer, string url)> MaakGitHubIssueAsync(
+        string pat, string owner, string repo, string title, string body,
+        string[] labels, ILogger log)
+    {
+        using var http = new HttpClient();
+        http.DefaultRequestHeaders.UserAgent.ParseAdd("SportlinkFeedbackWidget/2.0");
+        http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", pat);
+        http.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+        http.DefaultRequestHeaders.Add("X-GitHub-Api-Version", "2022-11-28");
+
+        var payload = JsonConvert.SerializeObject(new { title, body, labels });
+        var url = $"https://api.github.com/repos/{owner}/{repo}/issues";
+        var resp = await http.PostAsync(url, new StringContent(payload, Encoding.UTF8, "application/json"));
+
+        if (!resp.IsSuccessStatusCode)
+        {
+            // Retry zonder custom labels bij 422 (labels bestaan niet)
+            if ((int)resp.StatusCode == 422)
+            {
+                log.LogWarning("GitHub 422 bij labels {Labels} — retry zonder custom labels", string.Join(",", labels));
+                var fallbackLabels = labels.Where(l => l == "bug" || l == "enhancement" || l == "question").ToArray();
+                var fallbackPayload = JsonConvert.SerializeObject(new { title, body, labels = fallbackLabels });
+                resp = await http.PostAsync(url, new StringContent(fallbackPayload, Encoding.UTF8, "application/json"));
+            }
+
+            if (!resp.IsSuccessStatusCode)
+            {
+                var err = await resp.Content.ReadAsStringAsync();
+                log.LogWarning("GitHub issue aanmaken mislukt: HTTP {Status} — {Err}", (int)resp.StatusCode, err);
+                throw new InvalidOperationException($"GitHub API HTTP {(int)resp.StatusCode}");
+            }
+        }
+
+        var json = await resp.Content.ReadAsStringAsync();
+        dynamic created = JsonConvert.DeserializeObject<dynamic>(json)!;
+        int nummer = (int)created.number;
+        string issueUrl = (string)created.html_url;
+        log.LogInformation("GitHub issue #{Nr} aangemaakt via feedback widget", nummer);
+        return (nummer, issueUrl);
+    }
+
+    // ── Issue body samenstelllen ───────────────────────────────────────────────
+
+    private static string BouwIssueBody(FeedbackRequest dto, StructuredIssue structured)
+    {
+        var typeIcon = dto.Type switch { "Fout" => "🐛", "Verzoek" => "💡", _ => "❓" };
+        var ctx = dto.Context;
+        var beschrijving = Sanitize(dto.Beschrijving, 2000);
+        var tijdstip = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm") + " UTC";
+
+        var sb = new StringBuilder();
+        sb.AppendLine("## 🗣️ Gemeld via feedback widget");
+        sb.AppendLine();
+        sb.AppendLine("| Veld | Waarde |");
+        sb.AppendLine("|---|---|");
+        sb.AppendLine($"| Type | {typeIcon} {dto.Type} |");
+        if (ctx != null)
+        {
+            sb.AppendLine($"| Pagina | `{ctx.Pagina}` |");
+            sb.AppendLine($"| Versie | {ctx.Versie} |");
+            sb.AppendLine($"| Omgeving | {(ctx.Versie.Contains("dev", StringComparison.OrdinalIgnoreCase) ? "ontwikkeling" : "productie")} |");
+            if (!string.IsNullOrWhiteSpace(ctx.Browser))
+                sb.AppendLine($"| Browser | {ctx.Browser[..Math.Min(ctx.Browser.Length, 80)]} |");
+        }
+        sb.AppendLine($"| Tijdstip | {tijdstip} |");
+        sb.AppendLine();
+
+        sb.AppendLine("## Beschrijving (eigen woorden gebruiker)");
+        sb.AppendLine();
+        sb.AppendLine($"> {beschrijving.Replace("\n", "\n> ")}");
+        sb.AppendLine();
+
+        if (dto.VragenAntwoorden?.Count > 0)
+        {
+            sb.AppendLine("## Aanvullende context");
+            sb.AppendLine();
+            foreach (var qa in dto.VragenAntwoorden)
+            {
+                var vraag = Sanitize(qa.Vraag, 200);
+                var antwoord = Sanitize(qa.Antwoord, 500);
+                sb.AppendLine($"**{vraag}:** {antwoord}");
+                sb.AppendLine();
+            }
+        }
+
+        sb.AppendLine("## Analyse");
+        sb.AppendLine();
+        sb.AppendLine(structured.Samenvatting);
+        sb.AppendLine();
+
+        if (structured.Acceptatiecriteria.Count > 0)
+        {
+            sb.AppendLine("## Acceptatiecriteria");
+            sb.AppendLine();
+            foreach (var criterium in structured.Acceptatiecriteria)
+                sb.AppendLine($"- [ ] {Sanitize(criterium, 120)}");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("---");
+        sb.AppendLine($"*Aangemaakt via BlazorAdmin feedback widget v{ctx?.Versie ?? "?"}*");
+
+        return sb.ToString();
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private static string[] KiesLabels(string type) => type switch
+    {
+        "Fout" => ["bug", "type: bug", "via-feedback-widget", "needs-triage"],
+        "Verzoek" => ["enhancement", "type: feature", "via-feedback-widget", "needs-triage"],
+        _ => ["question", "via-feedback-widget", "needs-triage"]
+    };
+
+    private static string BouwQaBlok(List<VraagAntwoord>? qaList)
+    {
+        if (qaList == null || qaList.Count == 0) return "";
+        var sb = new StringBuilder("\nAanvullende context:\n");
+        foreach (var qa in qaList)
+            sb.AppendLine($"- {Sanitize(qa.Vraag, 200)}: {Sanitize(qa.Antwoord, 500)}");
+        return sb.ToString();
+    }
+
+    private static string Sanitize(string? input, int maxLen)
+    {
+        if (string.IsNullOrEmpty(input)) return "";
+        var clean = input
+            .Replace("<script", "&lt;script", StringComparison.OrdinalIgnoreCase)
+            .Replace("</script>", "&lt;/script&gt;", StringComparison.OrdinalIgnoreCase);
+        return clean.Length > maxLen ? clean[..maxLen] + "…" : clean;
+    }
+
+    private static bool TryAcquireSubmitSlot()
+    {
+        lock (_rateLock)
+        {
+            var cutoff = DateTime.UtcNow - RateLimitVenster;
+            while (_submits.TryPeek(out var first) && first < cutoff)
+                _submits.TryDequeue(out _);
+            if (_submits.Count >= MaxSubmissiesPerVenster) return false;
+            _submits.Enqueue(DateTime.UtcNow);
+            return true;
+        }
+    }
+
+    // ── Request / Response modellen ────────────────────────────────────────────
+
+    internal sealed class FeedbackRequest
+    {
+        public string Type { get; set; } = "";
+        public string Beschrijving { get; set; } = "";
+        public List<VraagAntwoord>? VragenAntwoorden { get; set; }
+        public FeedbackContext? Context { get; set; }
+    }
+
+    internal sealed class VraagAntwoord
+    {
+        public string Vraag { get; set; } = "";
+        public string Antwoord { get; set; } = "";
+    }
+
+    internal sealed class FeedbackContext
+    {
+        public string Pagina { get; set; } = "";
+        public string Versie { get; set; } = "";
+        public string Rol { get; set; } = "";
+        public string Browser { get; set; } = "";
+    }
+
+    private sealed record ValidateResponse(bool Volledig, List<string> Vragen);
+    private sealed record StructuredIssue(string Title, string Samenvatting, List<string> Acceptatiecriteria);
+}


### PR DESCRIPTION
## Summary

- Voegt een **FEEDBACK-knop** toe rechtsboven in de Blazor Admin GUI (alle pagina's via MainLayout)
- GPT-4o-mini valideert automatisch of de beschrijving volledig genoeg is — zo ja: direct naar overzicht; zo nee: max 3 gerichte aanvulvragen verschijnen inline
- Bij indienen structureert de AI de melding naar een GitHub Issue met acceptatiecriteria klaar voor Claude Code

## Gewijzigde bestanden

| Bestand | Wijziging |
|---|---|
| `FunctionApp/Feedback/FeedbackFunction.cs` | Nieuw — `POST /api/feedback/validate` + `POST /api/feedback/submit` |
| `BlazorAdmin/Shared/FeedbackWidget.razor` | Nieuw — Bootstrap modal, 3-stap adaptieve flow |
| `BlazorAdmin/Models/FeedbackModels.cs` | Nieuw — request/response models |
| `BlazorAdmin/Services/AdminApiClient.cs` | + `ValidateFeedbackAsync`, `SubmitFeedbackAsync` |
| `BlazorAdmin/Layout/MainLayout.razor` | FEEDBACK-knop in top-row |
| `BlazorAdmin/_Imports.razor` | + `@using BlazorAdmin.Shared` |
| `CHANGELOG.md` | Bijgewerkt |

## Vereiste configuratie

`GitHubPat` en `GitHubOwner` moeten zijn ingesteld als Azure App Setting (zie #103). In lokale dev geeft `/api/feedback/validate` gewoon antwoord; `/api/feedback/submit` geeft 503 als PAT ontbreekt.

## Test plan

- [x] `dotnet build FunctionApp` → exit 0
- [x] `dotnet build BlazorAdmin` → exit 0
- [x] `Test-App.ps1 -Fix` → 28 checks geslaagd
- [x] `POST /api/feedback/validate` volledig → `{ volledig: true, vragen: [] }`
- [x] `POST /api/feedback/validate` vaag → `{ volledig: false, vragen: ["...","...","..."] }`
- [x] Submit → 503 bij ontbrekende PAT (verwacht gedrag)

Sluit #129 (vervangt #110 en #111)

🤖 Generated with [Claude Code](https://claude.com/claude-code)