### PR TITLE
chore: sync v2/develop met main — #195 net_http_handler fix

### DIFF
--- a/BlazorAdmin/Program.cs
+++ b/BlazorAdmin/Program.cs
@@ -53,6 +53,10 @@ if (builder.HostEnvironment.IsProduction())
             .ConfigureHandler(
                 authorizedUrls: [capturedFunctionBaseUrl],
                 scopes: [capturedScope]);
+        // DelegatingHandler vereist een InnerHandler (de transport-laag).
+        // Zonder dit gooit HttpClient 'net_http_handler_not_assigned'.
+        // In Blazor WASM mapt HttpClientHandler op BrowserHttpHandler (browser fetch API).
+        handler.InnerHandler = new HttpClientHandler();
         var http = new HttpClient(handler) { BaseAddress = new Uri(capturedFunctionBaseUrl) };
         return new AdminApiClient(http);
     });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- Alle API-aanroepen vanuit de Admin GUI faalden met `net_http_handler_not_assigned` na het inloggen. Oorzaak: de `AuthorizationMessageHandler` (MSAL Bearer token) had geen transport-handler toegewezen gekregen. Fix: `InnerHandler` expliciet gezet op `HttpClientHandler`, conform Blazor WASM vereisten. Dashboard, instellingen en feedbackknop werken nu correct.
+
 ---
 
 ## [2.1.1] — 2026-05-20


### PR DESCRIPTION
Synchroniseert `v2/develop` met `main` na hotfix #195 (PR #198).

Wijziging: `AuthorizationMessageHandler.InnerHandler` expliciet gezet — alle API-aanroepen vanuit de Admin GUI werkten niet na inloggen.