### PR TITLE
fix(#140): doordeweeks geeft altijd maandag t/m donderdag terug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,13 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 _Wijzigingen op `v2/develop` die nog niet zijn vrijgegeven._
 
 ### Security
+- **Security Gate bewaakt nu ook v2/develop PRs** (#135): `security-scan.yml` triggert voortaan ook op pull requests richting `v2/develop`. Eerder was er een blinde vlek waarbij code zonder beveiligingscontrole `v2/develop` in kon via een PR.
 - **Blazor Admin GUI: Entra ID auth in productie** (geen issue nr): `Program.cs` detecteert automatisch de omgeving — in productie (SWA-deployment) wordt `EntraAuthService` geregistreerd met MSAL, in development `LocalAuthService`. `appsettings.Production.json` bevat de AzureAd-configuratie (placeholders; in te vullen na Entra-registratie). De SWA CLI-configuratie (`swa-cli.config.json`) maakt lokaal testen van auth-flows mogelijk zonder echte Entra ID.
+
+### Fixed
+- **'Doordeweeks' geeft altijd maandag t/m donderdag terug** (#140): bij e-mails als 'kunnen wij volgende week doordeweeks spelen?' retourneerde de AI soms vrijdag of weekenddagen. AI-prompt verduidelijkt ('doordeweeks = ma-do, vrijdag is geen doordeweekse dag') én deterministische code-override in `BerichtPipeline` zorgt dat bij aanwezigheid van 'doordeweeks' altijd exact de vier weekdagen (ma/di/wo/do) van de afgeleide kalenderweek worden gebruikt.
+- **API-ready loading screen** (#137): BlazorAdmin toonde een 'Fetch error' bij het opstarten als de FunctionApp nog niet klaar was. Er verschijnt nu een laadscherm totdat de backend bereikbaar is.
+- **TeamRegelDto hardcoded ClubCode verwijderd** (#135): standaard `ClubCode = "VRC"` in `TeamRegelDto` vervangen door `string.Empty` — voorkomt stille multi-club data-isolatie bypass bij ontbrekende ClubCode.
 
 ### Added
 - **Intelligente Feedback Widget** (#129): Beheerders kunnen rechtsboven in de Admin GUI op **FEEDBACK** klikken om een fout of wens te melden. Na invullen valideert GPT-4o-mini automatisch of de beschrijving volledig genoeg is — als dat zo is gaat de melding direct door, anders verschijnen gericht aanvulvragen (max 3). De uiteindelijke beschrijving wordt door de AI omgezet naar een gestructureerd GitHub issue met acceptatiecriteria, dat Claude Code autonoom kan oppakken.

--- a/FunctionApp/Email/BerichtAiService.cs
+++ b/FunctionApp/Email/BerichtAiService.cs
@@ -97,6 +97,7 @@ public class BerichtAiService
             - Leeftijdscategorieën: "O13", "Onder 13", "onder 13" etc. normaliseren naar "JO13". Idem voor alle leeftijden (O7→JO7, O19→JO19, etc.). Meisjes: "MO13" blijft "MO13"
             - Meerdere datums voor hetzelfde team = beschikbaarheid_check (NIET buiten_scope)
             - Alleen buiten_scope als het verzoek echt niet over veldbeschikbaarheid of herplannen gaat, of als er meerdere VERSCHILLENDE teams worden genoemd zonder duidelijk verband
+            - 'doordeweeks' betekent maandag t/m donderdag (vrijdag is GEEN doordeweekse dag). Bij 'volgende week doordeweeks': vul 'datums' met ALLE VIER weekdagen (ma/di/wo/do) van de volgende kalenderweek. Voorbeeld: vandaag zondag 18 mei → 'volgende week doordeweeks' → datums: ["2026-05-19","2026-05-20","2026-05-21","2026-05-22"]
 
             KNVB-regelcheck (voor herplan_verzoek):
             Vul "knvbNotitie" in als op basis van datum en teamtype een KNVB-regel waarschijnlijk van toepassing is.

--- a/FunctionApp/Processing/BerichtPipeline.cs
+++ b/FunctionApp/Processing/BerichtPipeline.cs
@@ -91,7 +91,8 @@ public static class BerichtPipeline
         switch (classificatie.Type)
         {
             case VerzoekType.BeschikbaarheidCheck:
-                var alleDatums = classificatie.GetAlleDatums();
+                var alleDatums = ExpandDoordeweeksDatums(
+                    classificatie.GetAlleDatums(), bericht.Onderwerp, bericht.Body);
 
                 var cc2 = SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
                 bool heeftExterneTegenstander = !string.IsNullOrWhiteSpace(classificatie.Tegenstander)
@@ -283,6 +284,40 @@ public static class BerichtPipeline
     }
 
     // ── Private helpers ──
+
+    /// <summary>
+    /// Als de berichttekst 'doordeweeks' bevat, vervang de AI-datums door de exacte
+    /// maandag t/m donderdag van de week die de AI afleidde. Vrijdag is nooit doordeweeks.
+    /// </summary>
+    private static List<string> ExpandDoordeweeksDatums(
+        List<string> aiDatums, string onderwerp, string body)
+    {
+        var tekst = (onderwerp + " " + body).ToLowerInvariant();
+        if (!tekst.Contains("doordeweeks"))
+            return aiDatums;
+
+        // Leid de weekmaandag af: óf uit de eerste AI-datum, óf uit "volgende week"
+        DateOnly weekStart;
+        if (aiDatums.Count > 0 && DateOnly.TryParse(aiDatums[0], out var firstDate))
+        {
+            // Rol terug naar de maandag van de week van die datum
+            int daysFromMonday = ((int)firstDate.DayOfWeek - (int)DayOfWeek.Monday + 7) % 7;
+            weekStart = firstDate.AddDays(-daysFromMonday);
+        }
+        else
+        {
+            // Geen AI-datum: neem de volgende kalenderweek
+            var today = DateOnly.FromDateTime(DateTime.Today);
+            int daysUntilMonday = ((int)DayOfWeek.Monday - (int)today.DayOfWeek + 7) % 7;
+            if (daysUntilMonday == 0) daysUntilMonday = 7;
+            weekStart = today.AddDays(daysUntilMonday);
+        }
+
+        // Maandag t/m donderdag (4 dagen)
+        return Enumerable.Range(0, 4)
+            .Select(i => weekStart.AddDays(i).ToString("yyyy-MM-dd"))
+            .ToList();
+    }
 
     private static DateOnly? ExtractExpliciteDatum(string tekst)
     {


### PR DESCRIPTION
## Samenvatting

Fixes #140

- **BerichtAiService**: expliciete prompt-regel toegevoegd — `doordeweeks = maandag t/m donderdag; vrijdag is GEEN doordeweekse dag; volgende week doordeweeks → alle vier weekdagen invullen`
- **BerichtPipeline.ExpandDoordeweeksDatums**: deterministische code-override die, als de berichttekst 'doordeweeks' bevat, de AI-datums vervangt door exact maandag t/m donderdag van de afgeleid kalenderweek

## Testplan

- [ ] Dry-run met "Kunnen wij volgende week doordeweeks een oefenwedstrijd spelen?" → datums moeten maandag t/m donderdag zijn
- [ ] Dry-run zonder "doordeweeks" → bestaand gedrag ongewijzigd
- [ ] Build groen: `dotnet build FunctionApp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)