### PR TITLE
security(#177): MSAL auth-gate — admin UI vereist nu Microsoft login

### DIFF
--- a/BlazorAdmin/App.razor
+++ b/BlazorAdmin/App.razor
@@ -27,12 +27,28 @@
 }
 else
 {
-    <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
-        <Found Context="routeData">
-            <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
-            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-        </Found>
-    </Router>
+    <CascadingAuthenticationState>
+        <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+            <Found Context="routeData">
+                <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
+                    <NotAuthorized>
+                        @if (context.User.Identity is { IsAuthenticated: false })
+                        {
+                            <RedirectToLogin />
+                        }
+                        else
+                        {
+                            <p class="p-4">Je bent niet gemachtigd om deze pagina te bekijken.</p>
+                        }
+                    </NotAuthorized>
+                    <Authorizing>
+                        <p class="p-4">Authenticeren...</p>
+                    </Authorizing>
+                </AuthorizeRouteView>
+                <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+            </Found>
+        </Router>
+    </CascadingAuthenticationState>
 }
 
 @code {

--- a/BlazorAdmin/Pages/Authentication.razor
+++ b/BlazorAdmin/Pages/Authentication.razor
@@ -1,0 +1,6 @@
+@page "/authentication/{action}"
+<RemoteAuthenticatorView Action="@Action" />
+
+@code {
+    [Parameter] public string? Action { get; set; }
+}

--- a/BlazorAdmin/Pages/EmailTemplates.razor
+++ b/BlazorAdmin/Pages/EmailTemplates.razor
@@ -1,4 +1,5 @@
 @page "/email-templates"
+@attribute [Authorize]
 @inject AdminApiClient Api
 @inject IAuthService Auth
 

--- a/BlazorAdmin/Pages/EmailTester.razor
+++ b/BlazorAdmin/Pages/EmailTester.razor
@@ -1,4 +1,5 @@
 @page "/email-tester"
+@attribute [Authorize]
 @inject AdminApiClient Api
 
 <PageTitle>Email-tester — VRC Admin</PageTitle>

--- a/BlazorAdmin/Pages/Home.razor
+++ b/BlazorAdmin/Pages/Home.razor
@@ -1,4 +1,5 @@
 @page "/"
+@attribute [Authorize]
 @inject AdminApiClient Api
 
 <PageTitle>Dashboard — VRC Admin</PageTitle>

--- a/BlazorAdmin/Pages/Instellingen.razor
+++ b/BlazorAdmin/Pages/Instellingen.razor
@@ -1,4 +1,5 @@
 @page "/instellingen"
+@attribute [Authorize]
 @inject AdminApiClient Api
 @inject IAuthService Auth
 

--- a/BlazorAdmin/Pages/Voorkeurstijden.razor
+++ b/BlazorAdmin/Pages/Voorkeurstijden.razor
@@ -1,4 +1,5 @@
 @page "/voorkeurstijden"
+@attribute [Authorize]
 @inject AdminApiClient Api
 @using BlazorAdmin.Models
 

--- a/BlazorAdmin/Program.cs
+++ b/BlazorAdmin/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
@@ -48,7 +49,9 @@ if (builder.HostEnvironment.IsProduction())
 }
 else
 {
-    // Ontwikkeling: geen auth, plain HttpClient
+    // Ontwikkeling: geen MSAL; fake AuthenticationStateProvider zodat [Authorize] werkt.
+    builder.Services.AddAuthorizationCore();
+    builder.Services.AddScoped<AuthenticationStateProvider, AlwaysAuthenticatedStateProvider>();
     builder.Services.AddScoped<IAuthService, LocalAuthService>();
     builder.Services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(functionBaseUrl) });
     builder.Services.AddScoped<AdminApiClient>();

--- a/BlazorAdmin/Services/AlwaysAuthenticatedStateProvider.cs
+++ b/BlazorAdmin/Services/AlwaysAuthenticatedStateProvider.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Components.Authorization;
+using System.Security.Claims;
+
+namespace BlazorAdmin.Services;
+
+// Lokale ontwikkeling: AuthenticationState geeft altijd een ingelogde admin terug.
+// Productie: MSAL (WebAssemblyAuthenticationStateProvider) via AddMsalAuthentication.
+public class AlwaysAuthenticatedStateProvider : AuthenticationStateProvider
+{
+    private static readonly AuthenticationState _state = new(
+        new ClaimsPrincipal(new ClaimsIdentity(
+            [new Claim(ClaimTypes.Name, "LocalDev"), new Claim("roles", "admin")],
+            authenticationType: "LocalDev")));
+
+    public override Task<AuthenticationState> GetAuthenticationStateAsync()
+        => Task.FromResult(_state);
+}

--- a/BlazorAdmin/Shared/RedirectToLogin.razor
+++ b/BlazorAdmin/Shared/RedirectToLogin.razor
@@ -1,0 +1,8 @@
+@inject NavigationManager NavigationManager
+
+@code {
+    protected override void OnInitialized()
+    {
+        NavigationManager.NavigateToLogin("authentication/login");
+    }
+}

--- a/BlazorAdmin/_Imports.razor
+++ b/BlazorAdmin/_Imports.razor
@@ -1,5 +1,8 @@
 ﻿@using System.Net.Http
 @using System.Net.Http.Json
+@using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web


### PR DESCRIPTION
## Probleem

Niet-ingelogde gebruikers zagen de volledige admin UI (met lege data — API gaf 401). Dit is ongewenst: de admin UI mag alleen zichtbaar zijn na succesvolle Entra ID authenticatie.

## Technische oorzaak

- `App.razor` gebruikte `<RouteView>` i.p.v. `<AuthorizeRouteView>`
- Geen `CascadingAuthenticationState` → `[Authorize]` werkte nergens
- `AccessTokenNotAvailableException` werd geslikt in `AdminApiClient` → geen MSAL-redirect
- Geen `Authentication.razor` pagina voor MSAL callback-routes

## Wijzigingen

| Bestand | Wat |
|---|---|
| `App.razor` | `CascadingAuthenticationState` + `AuthorizeRouteView` + `RedirectToLogin` bij niet-ingelogd |
| `Authentication.razor` | Nieuw — `RemoteAuthenticatorView` voor MSAL login/logout/register callbacks |
| `RedirectToLogin.razor` | Nieuw — navigeert naar `authentication/login` bij ongeautoriseerde toegang |
| `AlwaysAuthenticatedStateProvider.cs` | Nieuw — fake auth-state voor lokale ontwikkeling (dev) |
| `Program.cs` | `AddAuthorizationCore` + `AlwaysAuthenticatedStateProvider` in dev-pad |
| Alle admin-pagina's | `@attribute [Authorize]` toegevoegd |

## Gedrag na fix

- **Productie:** Niet-ingelogd → directe redirect naar Microsoft login-pagina
- **Ontwikkeling:** Altijd direct ingelogd als LocalDev/admin (geen MSAL nodig)

## Test plan

- [ ] CI groen
- [ ] Na deploy: InPrivate browser → site → directe redirect naar Microsoft login (geen UI zichtbaar)
- [ ] Na inloggen met admin-account → admin UI zichtbaar
- [ ] Dev build werkt nog normaal (dotnet run, geen login vereist)

Fixes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)