### PR TITLE
hotfix(#169): Blazor-Environment header — fix SWA productiecrash

### DIFF
--- a/BlazorAdmin/wwwroot/staticwebapp.config.json
+++ b/BlazorAdmin/wwwroot/staticwebapp.config.json
@@ -1,4 +1,7 @@
 {
+  "globalHeaders": {
+    "Blazor-Environment": "Production"
+  },
   "navigationFallback": {
     "rewrite": "/index.html",
     "exclude": ["/api/*", "/_framework/*", "/css/*", "/js/*", "/*.{png,jpg,gif,ico,woff,woff2}"]


### PR DESCRIPTION
## Probleem

Blazor Admin GUI crasht direct op https://lively-field-03c896603.7.azurestaticapps.net met 'An unhandled error has occurred'.

## Oorzaak

`staticwebapp.config.json` stuurde geen `Blazor-Environment: Production` response header. Blazor WASM laadde daardoor alleen `appsettings.json` (met `FunctionBaseUrl: localhost:7094`) en negeerde `appsettings.Production.json` (met echte Function App URL + MSAL/Entra ID config). MSAL initialiseerde zonder ClientId → crash.

## Fix

`globalHeaders` toegevoegd aan `staticwebapp.config.json`:
```json
{ "Blazor-Environment": "Production" }
```

## Na merge

Blazor SWA opnieuw deployen (handmatig of via CI zodra `AZURE_STATIC_WEB_APPS_API_TOKEN` secret is toegevoegd). Dan ook `main → v2/develop` PR aanmaken om fix door te zetten.

Fixes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)