### PR TITLE
release: v2.1.2 — net_http_handler_not_assigned fix (#195)

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.1.1</Version>
+    <Version>2.1.2</Version>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,15 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+---
+
+## [2.1.2] — 2026-05-20
+
+**PATCH-release: API-connectie hersteld na login — `net_http_handler_not_assigned` opgelost.**
+
 ### Fixed
 
-- Alle API-aanroepen vanuit de Admin GUI faalden met `net_http_handler_not_assigned` na het inloggen. Oorzaak: de `AuthorizationMessageHandler` (MSAL Bearer token) had geen transport-handler toegewezen gekregen. Fix: `InnerHandler` expliciet gezet op `HttpClientHandler`, conform Blazor WASM vereisten. Dashboard, instellingen en feedbackknop werken nu correct.
+- **Alle API-aanroepen faalden na inloggen** (#195): dashboard, instellingen en feedbackknop gaven `net_http_handler_not_assigned` terug na een succesvolle login. Oorzaak: `AuthorizationMessageHandler` (die MSAL Bearer tokens toevoegt) is een `DelegatingHandler` en vereist een `InnerHandler` — de transport-laag die het HTTP-verzoek naar de browser fetch API stuurt. Zonder expliciete toewijzing gooit Blazor WASM de fout bij elke API-aanroep. Fix: `handler.InnerHandler = new HttpClientHandler()` in `Program.cs`.
 
 ---
 

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.1.1</Version>
-    <AssemblyVersion>2.1.1.0</AssemblyVersion>
-    <FileVersion>2.1.1.0</FileVersion>
+    <Version>2.1.2</Version>
+    <AssemblyVersion>2.1.2.0</AssemblyVersion>
+    <FileVersion>2.1.2.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
## Summary

- CHANGELOG: [Unreleased] leeg, v2.1.2 sectie toegevoegd met beschrijving van #195 fix
- Versie bump naar 2.1.2 in beide `.csproj` bestanden

De eigenlijke code-fix zit al in `v2/develop` via de eerdere hotfix (PR #198).
Dit PR formaliseert de release: versienummer + CHANGELOG correct.

## Test plan

- [ ] Build slaagt (gecontroleerd lokaal)
- [ ] Na merge: tag v2.1.2 aanmaken → release.yml workflow maakt GitHub Release aan

🤖 Generated with [Claude Code](https://claude.com/claude-code)