### PR TITLE
fix(#175): health endpoint Anonymous — 20s startup-vertraging Blazor opgelost

### DIFF
--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -270,7 +270,7 @@ namespace SportlinkFunction.Planner
 
         [Function("Health")]
         public static IActionResult Health(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "health")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "health")] HttpRequest req,
             FunctionContext context)
         {
             return new OkObjectResult(new { status = "ok", timestamp = DateTime.UtcNow });


### PR DESCRIPTION
## Probleem

`/api/health` gebruikte `AuthorizationLevel.Function`, waardoor de Blazor startup health-check altijd **401** terugkreeg. `App.razor` retried dit 40× met 500ms tussenruimte = **~20 seconden wachten** vóór de UI zichtbaar werd.

## Oplossing

`AuthorizationLevel.Function` → `AuthorizationLevel.Anonymous` op het health-endpoint.

Health-checks zijn publiek bedoeld (status "ok" + timestamp — geen gevoelige data). Admin-beveiliging zit op de juiste laag: Easy Auth + `EasyAuthHelper.RequireAdmin()` op `/api/beheer/*`, `/api/test/*`, `/api/feedback/*`.

## Test plan

- [ ] CI groen
- [ ] Na deploy: `GET /api/health` → 200 (zonder function key)
- [ ] Blazor app start direct op zonder 20s vertraging
- [ ] Admin-endpoints nog steeds 401 zonder token

Fixes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)