### PR TITLE
security(#179): auth-gate boven Router — MainLayout nooit zichtbaar zonder login

### DIFF
--- a/BlazorAdmin/App.razor
+++ b/BlazorAdmin/App.razor
@@ -1,4 +1,6 @@
 @inject HttpClient Http
+@inject AuthenticationStateProvider AuthStateProvider
+@inject NavigationManager NavManager
 @implements IAsyncDisposable
 
 @if (_phase is Phase.Checking or Phase.Ready)
@@ -25,38 +27,72 @@
         </div>
     </div>
 }
-else
+else if (_onAuthRoute)
 {
-    <CascadingAuthenticationState>
-        <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
-            <Found Context="routeData">
-                <AuthorizeRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)">
-                    <NotAuthorized>
-                        @if (context.User.Identity is { IsAuthenticated: false })
-                        {
-                            <RedirectToLogin />
-                        }
-                        else
-                        {
-                            <p class="p-4">Je bent niet gemachtigd om deze pagina te bekijken.</p>
-                        }
-                    </NotAuthorized>
-                    <Authorizing>
-                        <p class="p-4">Authenticeren...</p>
-                    </Authorizing>
-                </AuthorizeRouteView>
-                <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-            </Found>
-        </Router>
-    </CascadingAuthenticationState>
+    @* MSAL-callbackroute: render Router zonder layout zodat Authentication.razor kan verwerken. *@
+    <Router AppAssembly="@typeof(App).Assembly">
+        <Found Context="routeData">
+            <RouteView RouteData="@routeData" />
+        </Found>
+    </Router>
 }
+else if (_isAuthenticated)
+{
+    @* Ingelogd: toon volledige applicatie met MainLayout en navigatie. *@
+    <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+        <Found Context="routeData">
+            <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+        </Found>
+    </Router>
+}
+@* Niet ingelogd en geen authroute: niets tonen — NavigateToLogin is al aangeroepen. *@
 
 @code {
     private Phase _phase = Phase.Checking;
     private string _statusText = "Verbinding maken...";
     private readonly CancellationTokenSource _cts = new();
+    private bool _isAuthenticated;
+    private bool _onAuthRoute;
+    private bool _authCheckInProgress;
 
-    protected override async Task OnInitializedAsync() => await CheckApiAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        NavManager.LocationChanged += HandleLocationChange;
+        _onAuthRoute = NavManager.Uri.Contains("/authentication/");
+        await CheckApiAsync();
+        if (!_onAuthRoute)
+            await CheckAuthAsync();
+    }
+
+    private void HandleLocationChange(object? sender, LocationChangedEventArgs e)
+    {
+        var wasOnAuthRoute = _onAuthRoute;
+        _onAuthRoute = e.Location.Contains("/authentication/");
+
+        // Terugkeer van MSAL-callback naar de app → auth opnieuw controleren
+        if (wasOnAuthRoute && !_onAuthRoute)
+            InvokeAsync(async () => { await CheckAuthAsync(); StateHasChanged(); });
+        else
+            InvokeAsync(StateHasChanged);
+    }
+
+    private async Task CheckAuthAsync()
+    {
+        if (_authCheckInProgress) return;
+        _authCheckInProgress = true;
+        try
+        {
+            var state = await AuthStateProvider.GetAuthenticationStateAsync();
+            _isAuthenticated = state.User.Identity?.IsAuthenticated ?? false;
+            if (!_isAuthenticated)
+                NavManager.NavigateToLogin("authentication/login");
+        }
+        finally
+        {
+            _authCheckInProgress = false;
+        }
+    }
 
     private async Task CheckApiAsync()
     {
@@ -83,12 +119,12 @@ else
             await Task.Delay(500, _cts.Token);
         }
 
-        // Na ~20s nog steeds geen verbinding → toon app in degraded mode
         _phase = Phase.Running;
     }
 
     public async ValueTask DisposeAsync()
     {
+        NavManager.LocationChanged -= HandleLocationChange;
         await _cts.CancelAsync();
         _cts.Dispose();
     }

--- a/BlazorAdmin/Pages/EmailTemplates.razor
+++ b/BlazorAdmin/Pages/EmailTemplates.razor
@@ -1,5 +1,4 @@
 @page "/email-templates"
-@attribute [Authorize]
 @inject AdminApiClient Api
 @inject IAuthService Auth
 

--- a/BlazorAdmin/Pages/EmailTester.razor
+++ b/BlazorAdmin/Pages/EmailTester.razor
@@ -1,5 +1,4 @@
 @page "/email-tester"
-@attribute [Authorize]
 @inject AdminApiClient Api
 
 <PageTitle>Email-tester — VRC Admin</PageTitle>

--- a/BlazorAdmin/Pages/Home.razor
+++ b/BlazorAdmin/Pages/Home.razor
@@ -1,5 +1,4 @@
 @page "/"
-@attribute [Authorize]
 @inject AdminApiClient Api
 
 <PageTitle>Dashboard — VRC Admin</PageTitle>

--- a/BlazorAdmin/Pages/Instellingen.razor
+++ b/BlazorAdmin/Pages/Instellingen.razor
@@ -1,5 +1,4 @@
 @page "/instellingen"
