### PR TITLE
fix(#195): net_http_handler_not_assigned — AuthorizationMessageHandler InnerHandler

### DIFF
--- a/BlazorAdmin/Program.cs
+++ b/BlazorAdmin/Program.cs
@@ -53,6 +53,10 @@ if (builder.HostEnvironment.IsProduction())
             .ConfigureHandler(
                 authorizedUrls: [capturedFunctionBaseUrl],
                 scopes: [capturedScope]);
+        // DelegatingHandler vereist een InnerHandler (de transport-laag).
+        // Zonder dit gooit HttpClient 'net_http_handler_not_assigned'.
+        // In Blazor WASM mapt HttpClientHandler op BrowserHttpHandler (browser fetch API).
+        handler.InnerHandler = new HttpClientHandler();
         var http = new HttpClient(handler) { BaseAddress = new Uri(capturedFunctionBaseUrl) };
         return new AdminApiClient(http);
     });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- Alle API-aanroepen vanuit de Admin GUI faalden met `net_http_handler_not_assigned` na het inloggen. Oorzaak: de `AuthorizationMessageHandler` (MSAL Bearer token) had geen transport-handler toegewezen gekregen. Fix: `InnerHandler` expliciet gezet op `HttpClientHandler`, conform Blazor WASM vereisten. Dashboard, instellingen en feedbackknop werken nu correct.
+
 ---
 
 ## [2.1.1] — 2026-05-20


### PR DESCRIPTION
## Summary

- `AuthorizationMessageHandler` is een `DelegatingHandler` en vereist een `InnerHandler` (de transport-laag naar de browser fetch API).
- Zonder expliciete toewijzing gooit Blazor WASM `net_http_handler_not_assigned` bij **elke** API-aanroep — dashboard, instellingen én feedbackknop faalden allemaal.
- Fix: `handler.InnerHandler = new HttpClientHandler()` vóór `new HttpClient(handler)`. In Blazor WASM mapt `HttpClientHandler` op de browser fetch API.

Fixes #195

## Test plan

- [ ] Incognito browser — inloggen met jaapadmin@vv-vrc.nl
- [ ] Dashboard laadt zonder fouten (sync-status zichtbaar)
- [ ] Instellingen-pagina laadt en toont huidige waarden
- [ ] Feedbackknop: validatie en submit werken zonder `net_http_handler_not_assigned`
- [ ] F12 Network: API-calls naar `func-vrc-sportlink.azurewebsites.net` slagen met Bearer token

🤖 Generated with [Claude Code](https://claude.com/claude-code)