### PR TITLE
chore(#214): vervang stille fallbacks door InvalidOperationException

### DIFF
--- a/FunctionApp/Email/BerichtAiService.cs
+++ b/FunctionApp/Email/BerichtAiService.cs
@@ -54,7 +54,8 @@ public class BerichtAiService
 
     private static string BouwClassificatieSystemPrompt()
     {
-        var clubNaam = SystemUtilities.AppSettings.GetSetting("clubName") ?? "de thuisclub";
+        var clubNaam = SystemUtilities.AppSettings.GetSetting("clubName")
+            ?? throw new InvalidOperationException("Vereiste instelling 'clubName' ontbreekt in dbo.AppSettings");
 
         return $$"""
             Je bent een assistent voor de coördinator thuiswedstrijden van {{clubNaam}}.

--- a/FunctionApp/Email/BerichtResponseGenerator.cs
+++ b/FunctionApp/Email/BerichtResponseGenerator.cs
@@ -604,7 +604,8 @@ public static class BerichtResponseGenerator
             return voetnoot;
 
         // Fallback: auto-opgebouwde handtekening uit losse instellingen
-        var afzenderNaam = SystemUtilities.AppSettings.GetSetting("plannerAfzenderNaam") ?? "Veldplanner";
+        var afzenderNaam = SystemUtilities.AppSettings.GetSetting("plannerAfzenderNaam")
+            ?? throw new InvalidOperationException("Vereiste instelling 'plannerAfzenderNaam' ontbreekt in dbo.AppSettings");
         var coordinatorNaam = SystemUtilities.AppSettings.GetSetting("coordinatorNaam");
         var coordinatorFunctie = SystemUtilities.AppSettings.GetSetting("coordinatorFunctie") ?? "Coördinator thuiswedstrijden";
 

--- a/FunctionApp/Planner/PlannerHtmlGenerator.cs
+++ b/FunctionApp/Planner/PlannerHtmlGenerator.cs
@@ -134,7 +134,8 @@ namespace SportlinkFunction.Planner
             sb.AppendLine("</div>");
 
             // Samenvatting
-            var plannerNaam = SystemUtilities.AppSettings.GetSetting("plannerAfzenderNaam") ?? "Veldplanner";
+            var plannerNaam = SystemUtilities.AppSettings.GetSetting("plannerAfzenderNaam")
+                ?? throw new InvalidOperationException("Vereiste instelling 'plannerAfzenderNaam' ontbreekt in dbo.AppSettings");
             sb.AppendLine($"<p style='margin:10px 0;color:{TXT_DIM};font-size:11px;'>Suggesties: {suggesties.Count} | Van veld 5 verplaatst: {suggesties.Count(s => s.HuidigVeldNummer == 5)} | Gegenereerd door {plannerNaam}</p>");
 
             // JavaScript: klik-interactie
@@ -559,7 +560,9 @@ document.addEventListener('click', () => {
                 sb.AppendLine($"<tr style='background:{r.Bg};border-bottom:1px solid #e5e7eb;'><td style='padding:5px 6px;'>{r.T:HH:mm}</td><td style='padding:5px 6px;'>{r.V}</td><td style='padding:5px 6px;'>{r.W}</td><td style='padding:5px 6px;color:{r.Fg};'>{r.S}</td></tr>");
 
             sb.AppendLine("</table>");
-            sb.AppendLine($"<p style='margin:15px 0 0 0;font-size:11px;color:#999;'>{SystemUtilities.AppSettings.GetSetting("plannerAfzenderNaam") ?? "Veldplanner"}</p>");
+            var plannerNaamFooter = SystemUtilities.AppSettings.GetSetting("plannerAfzenderNaam")
+                ?? throw new InvalidOperationException("Vereiste instelling 'plannerAfzenderNaam' ontbreekt in dbo.AppSettings");
+            sb.AppendLine($"<p style='margin:15px 0 0 0;font-size:11px;color:#999;'>{plannerNaamFooter}</p>");
             sb.AppendLine("</body></html>");
             return sb.ToString();
         }


### PR DESCRIPTION
## Samenvatting
- plannerAfzenderNaam en clubName zijn verplichte instellingen; ontbrekende waarde gooit nu InvalidOperationException
- Stille fallbacks 'Veldplanner' en 'de thuisclub' verwijderd — maskeerden misconfiguratie bij multi-club uitrol
- 4 locaties gewijzigd: BerichtResponseGenerator.cs, BerichtAiService.cs, PlannerHtmlGenerator.cs (2x)

## Test plan
- [x] dotnet build groen (0 errors, 0 warnings)

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)