### PR TITLE
feat(#139): geocoding via Nominatim — AccommodatiePlaats + automatische GPS-coördinaten

### DIFF
--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -19,8 +19,18 @@ public class AppSettingsDto
     public int? HerplanDeadlineDagen { get; set; }
     public int? BufferMinuten { get; set; }
     public string? EmailVoetnoot { get; set; }
+    public string? AccommodatiePlaats { get; set; }
+    public double? AccommodatieLatitude { get; set; }
+    public double? AccommodatieLongitude { get; set; }
     public string? FetchScheduleLeesbaar { get; set; }
     public List<string>? VolgendeMomenten { get; set; }
+}
+
+public class GeocodeResultDto
+{
+    public double Lat { get; set; }
+    public double Lon { get; set; }
+    public string DisplayName { get; set; } = "";
 }
 
 public class SettingsUpdateDto

--- a/BlazorAdmin/Pages/Instellingen.razor
+++ b/BlazorAdmin/Pages/Instellingen.razor
@@ -35,6 +35,29 @@ else
                 <input class="form-control" @bind="settings.Accommodatie" />
             </div>
             <div class="col-md-6 mb-3">
+                <label class="form-label">Accommodatieplaats</label>
+                <div class="input-group">
+                    <input class="form-control" @bind="settings.AccommodatiePlaats" placeholder="bijv. Veenendaal" />
+                    <button class="btn btn-outline-secondary" type="button"
+                            @onclick="ZoekCoordinaten" disabled="@(geocoding || string.IsNullOrWhiteSpace(settings.AccommodatiePlaats))">
+                        @(geocoding ? "Zoeken..." : "Zoek coördinaten")
+                    </button>
+                </div>
+                @if (settings.AccommodatieLatitude.HasValue && settings.AccommodatieLongitude.HasValue)
+                {
+                    <small class="form-text text-muted">
+                        Coördinaten: @settings.AccommodatieLatitude.Value.ToString("F4", System.Globalization.CultureInfo.InvariantCulture), @settings.AccommodatieLongitude.Value.ToString("F4", System.Globalization.CultureInfo.InvariantCulture)
+                    </small>
+                }
+                @if (!string.IsNullOrEmpty(geocodeMessage))
+                {
+                    <small class="form-text @(geocodeError ? "text-danger" : "text-success")">@geocodeMessage</small>
+                }
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-6 mb-3">
                 <label class="form-label">Intern domein</label>
                 <input class="form-control" @bind="settings.InternDomein" placeholder="bv. vv-vrc.nl" />
                 <small class="form-text text-muted">Emails van dit domein worden overgeslagen</small>
@@ -187,6 +210,10 @@ else
     private string? successMessage;
     private string? herstartMessage;
 
+    private bool geocoding;
+    private string? geocodeMessage;
+    private bool geocodeError;
+
     private List<UitgeslotenEmailAdresDto> uitgeslotenEmails = new();
     private UitgeslotenEmailAdresDto? nieuwAdres;
     private string? uitgeslotenMessage;
@@ -239,6 +266,27 @@ else
         await LaadUitgeslotenEmailsAsync();
     }
 
