### PR TITLE
release: v2.1.0 (retry) — net9.0 fix toegepast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ _Wijzigingen op `v2/develop` die nog niet zijn vrijgegeven._
 
 **MINOR-release: Easy Auth bearer-token, Feedback Widget, KNVB-context, geocoding en pipeline-refactor.**
 
+### Fixed
+- **TargetFramework FunctionApp terug naar net9.0** (#162): eerste deploy-poging van v2.1.0 faalde omdat `net10.0` niet ondersteund wordt op Azure Functions Linux Consumption plan. Per officiële Microsoft-docs: ".NET 10 apps cannot run on Linux Consumption — use Flex Consumption instead". FunctionApp + FunctionApp.Tests teruggebracht naar `net9.0`; BlazorAdmin blijft op `net10.0` (browser-runtime, geen Azure-restrictie). Migratie naar Flex Consumption + .NET 10 staat als aparte epic op de roadmap (deadline 10 november 2026 — EOL van .NET 9).
+
 ### Security
 - **Easy Auth op Function App — Bearer token auth** (#100): Admin GUI (Blazor WASM) authenticeert nu direct via Entra ID met MSAL. Bearer tokens worden automatisch meegestuurd naar de Function App, die de tokens valideert via Azure Easy Auth. SWA-proxying van API-calls is losgelaten — SWA dient alleen statische bestanden. Alle `/api/beheer/*`, `/api/test/*` en `/api/feedback/*` endpoints controleren het `X-MS-CLIENT-PRINCIPAL` header (via `EasyAuthHelper`) en vereisen de `admin`-rol. Lokale ontwikkeling werkt zonder auth (`WEBSITE_SITE_NAME` afwezig). CORS geconfigureerd zodat alleen de SWA-origin (`lively-field-03c896603.7.azurestaticapps.net`) API-calls mag doen.
 - **Security Gate bewaakt nu ook v2/develop PRs** (#135): `security-scan.yml` triggert voortaan ook op pull requests richting `v2/develop`. Eerder was er een blinde vlek waarbij code zonder beveiligingscontrole `v2/develop` in kon via een PR.

--- a/FunctionApp.Tests/FunctionApp.Tests.csproj
+++ b/FunctionApp.Tests/FunctionApp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Release v2.1.0 — tweede poging

Eerste poging (#159) faalde op productie door .NET runtime/target mismatch. Issue #162 is opgelost door PR #164 — \`FunctionApp\` TargetFramework terug naar \`net9.0\` (zie [Microsoft Learn](https://learn.microsoft.com/azure/azure-functions/supported-languages): .NET 10 wordt niet ondersteund op Linux Consumption).

## Wijzigingen t.o.v. eerste poging

- \`FunctionApp/fa-dev-sportlink-01.csproj\`: \`net10.0\` → \`net9.0\`
- \`FunctionApp.Tests/FunctionApp.Tests.csproj\`: \`net10.0\` → \`net9.0\`
- \`BlazorAdmin/BlazorAdmin.csproj\`: blijft \`net10.0\` (browser-runtime)
- CHANGELOG-entry onder [2.1.0]
- \`Sportlink Admin GUI\` orphan client secret verwijderd (#154 gesloten)
- Allowlist voor historische PII commit \`5311d64\` (#161)

## Inhoud v2.1.0

Zie [CHANGELOG.md → 2.1.0](https://github.com/Jaapbeus/Sportlink-wedstrijdzaken/blob/v2/develop/CHANGELOG.md):
- Easy Auth Bearer-token (#100)
- Geocoding via Nominatim (#139)
- Feedback Widget (#129)
- KNVB-regels in AI-context (#73)
- Teamleider-notificatie (#66)
- Schedule-restart via Azure Management API (#27)
- GitHub Issues bij exceptions (#105, #106)
- Team-schedule endpoint (#70)
- Error fingerprinting (#104)
- Unit tests (#51)
- BerichtPipeline refactor (#120)

## Verificatie

- [x] CI groen op v2/develop
- [x] \`dotnet build\` alle 3 projecten — 0 warnings, 0 errors
- [x] \`dotnet test\` — 13/13 passed
- [x] Azure runtime al op \`DOTNET-ISOLATED|9.0\` (matched met csproj)

## Acties ná deploy

- [ ] deploy.yml workflow groen (smoke test 200 op /api/health)
- [ ] Tag v2.1.0 aanmaken
- [ ] Issue #155 — admin-rol toewijzen in Entra ID (eigenaar-actie, blokker voor toegang admin GUI)
- [ ] Issue #131 — Managed Identity (niet blokkerend)

## CISO / DPO

- ✓ Geen secrets in diff
- ✓ Security Gate groen
- ✓ Multi-club isolatie behouden
- ⚠️ Historische PII #161 onder allowlist (eigenaarsbeslissing later)

🤖 Generated with [Claude Code](https://claude.com/claude-code)