### PR TITLE
security: Entra ID auth in productie + lokale SWA CLI setup

### DIFF
--- a/BlazorAdmin/Program.cs
+++ b/BlazorAdmin/Program.cs
@@ -15,9 +15,21 @@ if (string.IsNullOrWhiteSpace(functionBaseUrl))
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(functionBaseUrl) });
 builder.Services.AddScoped<AdminApiClient>();
 
-// Auth: lokale dev = LocalAuthService (altijd admin); productie = idem totdat MSAL volledig geconfigureerd is.
-// De feitelijke routebescherming verloopt in productie via staticwebapp.config.json (SWA Entra ID).
-// Zie docs/v2-admin-handleiding.md voor Entra ID app-registratie en het wisselen naar EntraAuthService.
-builder.Services.AddScoped<IAuthService, LocalAuthService>();
+// Auth: Production = Entra ID via MSAL + EntraAuthService (rollen uit claims).
+//       Development = LocalAuthService (altijd admin, geen login — voor lokaal testen).
+// SWA-routing in staticwebapp.config.json beschermt de /api/beheer/* endpoints ook server-side.
+// EntraAuthService geeft de Blazor UI de juiste rolinfo voor menu-items verbergen.
+if (builder.HostEnvironment.IsProduction())
+{
+    builder.Services.AddMsalAuthentication(options =>
+    {
+        builder.Configuration.Bind("AzureAd", options.ProviderOptions.Authentication);
+    });
+    builder.Services.AddScoped<IAuthService, EntraAuthService>();
+}
+else
+{
+    builder.Services.AddScoped<IAuthService, LocalAuthService>();
+}
 
 await builder.Build().RunAsync();