+    private async Task ZoekCoordinaten()
+    {
+        if (settings == null || string.IsNullOrWhiteSpace(settings.AccommodatiePlaats)) return;
+        geocoding = true;
+        geocodeMessage = null;
+        geocodeError = false;
+        var r = await Api.GeocodeAsync(settings.AccommodatiePlaats);
+        if (r.Success && r.Data != null)
+        {
+            settings.AccommodatieLatitude = r.Data.Lat;
+            settings.AccommodatieLongitude = r.Data.Lon;
+            geocodeMessage = $"Gevonden: {r.Data.DisplayName}";
+        }
+        else
+        {
+            geocodeError = true;
+            geocodeMessage = r.ErrorMessage ?? "Niet gevonden";
+        }
+        geocoding = false;
+    }
+
     private async Task OpslaanAsync()
     {
         if (settings == null) return;
@@ -253,6 +301,9 @@ else
             Velden = new()
             {
                 ["Accommodatie"] = settings.Accommodatie,
+                ["AccommodatiePlaats"] = settings.AccommodatiePlaats,
+                ["AccommodatieLatitude"] = settings.AccommodatieLatitude?.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                ["AccommodatieLongitude"] = settings.AccommodatieLongitude?.ToString(System.Globalization.CultureInfo.InvariantCulture),
                 ["InternDomein"] = settings.InternDomein,
                 ["HerplanDeadlineDagen"] = settings.HerplanDeadlineDagen?.ToString(),
                 ["BufferMinuten"] = settings.BufferMinuten?.ToString(),

--- a/BlazorAdmin/Services/AdminApiClient.cs
+++ b/BlazorAdmin/Services/AdminApiClient.cs
@@ -102,6 +102,11 @@ public class AdminApiClient
         return await GetAsync<EmailLogResponse>("api/beheer/email-log?" + string.Join("&", qp));
     }
 
+    // ── Geocoding ──
+
+    public async Task<ApiResult<GeocodeResultDto>> GeocodeAsync(string plaatsnaam)
+        => await GetAsync<GeocodeResultDto>($"api/beheer/geocode?plaatsnaam={Uri.EscapeDataString(plaatsnaam)}");
+
     // ── Email tester ──
 
     public async Task<ApiResult<TestEmailResponse>> TestEmailAsync(TestEmailRequest dto)

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -333,6 +333,17 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.AppSet
     ALTER TABLE [dbo].[AppSettings] ADD [BufferMinuten] INT NULL;
 GO
 
+-- v2 — #139: AccommodatiePlaats + GPS-coördinaten voor geocoding en zonsondergangsberekening
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.AppSettings') AND name = 'AccommodatiePlaats')
+    ALTER TABLE [dbo].[AppSettings] ADD [AccommodatiePlaats] NVARCHAR(100) NULL;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.AppSettings') AND name = 'AccommodatieLatitude')
+    ALTER TABLE [dbo].[AppSettings] ADD [AccommodatieLatitude] FLOAT NULL;
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.AppSettings') AND name = 'AccommodatieLongitude')
+    ALTER TABLE [dbo].[AppSettings] ADD [AccommodatieLongitude] FLOAT NULL;
+GO
+
 -- v2 — #88: AppSettingsAudit — append-only auditlog van AppSettings/template wijzigingen
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.AppSettingsAudit'))
 BEGIN

--- a/Database/dbo/Tables/AppSettings.sql
+++ b/Database/dbo/Tables/AppSettings.sql
@@ -14,5 +14,8 @@
 	[InternDomein]			NVARCHAR(100)	NULL,	-- bijv. 'vv-vrc.nl' — emails van dit domein overslaan
 	[HerplanDeadlineDagen]	INT				NULL,	-- default 8: herplanverzoek mag niet eerder dan X dagen voor wedstrijd
 	[BufferMinuten]			INT				NULL,	-- default 15: buffer tussen wedstrijden op hetzelfde veld
-	[EmailVoetnoot]			NVARCHAR(MAX)	NULL	-- vrij te bewerken voettekst die onder alle uitgaande e-mails wordt geplaatst
+	[EmailVoetnoot]			NVARCHAR(MAX)	NULL,	-- vrij te bewerken voettekst die onder alle uitgaande e-mails wordt geplaatst
+	[AccommodatiePlaats]	NVARCHAR(100)	NULL,	-- plaatsnaam voor geocoding en zonsondergangsberekening
+	[AccommodatieLatitude]	FLOAT			NULL,	-- breedtegraad WGS84 (decimaal)
+	[AccommodatieLongitude]	FLOAT			NULL	-- lengtegraad WGS84 (decimaal)
 	)

