### PR TITLE
fix(#171): Blazor WASM crasht — WasmApplicationEnvironmentName voor .NET 10

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -8,6 +8,13 @@
     <Version>2.1.0</Version>
   </PropertyGroup>
 
+  <!-- .NET 10: Blazor-Environment HTTP header is vervangen door WasmApplicationEnvironmentName.
+       Zonder dit laadt Blazor altijd appsettings.json (localhost) en negeert appsettings.Production.json.
+       Zie: https://learn.microsoft.com/aspnet/core/release-notes/aspnetcore-10.0#blazor -->
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <WasmApplicationEnvironmentName>Production</WasmApplicationEnvironmentName>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-_Wijzigingen op `v2/develop` die nog niet zijn vrijgegeven._
+### Fixed
+- **Blazor WASM crasht op SWA — .NET 10 omgevingsnaam** (#171): in .NET 10 is de `Blazor-Environment` HTTP header vervangen door `<WasmApplicationEnvironmentName>` in het `.csproj` bestand. Zonder deze instelling laadde Blazor altijd `appsettings.json` (met localhost URL) in plaats van `appsettings.Production.json`, waardoor MSAL zonder ClientId initialiseerde en de app crashte. Fix: `<WasmApplicationEnvironmentName>Production</WasmApplicationEnvironmentName>` toegevoegd aan `BlazorAdmin.csproj` voor Release-builds. Tevens Easy Auth opnieuw ingeschakeld op de Function App.
 
 ---
 


### PR DESCRIPTION
## Probleem

Blazor Admin GUI crasht met 'An unhandled error has occurred' op https://lively-field-03c896603.7.azurestaticapps.net, ook na de eerder gedeployde `Blazor-Environment: Production` header (PR #170).

## Diagnose

In .NET 10 is de `Blazor-Environment` HTTP header **niet langer ondersteund** voor standalone Blazor WebAssembly apps. Dit staat expliciet gedocumenteerd in de [.NET 10 release notes](https://learn.microsoft.com/aspnet/core/release-notes/aspnetcore-10.0?view=aspnetcore-10.0#blazor):

> The `Blazor-Environment` header and `Properties/launchSettings.json` file (`ASPNETCORE_ENVIRONMENT` environment variable) are **no longer used** to control the environment in standalone Blazor WebAssembly apps. Starting in .NET 10, set the environment with the `<WasmApplicationEnvironmentName>` property in the app's project file.

Gevolg: Blazor laadde altijd `appsettings.json` (`FunctionBaseUrl: localhost:7094`) en negeerde `appsettings.Production.json`. MSAL initialiseerde zonder `ClientId` en `Authority` → crash bij startup.

Tevens was Easy Auth op `func-vrc-sportlink` uitgeschakeld (`platform.enabled: false`). Dit is hersteld via az CLI.

## Wijzigingen

- `BlazorAdmin/BlazorAdmin.csproj`: `<WasmApplicationEnvironmentName>Production</WasmApplicationEnvironmentName>` toegevoegd voor Release-builds
- `CHANGELOG.md`: fix gedocumenteerd onder `[Unreleased]`
- Azure: Easy Auth opnieuw ingeschakeld (az CLI, buiten dit PR)

## Resterende handmatige acties (buiten scope PR)

Zie issue #155 voor het toewijzen van de admin-rol in Entra ID.

**Kritiek — SPA Redirect URI ontbreekt in App Registration:**
Azure Portal → App Registration 'Sportlink Admin GUI' → Authentication → Add platform → Single-page application:
- URI: `https://lively-field-03c896603.7.azurestaticapps.net/authentication/login-callback`

Zonder deze SPA URI kan MSAL de login-callback niet verwerken (OAuth PKCE flow).

## Test plan

- [ ] CI groen (Security Gate + Deploy)
- [ ] SWA laadt zonder crash na deploy
- [ ] Login-flow werkt nadat SPA redirect URI is toegevoegd (handmatige actie vereist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)