### PR TITLE
fix(#162): TargetFramework FunctionApp terug naar net9.0 voor Linux Consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ _Wijzigingen op `v2/develop` die nog niet zijn vrijgegeven._
 
 **MINOR-release: Easy Auth bearer-token, Feedback Widget, KNVB-context, geocoding en pipeline-refactor.**
 
+### Fixed
+- **TargetFramework FunctionApp terug naar net9.0** (#162): eerste deploy-poging van v2.1.0 faalde omdat `net10.0` niet ondersteund wordt op Azure Functions Linux Consumption plan. Per officiële Microsoft-docs: ".NET 10 apps cannot run on Linux Consumption — use Flex Consumption instead". FunctionApp + FunctionApp.Tests teruggebracht naar `net9.0`; BlazorAdmin blijft op `net10.0` (browser-runtime, geen Azure-restrictie). Migratie naar Flex Consumption + .NET 10 staat als aparte epic op de roadmap (deadline 10 november 2026 — EOL van .NET 9).
+
 ### Security
 - **Easy Auth op Function App — Bearer token auth** (#100): Admin GUI (Blazor WASM) authenticeert nu direct via Entra ID met MSAL. Bearer tokens worden automatisch meegestuurd naar de Function App, die de tokens valideert via Azure Easy Auth. SWA-proxying van API-calls is losgelaten — SWA dient alleen statische bestanden. Alle `/api/beheer/*`, `/api/test/*` en `/api/feedback/*` endpoints controleren het `X-MS-CLIENT-PRINCIPAL` header (via `EasyAuthHelper`) en vereisen de `admin`-rol. Lokale ontwikkeling werkt zonder auth (`WEBSITE_SITE_NAME` afwezig). CORS geconfigureerd zodat alleen de SWA-origin (`lively-field-03c896603.7.azurestaticapps.net`) API-calls mag doen.
 - **Security Gate bewaakt nu ook v2/develop PRs** (#135): `security-scan.yml` triggert voortaan ook op pull requests richting `v2/develop`. Eerder was er een blinde vlek waarbij code zonder beveiligingscontrole `v2/develop` in kon via een PR.

--- a/FunctionApp.Tests/FunctionApp.Tests.csproj
+++ b/FunctionApp.Tests/FunctionApp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Doel

Lost issue #162 op zodat v2.1.0 opnieuw gedeployed kan worden zonder productie-incident.

## Root cause (uit #162)

De v2.1.0 deploy-poging vanmiddag faalde omdat \`net10.0\` niet wordt ondersteund op Azure Functions Linux Consumption plan. Officiële Microsoft-uitspraak:

> "You can't run .NET 10 apps on Linux in the Consumption plan. To run on Linux, you should instead use the Flex Consumption plan."
>
> — [learn.microsoft.com/azure/azure-functions/supported-languages](https://learn.microsoft.com/azure/azure-functions/supported-languages)

## Wijzigingen

| Bestand | Van | Naar | Reden |
|---|---|---|---|
| \`FunctionApp/fa-dev-sportlink-01.csproj\` | \`net10.0\` | **\`net9.0\`** | Matched met Linux Consumption runtime |
| \`FunctionApp.Tests/FunctionApp.Tests.csproj\` | \`net10.0\` | **\`net9.0\`** | Moet matchen met FunctionApp (project-reference) |
| \`BlazorAdmin/BlazorAdmin.csproj\` | \`net10.0\` | \`net10.0\` (ongewijzigd) | Browser-runtime, geen Azure-restrictie |
| \`CHANGELOG.md\` | — | fix-entry onder [2.1.0] | Documentatie |

## Test plan

- [x] \`dotnet build FunctionApp/fa-dev-sportlink-01.csproj\` — 0 warnings, 0 errors
- [x] \`dotnet build FunctionApp.Tests/FunctionApp.Tests.csproj\` — 0 warnings, 0 errors
- [x] \`dotnet build BlazorAdmin/BlazorAdmin.csproj\` — 0 warnings, 0 errors
- [x] \`dotnet test FunctionApp.Tests\` — 13/13 passed
- [x] Pre-commit hook: geen sensitive data
- [x] Pre-push hook: geen sensitive data
- [ ] Security Gate CI groen
- [ ] Na merge in v2/develop: nieuwe release-PR v2/develop → main
- [ ] Productie-deploy succesvol (smoke test groen)

## CISO/DPO check

- Geen secrets in diff
- Alleen TargetFramework-wijziging + CHANGELOG-aanvulling
- Geen functionele code-wijzigingen → geen security-implicaties

## Vervolg

Na merge van deze PR opnieuw release-cyclus starten voor v2.1.0. Aparte epic moet aangemaakt worden voor de migratie naar Flex Consumption + .NET 10 LTS vóór 10 november 2026 (EOL .NET 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)