--- a/BlazorAdmin/wwwroot/appsettings.Production.json
+++ b/BlazorAdmin/wwwroot/appsettings.Production.json
@@ -1,3 +1,8 @@
 {
-  "FunctionBaseUrl": ""
+  "FunctionBaseUrl": "",
+  "AzureAd": {
+    "Authority": "https://login.microsoftonline.com/TENANT_ID_HIER_INVULLEN",
+    "ClientId": "CLIENT_ID_HIER_INVULLEN",
+    "ValidateAuthority": true
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 _Wijzigingen op `v2/develop` die nog niet zijn vrijgegeven._
 
+### Security
+- **Blazor Admin GUI: Entra ID auth in productie** (geen issue nr): `Program.cs` detecteert automatisch de omgeving — in productie (SWA-deployment) wordt `EntraAuthService` geregistreerd met MSAL, in development `LocalAuthService`. `appsettings.Production.json` bevat de AzureAd-configuratie (placeholders; in te vullen na Entra-registratie). De SWA CLI-configuratie (`swa-cli.config.json`) maakt lokaal testen van auth-flows mogelijk zonder echte Entra ID.
+
 ### Added
 - **Intelligente Feedback Widget** (#129): Beheerders kunnen rechtsboven in de Admin GUI op **FEEDBACK** klikken om een fout of wens te melden. Na invullen valideert GPT-4o-mini automatisch of de beschrijving volledig genoeg is — als dat zo is gaat de melding direct door, anders verschijnen gericht aanvulvragen (max 3). De uiteindelijke beschrijving wordt door de AI omgezet naar een gestructureerd GitHub issue met acceptatiecriteria, dat Claude Code autonoom kan oppakken.
 

--- a/docs/v2-admin-handleiding.md
+++ b/docs/v2-admin-handleiding.md
@@ -185,37 +185,122 @@ Alleen toegewezen gebruikers krijgen toegang. Niet-toegewezen gebruikers krijgen
 
 ---
 
-## 6. Aanzetten van EntraAuthService in Blazor
+## 6. EntraAuthService in productie (automatisch geactiveerd)
 
-De huidige `Program.cs` registreert standaard `LocalAuthService` voor zowel Development als
-Production. Voor échte productie-auth:
+`BlazorAdmin/Program.cs` detecteert de omgeving automatisch:
 
-1. Voeg in `Program.cs` toe:
-   ```csharp
-   builder.Services.AddMsalAuthentication(options =>
-   {
-       builder.Configuration.Bind("AzureAd", options.ProviderOptions.Authentication);
-   });
-   ```
-2. Vervang `LocalAuthService` door `EntraAuthService` in de Production-tak van Program.cs
-3. Voeg `appsettings.Production.json` toe met:
-   ```json
-   {
-     "AzureAd": {
-       "Authority": "https://login.microsoftonline.com/TENANT_ID",
-       "ClientId": "APPLICATION_CLIENT_ID",
-       "ValidateAuthority": true
-     }
-   }
-   ```
+- **Development** (`ASPNETCORE_ENVIRONMENT=Development`) → `LocalAuthService` — altijd admin, geen login
+- **Production** (SWA-deployment) → `AddMsalAuthentication` + `EntraAuthService` — echte Entra ID rollen
 
-> Dit is **bewust nog niet gedaan** in de eerste v2 release — SWA-routing in
-> `staticwebapp.config.json` regelt al de daadwerkelijke beveiliging. EntraAuthService is alleen
-> nodig zodra je rollen client-side wilt gebruiken (bijv. menu's verbergen).
+Er is geen handmatige stap nodig om te switchen. Vul wel de placeholders in `appsettings.Production.json` in:
+
+```json
+// BlazorAdmin/wwwroot/appsettings.Production.json
+{
+  "AzureAd": {
+    "Authority": "https://login.microsoftonline.com/TENANT_ID_HIER_INVULLEN",
+    "ClientId": "CLIENT_ID_HIER_INVULLEN",
+    "ValidateAuthority": true
+  }
+}
+```
+
+- `TENANT_ID_HIER_INVULLEN` → Entra ID → **Overview** → Directory (tenant) ID
+- `CLIENT_ID_HIER_INVULLEN` → Entra ID → **App registrations** → `vrc-admin-swa` → Application (client) ID
+
+Commit `appsettings.Production.json` mee (bevat geen secrets — alleen tenant/client ID, die zijn publiek).
 
 ---
 
-## 7. Snel testen
+## 7. Lokaal testen met Azure SWA CLI (aanbevolen vóór productie)
+
+De Azure Static Web Apps CLI emuleert het volledige SWA-gedrag lokaal: routering, auth-emulatie
+en `/api/*` proxying naar de Function App. Hiermee kun je de authenticatieflow testen
+**zonder een echte Entra ID app-registratie of Azure resource**.
+
+### Vereisten (eenmalig)
+
+1. **Node.js** ≥ 18 — [nodejs.org](https://nodejs.org/)
+2. **Azure SWA CLI** installeren:
+   ```powershell
+   npm install -g @azure/static-web-apps-cli
+   swa --version   # controleer installatie
+   ```
+
+### Opstarten
+
+Stap 1 — start de bestaande backends (elk in een eigen terminal):
+
+```powershell
+# Terminal 1: Azurite (opslag emulator)
+azurite --location $env:TEMP\azurite
+
+# Terminal 2: Function App backend
+cd FunctionApp
+func start --port 7094
+
+# Terminal 3: Blazor WASM dev server
+cd BlazorAdmin
+dotnet run --launch-profile http
+# → draait op http://localhost:5242
+```
+
+Stap 2 — start de SWA emulator (vierde terminal):
+
+```powershell
+# In de repo root (waar swa-cli.config.json staat)
+swa start sportlink-admin
+# → SWA emulator draait op http://localhost:4280
+```
+
+### Wat de SWA CLI doet
+
+| Functie | Gedrag |
+|---|---|
+| **Blazor WASM** | Proxy naar `http://localhost:5242` |
+| **`/api/*`** | Proxy naar `http://localhost:7094` |
+| **Routeregels** | `staticwebapp.config.json` afgedwongen (rollen, redirects) |
+| **Auth emulatie** | Mock login op `http://localhost:4280/.auth/login/aad` |
+
+### Authenticatie lokaal testen
+
+Ga naar `http://localhost:4280` — de SWA CLI stuurt je door naar een mock login-pagina.
+Vul daar in:
+
+| Veld | Waarde voor testen |
+|---|---|
+| User ID | Willekeurig getal |
+| Username | `testbeheerder` |
+| Roles | `admin` |
+
+Na "Login" ben je ingelogd als admin zonder enige Entra ID. Zo kun je controleren of:
+- `/api/beheer/*` endpoints bereikbaar zijn met admin-rol
+- Pagina's en navigatie kloppen voor ingelogde gebruikers
+- Niet-admins netjes een 403 krijgen (rol leeg laten bij test)
+
+> **Let op:** De `ASPNETCORE_ENVIRONMENT` van de Blazor dev server is `Development`,
+> dus `LocalAuthService` is actief — de Blazor UI toont altijd admin.
+> De SWA CLI emuleert de route-beveiliging (endpoints), niet de Blazor UI.
+> Productie-test de UI door de Blazor app te publiceren en te serveren via `swa start`.
+
+### Volledige productie-emulatie (optioneel)
+
+Wil je ook de Blazor `Production`-omgeving testen (met echte EntraAuthService)?
+
+```powershell
+# Publiceer Blazor naar een lokale map
+dotnet publish BlazorAdmin/BlazorAdmin.csproj -c Release -o ./blazor-publish
+
+# Start SWA met de gepubliceerde bestanden (geen dev server)
+swa start ./blazor-publish/wwwroot --api-devserver-url http://localhost:7094
+```
+
+Hierbij laadt Blazor `appsettings.Production.json` met de `AzureAd`-sectie.
+Je hebt dan wél de echte Tenant ID en Client ID nodig (zie sectie 4 en 6).
+
+---
+
+## 8. Snel testen (endpoints direct)
 
 ```bash
 # Lokaal: alle endpoints zonder authenticatie (host-key uitschakelen kan via local.settings.json)
@@ -230,7 +315,7 @@ curl -X POST -H "Content-Type: application/json" \
   http://localhost:7094/api/test/email
 ```
 
-Of gebruik het geautomatiseerde smoke-test script (zie sectie 8):
+Of gebruik het geautomatiseerde smoke-test script (zie sectie 9):
 
 ```powershell
 .\scripts\smoke-test.ps1
@@ -238,7 +323,7 @@ Of gebruik het geautomatiseerde smoke-test script (zie sectie 8):
 
 ---
 
-## 8. Architectuur — bekende valkuilen bij lokale oplevering
+## 9. Architectuur — bekende valkuilen bij lokale oplevering
 
 Bij de v2-implementatie werden vier fouten pas bij runtime ontdekt die `dotnet build` gewoon liet
 passeren. Documentatie hiervan zodat deze fouten nooit meer onopgemerkt voorbij komen.

--- a/swa-cli.config.json
+++ b/swa-cli.config.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://aka.ms/azure/static-web-apps-cli/schema",
+  "configurations": {
+    "sportlink-admin": {
+      "appDevserverUrl": "http://localhost:5242",
+      "apiDevserverUrl": "http://localhost:7094",
+      "apiPrefix": "api"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **`Program.cs` defensief gemaakt**: development → `LocalAuthService`, productie → `EntraAuthService` + MSAL (automatisch op basis van omgeving)
- **`appsettings.Production.json`**: AzureAd-sectie toegevoegd met `TENANT_ID_HIER_INVULLEN` / `CLIENT_ID_HIER_INVULLEN` placeholders (geen secrets — mag in git)
- **`swa-cli.config.json`**: nieuwe config voor Azure SWA CLI — lokalal testen op poort 4280 met auth-emulatie, zonder echte Entra ID
- **`docs/v2-admin-handleiding.md`**: nieuwe sectie 7 met stap-voor-stap SWA CLI setup, sectie 6 bijgewerkt naar huidige code

GitHub issues voor resterende productie-acties:
- #131 (`wacht op: eigenaar`): Managed Identity Website Contributor rol instellen
- #132 (`wacht op: eigenaar`): TENANT_ID/CLIENT_ID invullen na Entra-registratie

## Test plan

- [x] `dotnet build BlazorAdmin` — groen (0 warnings)
- [x] `dotnet build FunctionApp` — groen
- [ ] Lokaal: `swa start sportlink-admin` werkt na `npm install -g @azure/static-web-apps-cli`
- [ ] Mock login op `http://localhost:4280/.auth/login/aad` werkt

🤖 Generated with [Claude Code](https://claude.com/claude-code)