### PR TITLE
chore(#215): vervang GETDATE() door GETUTCDATE() in alle mta/timestamp-kolommen

### DIFF
--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -315,7 +315,7 @@ END
 GO
 -- Bestaande 'Gepland' rijen bijwerken naar 'Te bevestigen'
 UPDATE [planner].[GeplandeWedstrijden]
-SET [Status] = 'Te bevestigen', [mta_modified] = GETDATE()
+SET [Status] = 'Te bevestigen', [mta_modified] = GETUTCDATE()
 WHERE [Status] = 'Gepland';
 GO
 
@@ -346,7 +346,7 @@ IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.AppSett
 BEGIN
     CREATE TABLE [dbo].[AppSettingsAudit] (
         [Id]            INT IDENTITY(1,1) NOT NULL,
-        [Tijdstip]      DATETIME2 NOT NULL CONSTRAINT [DF_AppSettingsAudit_Tijdstip] DEFAULT GETDATE(),
+        [Tijdstip]      DATETIME2 NOT NULL CONSTRAINT [DF_AppSettingsAudit_Tijdstip] DEFAULT GETUTCDATE(),
         [GewijzigdDoor] NVARCHAR(100) NOT NULL,
         [Veld]          NVARCHAR(100) NOT NULL,
         [OudeWaarde]    NVARCHAR(MAX) NULL,
@@ -368,8 +368,8 @@ BEGIN
         [Prioriteit]    INT NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Prioriteit] DEFAULT 5,
         [Actief]        BIT NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Actief] DEFAULT 1,
         [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_ClubCode] DEFAULT 'VRC',
-        [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Inserted] DEFAULT GETDATE(),
-        [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Modified] DEFAULT GETDATE(),
+        [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Inserted] DEFAULT GETUTCDATE(),
+        [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Modified] DEFAULT GETUTCDATE(),
         CONSTRAINT [PK_TeamVoorkeurTijden] PRIMARY KEY CLUSTERED ([Id] ASC)
     );
 END
@@ -384,7 +384,7 @@ BEGIN
         [Omschrijving] NVARCHAR(500) NULL,
         [Actief]       BIT NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Actief]    DEFAULT 1,
         [ClubCode]     NVARCHAR(20) NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_ClubCode]  DEFAULT 'VRC',
-        [mta_inserted] DATETIME2 NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Inserted] DEFAULT GETDATE(),
+        [mta_inserted] DATETIME2 NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Inserted] DEFAULT GETUTCDATE(),
         CONSTRAINT [PK_UitgeslotenEmailAdressen] PRIMARY KEY CLUSTERED ([Id] ASC),
         CONSTRAINT [UQ_UitgeslotenEmailAdressen_Adres] UNIQUE ([EmailAdres], [ClubCode])
     );
@@ -406,8 +406,8 @@ BEGIN
         [BodyTemplate]  NVARCHAR(MAX) NOT NULL,
         [Actief]        BIT NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Actief] DEFAULT 1,
         [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_ClubCode] DEFAULT 'VRC',
-        [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Inserted] DEFAULT GETDATE(),
-        [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Modified] DEFAULT GETDATE(),
+        [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Inserted] DEFAULT GETUTCDATE(),
+        [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Modified] DEFAULT GETUTCDATE(),
         CONSTRAINT [PK_EmailTemplateInstellingen] PRIMARY KEY CLUSTERED ([Id] ASC),
         CONSTRAINT [UQ_EmailTemplateInstellingen_Key] UNIQUE ([TemplateKey], [ClubCode])
     );