--- a/FunctionApp/Admin/AdminSettingsFunction.cs
+++ b/FunctionApp/Admin/AdminSettingsFunction.cs
@@ -8,6 +8,7 @@ using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Globalization;
 using System.Net.Http.Headers;
 using System.Text;
 
@@ -40,10 +41,18 @@ public static class AdminSettingsFunction
     {
         "InternDomein", "HerplanDeadlineDagen", "BufferMinuten",
         "PlannerAfzenderNaam", "CoordinatorNaam", "CoordinatorFunctie", "PlannerEmailAdres",
-        "Accommodatie", "FetchSchedule", "EmailVoetnoot"
+        "Accommodatie", "FetchSchedule", "EmailVoetnoot",
+        "AccommodatiePlaats", "AccommodatieLatitude", "AccommodatieLongitude"
     };
 
     private const string ManagementApiVersion = "2022-03-01";
+
+    private static readonly HttpClient _geocodeClient;
+    static AdminSettingsFunction()
+    {
+        _geocodeClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        _geocodeClient.DefaultRequestHeaders.Add("User-Agent", "SportlinkAdmin/2.0");
+    }
 
     [Function("AdminSettingsGet")]
     public static async Task<IActionResult> Get(
@@ -64,7 +73,8 @@ public static class AdminSettingsFunction
                     [ClubName], [ClubCode], [SportlinkApiUrl], [SeasonStartMonth], [Accommodatie],
                     [LastSyncTimestamp], [FetchSchedule], [PlannerAfzenderNaam], [CoordinatorNaam],
                     [CoordinatorFunctie], [PlannerEmailAdres], [InternDomein], [HerplanDeadlineDagen],
-                    [BufferMinuten], [EmailVoetnoot]
+                    [BufferMinuten], [EmailVoetnoot], [AccommodatiePlaats],
+                    [AccommodatieLatitude], [AccommodatieLongitude]
                 FROM [dbo].[AppSettings]", connection);
 
             using var reader = await command.ExecuteReaderAsync();
@@ -218,6 +228,63 @@ public static class AdminSettingsFunction
             log.LogError(ex, "Fout bij opslaan AppSettings");
             return new ObjectResult(new { error = "Opslaan mislukt" }) { StatusCode = 500 };
         }
+    }
+
+    /// <summary>
+    /// Zoekt GPS-coördinaten op voor een plaatsnaam via Nominatim (OpenStreetMap).
+    /// Rate-limit: 1 req/sec per Nominatim ToS — ruim voldoende voor admin-gebruik.
+    /// </summary>
+    [Function("AdminGeocodeGet")]
+    public static async Task<IActionResult> Geocode(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "beheer/geocode")] HttpRequest req,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("AdminGeocodeGet");
+        var plaatsnaam = req.Query["plaatsnaam"].ToString().Trim();
+        if (string.IsNullOrWhiteSpace(plaatsnaam))
+            return new BadRequestObjectResult(new { error = "plaatsnaam is verplicht" });
+        if (plaatsnaam.Length > 100)
+            return new BadRequestObjectResult(new { error = "plaatsnaam te lang (max 100 tekens)" });
+
+        try
+        {
+            var url = $"https://nominatim.openstreetmap.org/search?q={Uri.EscapeDataString(plaatsnaam)}&format=json&limit=1&countrycodes=nl";
+            var response = await _geocodeClient.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                log.LogWarning("Nominatim antwoordde met {Status}", (int)response.StatusCode);
+                return new ObjectResult(new { error = "Geocoding service tijdelijk niet beschikbaar" }) { StatusCode = 502 };
+            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var results = JsonConvert.DeserializeObject<NominatimResult[]>(json);
+            if (results == null || results.Length == 0)
+                return new NotFoundObjectResult(new { error = $"Geen resultaat gevonden voor '{plaatsnaam}'" });
+
+            var r = results[0];
+            if (!double.TryParse(r.Lat, NumberStyles.Float, CultureInfo.InvariantCulture, out var lat) ||
+                !double.TryParse(r.Lon, NumberStyles.Float, CultureInfo.InvariantCulture, out var lon))
+                return new ObjectResult(new { error = "Ongeldige coördinaten ontvangen van geocoding service" }) { StatusCode = 502 };
+
+            return new OkObjectResult(new { lat, lon, displayName = r.DisplayName });
+        }
+        catch (TaskCanceledException)
+        {
+            log.LogWarning("Nominatim request time-out voor '{Plaatsnaam}'", plaatsnaam);
+            return new ObjectResult(new { error = "Geocoding service time-out (10s)" }) { StatusCode = 504 };
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij geocoding van '{Plaatsnaam}'", plaatsnaam);
+            return new ObjectResult(new { error = "Geocoding mislukt" }) { StatusCode = 500 };
+        }
+    }
+
+    private class NominatimResult
+    {
+        [JsonProperty("lat")] public string Lat { get; set; } = "";
+        [JsonProperty("lon")] public string Lon { get; set; } = "";
+        [JsonProperty("display_name")] public string DisplayName { get; set; } = "";
     }
 
     /// <summary>

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -25,7 +25,8 @@ namespace SportlinkFunction
                                    [PlannerAfzenderNaam], [CoordinatorNaam], [CoordinatorFunctie],
                                    [PlannerEmailAdres], [Accommodatie], [InternDomein],
                                    [HerplanDeadlineDagen], [BufferMinuten],
