### PR TITLE
feat(#137): API-ready loading screen — voorkom Fetch error bij opstarten

### DIFF
--- a/BlazorAdmin/App.razor
+++ b/BlazorAdmin/App.razor
@@ -1,6 +1,81 @@
-﻿<Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
-    <Found Context="routeData">
-        <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)"/>
-        <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-    </Found>
-</Router>
+@inject HttpClient Http
+@implements IAsyncDisposable
+
+@if (_phase is Phase.Checking or Phase.Ready)
+{
+    <div class="api-startup">
+        <div class="startup-card">
+            @if (_phase == Phase.Checking)
+            {
+                <div class="startup-spinner">
+                    <div class="spinner-ring"></div>
+                </div>
+                <p class="startup-label">@_statusText</p>
+            }
+            else
+            {
+                <div class="startup-check">
+                    <svg class="checkmark-svg" viewBox="0 0 52 52">
+                        <circle class="checkmark-circle" cx="26" cy="26" r="25" fill="none" />
+                        <path class="checkmark-path" fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8" />
+                    </svg>
+                </div>
+                <p class="startup-label startup-label-ready">Verbonden!</p>
+            }
+        </div>
+    </div>
+}
+else
+{
+    <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+        <Found Context="routeData">
+            <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+        </Found>
+    </Router>
+}
+
+@code {
+    private Phase _phase = Phase.Checking;
+    private string _statusText = "Verbinding maken...";
+    private readonly CancellationTokenSource _cts = new();
+
+    protected override async Task OnInitializedAsync() => await CheckApiAsync();
+
+    private async Task CheckApiAsync()
+    {
+        for (var attempt = 0; attempt < 40 && !_cts.Token.IsCancellationRequested; attempt++)
+        {
+            try
+            {
+                var r = await Http.GetAsync("api/health", _cts.Token);
+                if (r.IsSuccessStatusCode)
+                {
+                    _phase = Phase.Ready;
+                    StateHasChanged();
+                    await Task.Delay(1100, _cts.Token);
+                    _phase = Phase.Running;
+                    return;
+                }
+            }
+            catch (OperationCanceledException) { return; }
+            catch { }
+
+            if (attempt is 6)  _statusText = "Wachten op server...";
+            if (attempt is 15) _statusText = "Nog even geduld...";
+            StateHasChanged();
+            await Task.Delay(500, _cts.Token);
+        }
+
+        // Na ~20s nog steeds geen verbinding → toon app in degraded mode
+        _phase = Phase.Running;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cts.CancelAsync();
+        _cts.Dispose();
+    }
+
+    private enum Phase { Checking, Ready, Running }
+}

--- a/BlazorAdmin/wwwroot/css/app.css
+++ b/BlazorAdmin/wwwroot/css/app.css
@@ -105,6 +105,106 @@ code {
     color: #c02d76;
 }
 
