### PR TITLE
fix(#171): plain HttpClient ontbreekt in productie-DI — Blazor crash

### DIFF
--- a/BlazorAdmin/Program.cs
+++ b/BlazorAdmin/Program.cs
@@ -31,6 +31,11 @@ if (builder.HostEnvironment.IsProduction())
     // het Entra ID access token toe aan elk request richting de Function App URL.
     var capturedFunctionBaseUrl = functionBaseUrl;
     var capturedScope = apiScope;
+
+    // App.razor injecteert HttpClient voor de health check — registreer plain client zonder auth.
+    // AdminApiClient krijgt een eigen HttpClient mét AuthorizationMessageHandler (zie hieronder).
+    builder.Services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(capturedFunctionBaseUrl) });
+
     builder.Services.AddScoped<AdminApiClient>(sp =>
     {
         var handler = sp.GetRequiredService<AuthorizationMessageHandler>()


### PR DESCRIPTION
## Root cause

`App.razor` gebruikt `@inject HttpClient Http` voor de startup health check op `/api/health`.

In de productie-branch van `Program.cs` werd alleen `AdminApiClient` (met `AuthorizationMessageHandler`) geregistreerd — geen plain `HttpClient`. Daardoor faalde DI-resolutie bij het renderen van `App.razor`, wat direct resulteerde in **'An unhandled error has occurred'** vóór elke rendering.

## Oplossing

Voeg `AddScoped<HttpClient>` toe in de productie-branch, naast `AdminApiClient`:
- Plain `HttpClient` → alleen voor health check (geen auth nodig)
- `AdminApiClient` → behoudt eigen `HttpClient` mét `AuthorizationMessageHandler` + Bearer token

## Test plan

- [ ] CI build groen
- [ ] Na deploy: `https://lively-field-03c896603.7.azurestaticapps.net` laadt zonder crash
- [ ] Login-flow start (MSAL redirect naar Microsoft)
- [ ] Health check: `GET /api/health` → 200

Fixes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)