### PR TITLE
fix(#196): release.yml — CHANGELOG via env-var ipv JS template literal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,12 +80,20 @@ jobs:
 
       - name: GitHub Release aanmaken
         uses: actions/github-script@v7
+        env:
+          # Notes via env-var doorgeven — zo wordt CHANGELOG-content NIET als
+          # JavaScript template literal geparsed. Backticks, ${...} en andere
+          # markdown-tekens in CHANGELOG zouden anders een SyntaxError geven.
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+          RELEASE_PRERELEASE: ${{ inputs.prerelease }}
+          RELEASE_NOTES: ${{ steps.changelog.outputs.notes }}
         with:
           script: |
-            const version = '${{ steps.version.outputs.version }}';
-            const tag = '${{ steps.version.outputs.tag }}';
-            const isPrerelease = '${{ inputs.prerelease }}' === 'true';
-            const notes = `${{ steps.changelog.outputs.notes }}`;
+            const version = process.env.RELEASE_VERSION;
+            const tag = process.env.RELEASE_TAG;
+            const isPrerelease = process.env.RELEASE_PRERELEASE === 'true';
+            const notes = process.env.RELEASE_NOTES || '';
 
             const major = parseInt(version.split('.')[0]);
             const isV2Plus = major >= 2;
@@ -101,4 +109,4 @@ jobs:
               make_latest: isV2Plus ? 'true' : 'false'
             });
 
-            core.notice(`✅ Release ${tag} aangemaakt`);
+            core.notice(`Release ${tag} aangemaakt`);


### PR DESCRIPTION
Fixes #196.

Backticks in CHANGELOG.md braken de JS template literal in release.yml waarmee de GitHub Release wordt aangemaakt. Voor v2.1.1 moest de Release handmatig aangemaakt worden via gh CLI. Deze fix gebruikt environment variabelen zodat CHANGELOG-content nooit meer als JavaScript wordt geparsed.

Test plan: bij volgende tag-push moet de workflow automatisch slagen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)