### PR TITLE
chore: gitignore SECRET-ROTATION.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,12 @@
 !.env.template
 !.env.example
 
+# ── Lokale operationele documenten (niet in repo) ─────────────────────────────
+# Stap-voor-stap handleidingen met azure/github URLs en resource-namen.
+# Staan alleen lokaal — bevatten geen secrets maar wel infra-details die niet
+# publiek hoeven te zijn.
+SECRET-ROTATION.md
+
 # ── Build output ──────────────────────────────────────────────────────────────
 [Dd]ebug/
 [Dd]ebugPublic/


### PR DESCRIPTION
Voegt `SECRET-ROTATION.md` toe aan .gitignore zodat het lokale rotatie-instructiedocument nooit per ongeluk gecommit wordt.

Het document zelf staat alleen lokaal en bevat geen secrets maar wel infra-details (Azure/GitHub URLs, resource-namen) die niet publiek hoeven te zijn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)