### PR TITLE
release: v2.1.1

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.1.0</Version>
+    <Version>2.1.1</Version>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+---
+
+## [2.1.1] — 2026-05-20
+
+**PATCH-release: defense-in-depth auth-keten gevalideerd via 3-user-test (admin / user / geen-rol) op productie.**
+
+Zeven samenhangende fixes en verbeteringen sinds v2.1.0 die de Entra ID auth-flow definitief waterdicht maken voor multi-user/multi-rol scenario's. Volledige defense-in-depth architectuur met vijf onafhankelijke lagen (tenant + assignment-required + app roles + frontend role-gate + backend RequireAdmin) gedocumenteerd in `CLAUDE.md` en `docs/AZURE-ENTRA-SETUP.md`. Idempotente PowerShell-scripts in `scripts/` zorgen dat de Entra-config nooit meer handmatig hoeft.
+
 ### Added
 - **Post-logout redirect naar clubwebsite** (#192): na klikken op 'Uitloggen' belandde de gebruiker op `/authentication/logout-callback` met de MSAL default tekst 'Processing logout callback...' zonder feedback of exit-pad. `Authentication.razor` toont nu een groene-check + 'Je bent uitgelogd' melding, en redirect na 1,5 seconde naar de URL geconfigureerd in `PostLogoutRedirectUrl`. URL via `IConfiguration` uit `appsettings.Production.json` zodat dit per club configureerbaar is — geen hardcoded club-string in code (zie CLAUDE.md). Bij ontbrekende config: alleen de uitgelogd-melding, geen redirect.
 

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.1.0</Version>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
-    <FileVersion>2.1.0.0</FileVersion>
+    <Version>2.1.1</Version>
+    <AssemblyVersion>2.1.1.0</AssemblyVersion>
+    <FileVersion>2.1.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
## Summary

Release v2.1.1 — PATCH-bump van v2.1.0. Defense-in-depth auth-keten gevalideerd via 3-user-test op productie.

## Wat zit erin

Zeven samenhangende fixes/features sinds v2.1.0:

| Issue | Wat |
|---|---|
| #181 | Auth-redirect loop fix — MSAL splash blokkeerde login in InPrivate |
| #183 | Chrome incognito wasm-compression fix (`CompressionEnabled=false`) |
| #185 | Frontend role-gate (Layer 4) — tenant-user zonder rol → NoAccess pagina |
| #187 | Idempotente Entra setup scripts + protocol (`scripts/` + `docs/AZURE-ENTRA-SETUP.md`) |
| #189 | Verify/Configure UX onderscheid + Microsoft Graph schema fix (`roles` niet in accessToken) |
| #190 | CustomUserFactory voor Entra `roles` JSON-array — `IsInRole` werkt nu |
| #192 | Post-logout redirect naar clubwebsite |

## Wijzigingen in deze release-PR

- `BlazorAdmin/BlazorAdmin.csproj`: `<Version>` 2.1.0 → 2.1.1
- `FunctionApp/fa-dev-sportlink-01.csproj`: `<Version>` + `<AssemblyVersion>` + `<FileVersion>` 2.1.0 → 2.1.1
- `CHANGELOG.md`: `## [Unreleased]` content verplaatst naar `## [2.1.1] — 2026-05-20`, lege Unreleased aan top toegevoegd

## Test plan

- [x] `dotnet build BlazorAdmin -c Release` → 0 warnings, 0 errors
- [x] `dotnet build FunctionApp -c Debug` → 0 warnings, 0 errors
- [x] Auth-keten getest op productie (3-user-test):
  - jaapadmin (admin rol) → volledige UI ✓
  - 2e user (user rol) → UI laadt ✓
  - vv-vrc user zonder rol → geweigerd door Entra ✓
- [ ] Na merge: `git tag v2.1.1` + push → `release.yml` workflow → GitHub Release automatisch aangemaakt

🤖 Generated with [Claude Code](https://claude.com/claude-code)