--- a/Database/avg/Tables/ImportLog.sql
+++ b/Database/avg/Tables/ImportLog.sql
@@ -1,6 +1,6 @@
 CREATE TABLE [avg].[ImportLog] (
     [Id]               INT            IDENTITY (1, 1) NOT NULL,
-    [ImportDatum]      DATETIME       CONSTRAINT [DF_avg_ImportLog_ImportDatum] DEFAULT (GETDATE()) NOT NULL,
+    [ImportDatum]      DATETIME       CONSTRAINT [DF_avg_ImportLog_ImportDatum] DEFAULT (GETUTCDATE()) NOT NULL,
     [AantalRijen]      INT            NOT NULL,
     [CsvBestand]       NVARCHAR (500) NULL,
     [ImporterendeDoor] NVARCHAR (200) NULL,

--- a/Database/avg/Tables/Teambegeleiding.sql
+++ b/Database/avg/Tables/Teambegeleiding.sql
@@ -10,6 +10,6 @@ CREATE TABLE [avg].[Teambegeleiding] (
     [Naam]                   NVARCHAR (300) NULL,
     [Emailadres]             NVARCHAR (200) NULL,
     [Telefoonnummer]         NVARCHAR (50)  NULL,
-    [mta_imported]           DATETIME       CONSTRAINT [DF_avg_Teambegeleiding_mta_imported] DEFAULT (GETDATE()) NOT NULL,
+    [mta_imported]           DATETIME       CONSTRAINT [DF_avg_Teambegeleiding_mta_imported] DEFAULT (GETUTCDATE()) NOT NULL,
     CONSTRAINT [PK_avg_Teambegeleiding] PRIMARY KEY CLUSTERED ([Id] ASC)
 );

--- a/Database/dbo/System Stored Procedures/sp_MergeStgToHis.sql
+++ b/Database/dbo/System Stored Procedures/sp_MergeStgToHis.sql
@@ -123,7 +123,7 @@ WHEN MATCHED AND (';
     SET @SqlString += ')
 THEN UPDATE SET '
         + @SqlStringTmp + '
-    target.mta_modified = GETDATE()';
+    target.mta_modified = GETUTCDATE()';
 
     SET @SqlString += '
 WHEN NOT MATCHED BY TARGET THEN ';
@@ -143,7 +143,7 @@ WHEN NOT MATCHED BY TARGET THEN ';
     -- CONCAT supports both single and multi-column source keys
     SET @SqlString += '
 INSERT (' + @TargetPk + @SqlStringTargets + ', mta_inserted, mta_modified)
-VALUES (CONCAT('''', ' + @SourcePkColumns + ')' + @SqlStringValues + ', GETDATE(), GETDATE());';
+VALUES (CONCAT('''', ' + @SourcePkColumns + ')' + @SqlStringValues + ', GETUTCDATE(), GETUTCDATE());';
 
     EXEC sp_executesql @SqlString;
 

--- a/Database/dbo/Tables/AppSettingsAudit.sql
+++ b/Database/dbo/Tables/AppSettingsAudit.sql
@@ -1,6 +1,6 @@
 CREATE TABLE [dbo].[AppSettingsAudit] (
     [Id]            INT IDENTITY(1,1) NOT NULL,
-    [Tijdstip]      DATETIME2 NOT NULL CONSTRAINT [DF_AppSettingsAudit_Tijdstip] DEFAULT GETDATE(),
+    [Tijdstip]      DATETIME2 NOT NULL CONSTRAINT [DF_AppSettingsAudit_Tijdstip] DEFAULT GETUTCDATE(),
     [GewijzigdDoor] NVARCHAR(100) NOT NULL,
     [Veld]          NVARCHAR(100) NOT NULL,
     [OudeWaarde]    NVARCHAR(MAX) NULL,

--- a/Database/dbo/Tables/EmailTemplateInstellingen.sql
+++ b/Database/dbo/Tables/EmailTemplateInstellingen.sql
@@ -5,8 +5,8 @@ CREATE TABLE [dbo].[EmailTemplateInstellingen] (
     [BodyTemplate]  NVARCHAR(MAX) NOT NULL,
     [Actief]        BIT NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Actief] DEFAULT 1,
     [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_ClubCode] DEFAULT 'VRC',
-    [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Inserted] DEFAULT GETDATE(),
-    [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Modified] DEFAULT GETDATE(),
+    [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Inserted] DEFAULT GETUTCDATE(),
+    [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Modified] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_EmailTemplateInstellingen] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [UQ_EmailTemplateInstellingen_Key] UNIQUE ([TemplateKey], [ClubCode])
 );

--- a/Database/dbo/Tables/TeamVoorkeurTijden.sql
+++ b/Database/dbo/Tables/TeamVoorkeurTijden.sql
@@ -6,7 +6,7 @@ CREATE TABLE [dbo].[TeamVoorkeurTijden] (
     [Prioriteit]    INT NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Prioriteit] DEFAULT 5,
     [Actief]        BIT NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Actief] DEFAULT 1,
     [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_ClubCode] DEFAULT 'VRC',
-    [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Inserted] DEFAULT GETDATE(),
-    [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Modified] DEFAULT GETDATE(),
+    [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Inserted] DEFAULT GETUTCDATE(),
+    [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Modified] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_TeamVoorkeurTijden] PRIMARY KEY CLUSTERED ([Id] ASC)
 );

--- a/Database/dbo/Tables/UitgeslotenEmailAdressen.sql
+++ b/Database/dbo/Tables/UitgeslotenEmailAdressen.sql
@@ -4,7 +4,7 @@ CREATE TABLE [dbo].[UitgeslotenEmailAdressen] (
     [Omschrijving] NVARCHAR (500) NULL,
     [Actief]       BIT            NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Actief]    DEFAULT 1,
     [ClubCode]     NVARCHAR (20)  NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_ClubCode]  DEFAULT 'VRC',