-@attribute [Authorize]
 @inject AdminApiClient Api
 @inject IAuthService Auth
 

--- a/BlazorAdmin/Pages/Voorkeurstijden.razor
+++ b/BlazorAdmin/Pages/Voorkeurstijden.razor
@@ -1,5 +1,4 @@
 @page "/voorkeurstijden"
-@attribute [Authorize]
 @inject AdminApiClient Api
 @using BlazorAdmin.Models
 

--- a/BlazorAdmin/Shared/RedirectToLogin.razor
+++ b/BlazorAdmin/Shared/RedirectToLogin.razor
@@ -1,8 +1,0 @@
-@inject NavigationManager NavigationManager
-
-@code {
-    protected override void OnInitialized()
-    {
-        NavigationManager.NavigateToLogin("authentication/login");
-    }
-}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,39 @@ Zie [SECURITY.md](SECURITY.md) voor het volledige protocol.
 
 ## Architectuurregels — altijd van toepassing
 
+### Blazor auth-gate: altijd BOVEN de Router, nooit erin
+
+**KRITIEKE REGEL — twee keer overtreden (PR #178 en PR #179):**
+
+De Blazor admin UI mag nooit zichtbaar zijn voor niet-ingelogde gebruikers — ook niet kortstondig, ook niet de sidebar/navigatie, ook niet de FEEDBACK-knop.
+
+**Fout patroon (VERBODEN):**
+```razor
+<AuthorizeRouteView DefaultLayout="@typeof(MainLayout)">
+    <NotAuthorized><RedirectToLogin /></NotAuthorized>
+```
+→ `AuthorizeRouteView` rendert `MainLayout` (inclusief sidebar + alle knoppen) voor ALLE states — ook Authorizing en NotAuthorized. Gebruiker ziet de volledige UI.
+
+**Juist patroon (VERPLICHT):**
+```razor
+@* App.razor controleert auth VOORDAT Router/MainLayout wordt gerenderd *@
+else if (_onAuthRoute)       { <Router> ... <RouteView /> (geen layout) } // MSAL callback
+else if (_isAuthenticated)   { <Router> ... <RouteView DefaultLayout="MainLayout" /> }
+@* Niet ingelogd: niets tonen — NavigateToLogin is al aangeroepen *@
+```
+
+**Implementatieregels:**
+1. `App.razor` injecteert `AuthenticationStateProvider` en roept `GetAuthenticationStateAsync()` aan vóór de Router rendert
+2. `MainLayout` (sidebar, navigatie, FEEDBACK-knop) wordt ALLEEN gerenderd als `_isAuthenticated = true`
+3. `/authentication/...` routes (MSAL callbacks) krijgen een aparte Router-branch zonder layout
+4. `NavigationManager.LocationChanged` bewaken voor terugkeer van MSAL-callback naar app
+5. Geen `AuthorizeRouteView` gebruiken als de DefaultLayout de volledige app-shell is
+
+**Verificatie bij elke Blazor auth-wijziging:**
+- Open de site in Incognito/InPrivate mode
+- Controleer: wordt de Microsoft login-pagina getoond ZONDER enige admin-UI zichtbaar?
+- Controleer: is de zijbalk/navigatie/FEEDBACK-knop VOLLEDIG onzichtbaar vóór login?
+
 ### UTC in database, lokale tijd in GUI
 
 - **Database:** alle `DateTime` kolommen opslaan in **UTC** (GETUTCDATE(), geen GETDATE()).


### PR DESCRIPTION
## Wat was er mis (root cause)

`AuthorizeRouteView` met `DefaultLayout=MainLayout` rendert de **volledige layout** (sidebar, navigatie, FEEDBACK-knop) voor ALLE states — ook Authorizing en NotAuthorized. Twee keer aangeleverd als "fix" terwijl het probleem bleef bestaan.

## Correcte implementatie

`App.razor` controleert auth via `AuthenticationStateProvider` **vóór** de Router rendert:

```
Phase.Checking/Ready     → health check spinner
_onAuthRoute=true        → Router zonder layout (MSAL callbacks)
_isAuthenticated=true    → volledige app met MainLayout
(anders)                 → niets tonen, NavigateToLogin aangeroepen
```

`LocationChanged` event bewaakt terugkeer van MSAL-callback naar de app.

## Permanente preventie

- `CLAUDE.md`: architectuurregel toegevoegd met verificatieverplichting (InPrivate test na elke auth-wijziging)
- Memory opgeslagen: `feedback_blazor_auth_gate.md`

## Opgeruimd

- `RedirectToLogin.razor` verwijderd (redirect zit nu in `App.razor`)
- `[Authorize]` van pagina's verwijderd (misleidend zonder `AuthorizeRouteView`)
- Geen `CascadingAuthenticationState` of `AuthorizeRouteView` meer nodig

## Test plan

- [ ] CI groen
- [ ] Na deploy: InPrivate browser → site openen → **geen sidebar/navigatie/FEEDBACK zichtbaar** → directe redirect naar Microsoft login
- [ ] Na inloggen: volledige admin UI zichtbaar

Fixes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)