+/* ── API startup overlay ─────────────────────────────────────── */
+
+.api-startup {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f0f2f5;
+    z-index: 9999;
+}
+
+.startup-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 2.5rem 3rem;
+    background: white;
+    border-radius: 1rem;
+    box-shadow: 0 4px 32px rgba(0, 0, 0, .10);
+    min-width: 230px;
+    text-align: center;
+    animation: card-in 0.25s ease-out;
+}
+
+@keyframes card-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0);   }
+}
+
+.startup-label {
+    margin: 0;
+    font-size: .95rem;
+    color: #6c757d;
+    font-weight: 500;
+    min-height: 1.4em;
+    transition: color 0.3s;
+}
+
+.startup-label-ready {
+    color: #198754;
+}
+
+/* Spinner */
+.startup-spinner {
+    width: 3.5rem;
+    height: 3.5rem;
+}
+
+.spinner-ring {
+    width: 100%;
+    height: 100%;
+    border: 4px solid #e9ecef;
+    border-top-color: #0d6efd;
+    border-radius: 50%;
+    animation: spin 0.75s linear infinite;
+}
+
+@keyframes spin {
+    to { transform: rotate(360deg); }
+}
+
+/* Green checkmark */
+.startup-check {
+    width: 3.5rem;
+    height: 3.5rem;
+}
+
+.checkmark-svg {
+    width: 100%;
+    height: 100%;
+}
+
+.checkmark-circle {
+    stroke: #198754;
+    stroke-width: 2;
+    stroke-dasharray: 166;
+    stroke-dashoffset: 166;
+    animation: draw-circle 0.5s ease-out forwards;
+}
+
+.checkmark-path {
+    stroke: #198754;
+    stroke-width: 3.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-dasharray: 48;
+    stroke-dashoffset: 48;
+    animation: draw-check 0.3s ease-out 0.45s forwards;
+}
+
+@keyframes draw-circle {
+    to { stroke-dashoffset: 0; }
+}
+
+@keyframes draw-check {
+    to { stroke-dashoffset: 0; }
+}
+
 .form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {
     color: var(--bs-secondary-color);
     text-align: end;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ _Wijzigingen op `v2/develop` die nog niet zijn vrijgegeven._
 - **Blazor Admin GUI: Entra ID auth in productie** (geen issue nr): `Program.cs` detecteert automatisch de omgeving — in productie (SWA-deployment) wordt `EntraAuthService` geregistreerd met MSAL, in development `LocalAuthService`. `appsettings.Production.json` bevat de AzureAd-configuratie (placeholders; in te vullen na Entra-registratie). De SWA CLI-configuratie (`swa-cli.config.json`) maakt lokaal testen van auth-flows mogelijk zonder echte Entra ID.
 
 ### Added
+- **API-ready loading screen** (#137): De Admin GUI toont nu een laadscherm met draaiende spinner totdat de FunctionApp bereikbaar is. Zodra de verbinding is gemaakt verschijnt een groene vinkje-animatie, waarna de app zich opent. Voorkomt "Fetch error" op alle pagina's bij trage FunctionApp-opstart in lokale ontwikkeling.
 - **Intelligente Feedback Widget** (#129): Beheerders kunnen rechtsboven in de Admin GUI op **FEEDBACK** klikken om een fout of wens te melden. Na invullen valideert GPT-4o-mini automatisch of de beschrijving volledig genoeg is — als dat zo is gaat de melding direct door, anders verschijnen gericht aanvulvragen (max 3). De uiteindelijke beschrijving wordt door de AI omgezet naar een gestructureerd GitHub issue met acceptatiecriteria, dat Claude Code autonoom kan oppakken.
 
 ### Fixed


### PR DESCRIPTION
## Samenvatting

`App.razor` pollt `/api/health` tot de FunctionApp beschikbaar is voordat de Router (en daarmee de pagina-inhoud) wordt gerenderd. Hiermee verdwijnt de 'Fetch error' die alle pagina's toonden wanneer de FunctionApp bij lokaal opstarten nog niet klaar was.

## Wijzigingen

- **`App.razor`**: nieuwe opstart-fase met polling loop (max 40×500ms = 20s), CancellationToken voor cleanup, enum `Phase` (Checking → Ready → Running)
- **`wwwroot/css/app.css`**: `.api-startup` overlay, spinner-ring animatie, SVG checkmark draw-animatie

## Gedrag

- **Dev**: wacht automatisch op FunctionApp startup (~10-15s) — geen handmatige wachttijd meer nodig
- **Productie (SWA)**: API direct bereikbaar → checkmark verschijnt meteen, nauwelijks vertraging
- **Fallback**: na 20s toch laden (graceful degradation — betere foutmelding per pagina)

## Visueel

1. Spinner + "Verbinding maken..." → "Wachten op server..." → "Nog even geduld..."
2. Groen vinkje met SVG draw-animatie → 1.1s tonen
3. Normaal app renderen

Fixes #137