-    [mta_inserted] DATETIME2 (7)  NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Inserted] DEFAULT GETDATE(),
+    [mta_inserted] DATETIME2 (7)  NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Inserted] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_UitgeslotenEmailAdressen] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [UQ_UitgeslotenEmailAdressen_Adres] UNIQUE ([EmailAdres], [ClubCode])
 );

--- a/Database/planner/Tables/EmailVerwerking.sql
+++ b/Database/planner/Tables/EmailVerwerking.sql
@@ -14,8 +14,8 @@ CREATE TABLE [planner].[EmailVerwerking] (
     [Status]                NVARCHAR(30)    NOT NULL CONSTRAINT [DF_EmailVerwerking_Status] DEFAULT 'Ontvangen',
     [FoutMelding]           NVARCHAR(1000)  NULL,
     [ClubCode]              NVARCHAR(20)    NOT NULL CONSTRAINT [DF_EmailVerwerking_ClubCode] DEFAULT 'VRC',
-    [mta_inserted]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Ins] DEFAULT GETDATE(),
-    [mta_modified]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Mod] DEFAULT GETDATE(),
+    [mta_inserted]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Ins] DEFAULT GETUTCDATE(),
+    [mta_modified]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Mod] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_EmailVerwerking] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [UQ_EmailVerwerking_MessageId] UNIQUE ([MessageId])
 );

--- a/Database/planner/Tables/GeplandeWedstrijden.sql
+++ b/Database/planner/Tables/GeplandeWedstrijden.sql
@@ -14,8 +14,8 @@ CREATE TABLE [planner].[GeplandeWedstrijden] (
     [Opmerking]             NVARCHAR(500)  NULL,
     [IsVervallen]           BIT            NOT NULL CONSTRAINT [DF_GeplandeWedstrijden_IsVervallen] DEFAULT 0,
     [SportlinkWedstrijdCode] BIGINT        NULL,
-    [mta_inserted]          DATETIME       NOT NULL CONSTRAINT [DF_GeplandeWedstrijden_Ins] DEFAULT GETDATE(),
-    [mta_modified]          DATETIME       NOT NULL CONSTRAINT [DF_GeplandeWedstrijden_Mod] DEFAULT GETDATE(),
+    [mta_inserted]          DATETIME       NOT NULL CONSTRAINT [DF_GeplandeWedstrijden_Ins] DEFAULT GETUTCDATE(),
+    [mta_modified]          DATETIME       NOT NULL CONSTRAINT [DF_GeplandeWedstrijden_Mod] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_GeplandeWedstrijden] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [FK_GeplandeWedstrijden_Velden] FOREIGN KEY ([VeldNummer]) REFERENCES [dbo].[Velden]([VeldNummer]),
     CONSTRAINT [UQ_GeplandeWedstrijden_Slot] UNIQUE ([Datum], [AanvangsTijd], [VeldNummer], [VeldDeelGebruik])

--- a/Database/planner/Tables/HerplanVerzoeken.sql
+++ b/Database/planner/Tables/HerplanVerzoeken.sql
@@ -10,7 +10,7 @@ CREATE TABLE [planner].[HerplanVerzoeken] (
     [Status]                NVARCHAR(20)   NOT NULL CONSTRAINT [DF_HerplanVerzoeken_Status] DEFAULT 'Aangevraagd',
     [AangevraagdDoor]       NVARCHAR(200)  NULL,
     [Opmerking]             NVARCHAR(500)  NULL,
-    [mta_inserted]          DATETIME       NOT NULL CONSTRAINT [DF_HerplanVerzoeken_Ins] DEFAULT GETDATE(),
-    [mta_modified]          DATETIME       NOT NULL CONSTRAINT [DF_HerplanVerzoeken_Mod] DEFAULT GETDATE(),
+    [mta_inserted]          DATETIME       NOT NULL CONSTRAINT [DF_HerplanVerzoeken_Ins] DEFAULT GETUTCDATE(),
+    [mta_modified]          DATETIME       NOT NULL CONSTRAINT [DF_HerplanVerzoeken_Mod] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_HerplanVerzoeken] PRIMARY KEY CLUSTERED ([Id] ASC)
 );


### PR DESCRIPTION
## Samenvatting
- Alle mta_inserted, mta_modified, mta_imported, Tijdstip en ImportDatum kolommen gebruiken nu GETUTCDATE() conform architectuurregel
- sp_MergeStgToHis dynamic SQL bijgewerkt (2 locaties)
- Script.PostDeployment1.sql bijgewerkt (5 locaties)
- sp_UpdateSeasonTable bewust niet gewijzigd — gebruikt GETDATE() voor seizoenskalender-berekeningen op jaarbasis

## Test plan
- [x] dotnet build groen (0 errors, 0 warnings)
- [ ] Geen gedragswijziging op Azure SQL (Azure SQL draait in UTC)

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)