### PR TITLE
fix(#135): security-scan op v2/develop PRs + multi-club fix + docs

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['**']
   pull_request:
-    branches: [main]
+    branches: [main, v2/develop]
 
 permissions:
   contents: read

--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -130,5 +130,5 @@ public class TeamRegelDto
     public int Prioriteit { get; set; }
     public bool Actief { get; set; }
     public string? Opmerking { get; set; }
-    public string ClubCode { get; set; } = "VRC";
+    public string ClubCode { get; set; } = string.Empty;
 }

--- a/docs/v2-admin-handleiding.md
+++ b/docs/v2-admin-handleiding.md
@@ -14,7 +14,7 @@ draait op v1 (`main`). v2 wordt pas gedeployed wanneer alle Azure-resources zijn
 1. Stel `FunctionApp/local.settings.json` correct in (zie `local.settings.template.json`)
 2. Voer alle migraties uit op de lokale SQL Server:
    ```powershell
-   sqlcmd -S PTCL69L001 -d SportlinkSqlDb -E -i .\Database\Script.PostDeployment1.sql
+   sqlcmd -S YOUR_SQL_SERVER -d SportlinkSqlDb -E -i .\Database\Script.PostDeployment1.sql
    ```
 3. Installeer Azurite (voor storage emulator)
 


### PR DESCRIPTION
## Fixes #135 (gedeeltelijk)

### Wijzigingen

**Security Gate uitgebreid naar v2/develop**
`security-scan.yml` triggert nu ook op PRs richting `v2/develop`. Eerder had de Security Gate een blinde vlek: code kon ongecontroleerd `v2/develop` in via een PR. Nu blokkeert de gate ook daar bij fouten.

**Multi-club fix: hardcoded `ClubCode = "VRC"` verwijderd**
`TeamRegelDto` had `ClubCode = "VRC"` als default-waarde — een stille multi-club data-isolatie bypass. Vervangen door `string.Empty` zodat een ontbrekende ClubCode een zichtbare fout geeft in plaats van stilzwijgend club VRC te simuleren.

**Handleiding: hardcoded SQL-servernaam verwijderd**
`v2-admin-handleiding.md` bevatte de naam van de ontwikkelmachine (`PTCL69L001`). Vervangen door `YOUR_SQL_SERVER` — persoonsgebonden infranaam mag niet in publieke docs.

## Resterend uit #135
- [ ] CISO-audit: secrets, PII, gitignore, workflows, templates
- [ ] Repository publiek zetten na akkoord
- [ ] CLAUDE.md sessie-isolatie commit

## Test plan
- [ ] Security scan CI check groen na merge
- [ ] `ClubCode` leeg bij nieuw `TeamRegelDto` — geen "VRC" meer als default

🤖 Generated with [Claude Code](https://claude.com/claude-code)