### PR TITLE
feat(#192): post-logout redirect naar clubwebsite

### DIFF
--- a/BlazorAdmin/Pages/Authentication.razor
+++ b/BlazorAdmin/Pages/Authentication.razor
@@ -1,6 +1,48 @@
 @page "/authentication/{action}"
-<RemoteAuthenticatorView Action="@Action" />
+@using Microsoft.Extensions.Configuration
+@inject NavigationManager NavManager
+@inject IConfiguration Config
+
+<RemoteAuthenticatorView Action="@Action">
+    <LogOutSucceeded>
+        <div class="api-startup">
+            <div class="startup-card">
+                <div class="startup-check">
+                    <svg class="checkmark-svg" viewBox="0 0 52 52">
+                        <circle class="checkmark-circle" cx="26" cy="26" r="25" fill="none" />
+                        <path class="checkmark-path" fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8" />
+                    </svg>
+                </div>
+                <p class="startup-label startup-label-ready">Je bent uitgelogd.</p>
+                @if (!string.IsNullOrWhiteSpace(PostLogoutUrl))
+                {
+                    <p class="startup-label">Doorsturen naar de clubwebsite...</p>
+                }
+            </div>
+        </div>
+    </LogOutSucceeded>
+</RemoteAuthenticatorView>
 
 @code {
     [Parameter] public string? Action { get; set; }
+
+    private string? PostLogoutUrl => Config["PostLogoutRedirectUrl"];
+    private bool _redirectScheduled;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        // Na een succesvolle logout-callback en als er een PostLogoutRedirectUrl is
+        // geconfigureerd → na korte UX-pauze redirecten naar de clubwebsite.
+        // URL komt uit appsettings.Production.json zodat dit per club configureerbaar is
+        // (geen hardcoded club-strings in code — zie CLAUDE.md).
+        if (firstRender
+            && !_redirectScheduled
+            && string.Equals(Action, "logout-callback", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(PostLogoutUrl))
+        {
+            _redirectScheduled = true;
+            await Task.Delay(1500);
+            NavManager.NavigateTo(PostLogoutUrl, forceLoad: true);
+        }
+    }
 }

--- a/BlazorAdmin/wwwroot/appsettings.Production.json
+++ b/BlazorAdmin/wwwroot/appsettings.Production.json
@@ -4,5 +4,6 @@
     "Authority": "https://login.microsoftonline.com/74f2b2fe-a0af-4983-9520-ea3b2ac423fb",
     "ClientId": "75802a92-b3cb-4e98-bd4c-3167ce17d3fe",
     "ValidateAuthority": true
-  }
+  },
+  "PostLogoutRedirectUrl": "https://www.vv-vrc.nl/"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+- **Post-logout redirect naar clubwebsite** (#192): na klikken op 'Uitloggen' belandde de gebruiker op `/authentication/logout-callback` met de MSAL default tekst 'Processing logout callback...' zonder feedback of exit-pad. `Authentication.razor` toont nu een groene-check + 'Je bent uitgelogd' melding, en redirect na 1,5 seconde naar de URL geconfigureerd in `PostLogoutRedirectUrl`. URL via `IConfiguration` uit `appsettings.Production.json` zodat dit per club configureerbaar is — geen hardcoded club-string in code (zie CLAUDE.md). Bij ontbrekende config: alleen de uitgelogd-melding, geen redirect.
+
 ### Fixed
 - **Blazor WASM: CustomUserFactory voor Entra `roles` JSON-array** (#190): geauthenticeerde users met admin-rol kregen na login toch de NoAccess pagina te zien. Root cause: Blazor's standaard `RemoteUserAccount`-factory cast een JSON-array `"roles": ["admin"]` uit het ID-token naar één claim met de hele JSON-string als value (`'["admin"]'`). `ClaimsPrincipal.IsInRole("admin")` faalt daardoor — de claim value is een string, niet de losse rol-naam. Officieel Microsoft Learn troubleshoot artikel: https://learn.microsoft.com/troubleshoot/entra/entra-id/app-integration/troubleshoot-rabc-issues-webassembly-auth-apps. Fix: `BlazorAdmin/Services/CustomUserFactory.cs` toegevoegd dat de `roles` claim uit `account.AdditionalProperties` uitleest, de bestaande JSON-string claim verwijdert, en voor elk array-element een losse `Claim(roleClaim, value)` toevoegt. Geregistreerd in `Program.cs` via `.AddAccountClaimsPrincipalFactory<CustomUserFactory>()`. CLAUDE.md MSAL-checklist uitgebreid van 10 naar 11 verplichte items.
 


### PR DESCRIPTION
## Summary

Fixes #192.

Na 'Uitloggen' belandde de gebruiker op `/authentication/logout-callback` met de MSAL default tekst 'Processing logout callback...' — geen feedback, geen exit-pad.

## Wijzigingen

- `Authentication.razor`: `<LogOutSucceeded>` fragment met groene check + 'Je bent uitgelogd' melding. Daarna 1,5s delay → redirect via `NavigationManager.NavigateTo(forceLoad: true)`.
- `appsettings.Production.json`: `"PostLogoutRedirectUrl": "https://www.vv-vrc.nl/"` toegevoegd.
- URL via `IConfiguration` — geen hardcoded club-string in code (CLAUDE.md regel "Geen club-specifieke strings in code").
- Bij ontbrekende config: alleen de uitgelogd-melding, geen redirect. Dev (appsettings.json) heeft geen `PostLogoutRedirectUrl`, dus lokaal blijft de gebruiker gewoon op de pagina.

## Test plan

- [x] `dotnet build -c Release` → 0 warnings, 0 errors
- [ ] Na deploy: login als jaapadmin → Uitloggen → korte "Je bent uitgelogd" melding → automatisch naar https://www.vv-vrc.nl/

🤖 Generated with [Claude Code](https://claude.com/claude-code)