-                                   [AccommodatieLatitude], [AccommodatieLongitude], [EmailVoetnoot]
+                                   [AccommodatieLatitude], [AccommodatieLongitude], [EmailVoetnoot],
+                                   [AccommodatiePlaats]
                             FROM [dbo].[AppSettings]";
                         using (SqlCommand command = new SqlCommand(query, connection))
                         using (SqlDataReader reader = await command.ExecuteReaderAsync())
@@ -56,6 +57,7 @@ namespace SportlinkFunction
                                 Set("accommodatieLatitude", 15);
                                 Set("accommodatieLongitude", 16);
                                 Set("emailVoetnoot", 17);
+                                Set("accommodatiePlaats", 18);
                             }
                         }
                     }


### PR DESCRIPTION
## Samenvatting

Beheerders kunnen nu een plaatsnaam invullen in het veld **Accommodatieplaats** op de Instellingen-pagina en met één klik via de Zoek-knop automatisch GPS-coördinaten ophalen via Nominatim (OpenStreetMap, gratis, geen API-key nodig). Coördinaten worden als info-tekst getoond.

Fix kritieke bug: Utilities.cs bevraagde AccommodatieLatitude/AccommodatieLongitude die nog niet in het DB-schema bestonden.

## Wijzigingen

- AppSettings.sql + Script.PostDeployment1.sql: 3 nieuwe kolommen (AccommodatiePlaats, AccommodatieLatitude, AccommodatieLongitude) + idempotente migraties
- Utilities.cs: AccommodatiePlaats in SELECT query
- AdminSettingsFunction.cs: GET /api/beheer/geocode via Nominatim; AllowedFields uitgebreid
- AdminModels.cs: AppSettingsDto uitgebreid; GeocodeResultDto toegevoegd
- AdminApiClient.cs: GeocodeAsync() methode
- Instellingen.razor: AccommodatiePlaats + Zoek-knop + coördinaten als info-tekst

## Test plan

- [ ] dotnet build: 0 errors, 0 warnings (geverifieerd)
- [ ] Instellingen-pagina: AccommodatiePlaats-veld zichtbaar
- [ ] Plaatsnaam invullen en klikken: coördinaten verschijnen als info-tekst
- [ ] Opslaan: AccommodatiePlaats + Lat/Lon in DB
- [ ] Onbekende plaatsnaam: foutmelding

Generated with Claude Code