### PR TITLE
sec(#135): security-gate ook op v2/* PRs + sessie-isolatie + .env in .gitignore

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ['**']
   pull_request:
-    branches: [main]
+    branches: [main, 'v2/**']
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@
 **/__azurite_db_*.json
 **/__blobstorage__/
 
+# ── Environment files (secrets) ──────────────────────────────────────────────
+# .env-bestanden bevatten typisch wachtwoorden, API-keys en connection strings.
+.env
+.env.*
+!.env.template
+!.env.example
+
 # ── Build output ──────────────────────────────────────────────────────────────
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,12 @@ Deze regels gelden altijd, zonder uitzondering:
 
 5. **De Security Gate job is leidend.** Zolang `Security Gate — blokkeert merge bij fout` rood is, mag er niets gemerged worden — ook al zijn andere checks groen.
 
+6. **Sessie-isolatie — werk uitsluitend op de toegewezen branch.** Claude Code op het web draait in een ephemere container; meerdere sessies kunnen parallel actief zijn (bijv. één per open PR). Voorkom kruisbesmetting:
+   - Commit en push **alleen** naar de branch die in de sessie-instructies is genoemd. Nooit naar `main`, nooit naar de branch van een andere sessie.
+   - Vóór elke push: controleer `git branch --show-current` en vergelijk met de toegewezen branch.
+   - Maak **geen** wijzigingen aan bestanden buiten de repository en deel **geen** geheimen tussen sessies. Wat in deze container staat blijft in deze container.
+   - Bij twijfel over welke branch correct is: stop en vraag de gebruiker.
+
 Zie [SECURITY.md](SECURITY.md) voor het volledige protocol.
 
 ## Build & Run

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,7 +57,7 @@ Gitleaks installeren (optioneel maar sterk aanbevolen):
 
 ### Laag 2 — GitHub Actions (in de cloud, bij elke push)
 
-Bij elke push naar elke branch en bij elke pull request naar `main`:
+Bij elke push naar elke branch en bij elke pull request naar `main` of een `v2/*`-branch:
 
 | Check | Wat wordt gecontroleerd | Blokkeert merge? |
 |---|---|---|
@@ -163,7 +163,7 @@ Om te garanderen dat de Security Gate altijd actief is en niet omzeild kan worde
 
 1. Ga naar de repository op GitHub
 2. **Settings → Branches → Add branch protection rule**
-3. Branch name pattern: `main`
+3. Branch name pattern: `main` (herhaal deze stappen voor `v2/develop`)
 4. Vink aan:
    - ✅ **Require a pull request before merging**
    - ✅ **Require status checks to pass before merging**
@@ -172,7 +172,7 @@ Om te garanderen dat de Security Gate altijd actief is en niet omzeild kan worde
    - ✅ **Do not allow bypassing the above settings**
 5. Sla op
 
-Hierna is directe push naar `main` en merge met een rode Security Gate technisch onmogelijk — ook voor repo-eigenaren.
+Hierna is directe push naar `main` (of `v2/develop`) en merge met een rode Security Gate technisch onmogelijk — ook voor repo-eigenaren.
 
 ---
 


### PR DESCRIPTION
- security-scan.yml: pull_request trigger uitgebreid van [main] naar
  [main, v2/**] zodat de Security Gate ook PRs naar v2/develop blokkeert.
- CLAUDE.md: regel 6 toegevoegd over sessie-isolatie — branch verifiëren
  voor push, geen kruisbesmetting tussen parallelle web-sessies.
- SECURITY.md: vermeldt dat de gate ook actief is op v2/* en dat branch
  protection voor v2/develop herhaald moet worden.
- .gitignore: .env en .env.* expliciet uitgesloten (CISO-audit bevinding).

CISO-audit resultaat: repo bevat geen secrets, geen tracked CSV/Excel,
geen PII-patronen in getrackte bestanden. Veilig voor publiek na akkoord.