### PR TITLE
chore(#213): documenteer DEFAULT 'VRC' als migratie-backwards-compat

### DIFF
--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -57,7 +57,7 @@ BEGIN
 END
 GO
 
--- Velden: field definitions
+-- Velden: field definitions (ClubCode via DEFAULT 'VRC' — single-club initiële seed; bij multi-club handmatig per club inserten)
 IF NOT EXISTS (SELECT 1 FROM [dbo].[Velden])
 BEGIN
     INSERT INTO [dbo].[Velden] ([VeldNummer], [VeldNaam], [VeldType], [HeeftKunstlicht], [Actief])
@@ -71,7 +71,7 @@ BEGIN
 END
 GO
 
--- VeldBeschikbaarheid: field availability per day-of-week
+-- VeldBeschikbaarheid: field availability per day-of-week (ClubCode via DEFAULT 'VRC' — single-club initiële seed)
 -- DagVanWeek: 1=Monday, 2=Tuesday, ..., 6=Saturday, 7=Sunday
 IF NOT EXISTS (SELECT 1 FROM [dbo].[VeldBeschikbaarheid])
 BEGIN
@@ -96,7 +96,7 @@ BEGIN
 END
 GO
 
--- TeamRegels: team-specific scheduling exceptions
+-- TeamRegels: team-specific scheduling exceptions (ClubCode via DEFAULT 'VRC' — single-club initiële seed)
 IF NOT EXISTS (SELECT 1 FROM [dbo].[TeamRegels])
 BEGIN
     INSERT INTO [dbo].[TeamRegels] ([TeamNaam], [RegelType], [WaardeMinuten], [Prioriteit], [Actief], [Opmerking])
@@ -265,24 +265,26 @@ EXEC [dbo].[sp_UpdateSeasonTable] @SeasonStartMonth;
 GO
 -- ============================================================
 -- #30: Multi-club fundament — ClubCode + Accommodatie
+-- DEFAULT 'VRC' is uitsluitend voor migratie-backwards-compat (bestaande rijen krijgen hier een waarde).
+-- Alle nieuwe inserts geven ClubCode altijd expliciet mee vanuit AppSettings.
 -- ============================================================
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.AppSettings') AND name = 'ClubCode')
-    ALTER TABLE [dbo].[AppSettings] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_AppSettings_ClubCode] DEFAULT 'VRC';
+    ALTER TABLE [dbo].[AppSettings] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_AppSettings_ClubCode] DEFAULT 'VRC'; -- migratie-backwards-compat
 GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.AppSettings') AND name = 'Accommodatie')
-    ALTER TABLE [dbo].[AppSettings] ADD [Accommodatie] NVARCHAR(200) NULL CONSTRAINT [DF_AppSettings_Accommodatie] DEFAULT 'Sportpark Spitsbergen';
+    ALTER TABLE [dbo].[AppSettings] ADD [Accommodatie] NVARCHAR(200) NULL CONSTRAINT [DF_AppSettings_Accommodatie] DEFAULT 'Sportpark Spitsbergen'; -- TODO #221: club-specifieke default verwijderen
 GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Velden') AND name = 'ClubCode')
-    ALTER TABLE [dbo].[Velden] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_Velden_ClubCode] DEFAULT 'VRC';
+    ALTER TABLE [dbo].[Velden] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_Velden_ClubCode] DEFAULT 'VRC'; -- migratie-backwards-compat
 GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Speeltijden') AND name = 'ClubCode')
-    ALTER TABLE [dbo].[Speeltijden] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_Speeltijden_ClubCode] DEFAULT 'VRC';
+    ALTER TABLE [dbo].[Speeltijden] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_Speeltijden_ClubCode] DEFAULT 'VRC'; -- migratie-backwards-compat
 GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.TeamRegels') AND name = 'ClubCode')
-    ALTER TABLE [dbo].[TeamRegels] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_TeamRegels_ClubCode] DEFAULT 'VRC';
+    ALTER TABLE [dbo].[TeamRegels] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_TeamRegels_ClubCode] DEFAULT 'VRC'; -- migratie-backwards-compat
 GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.VeldBeschikbaarheid') AND name = 'ClubCode')
-    ALTER TABLE [dbo].[VeldBeschikbaarheid] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_VeldBeschikbaarheid_ClubCode] DEFAULT 'VRC';
+    ALTER TABLE [dbo].[VeldBeschikbaarheid] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_VeldBeschikbaarheid_ClubCode] DEFAULT 'VRC'; -- migratie-backwards-compat
 GO
 
 -- ============================================================

--- a/Database/dbo/Tables/AppSettingsAudit.sql
+++ b/Database/dbo/Tables/AppSettingsAudit.sql
@@ -5,6 +5,6 @@ CREATE TABLE [dbo].[AppSettingsAudit] (
     [Veld]          NVARCHAR(100) NOT NULL,
     [OudeWaarde]    NVARCHAR(MAX) NULL,
     [NieuweWaarde]  NVARCHAR(MAX) NULL,
-    [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_AppSettingsAudit_ClubCode] DEFAULT 'VRC',
+    [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_AppSettingsAudit_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
     CONSTRAINT [PK_AppSettingsAudit] PRIMARY KEY CLUSTERED ([Id] ASC)
 );

--- a/Database/dbo/Tables/EmailTemplateInstellingen.sql
+++ b/Database/dbo/Tables/EmailTemplateInstellingen.sql
@@ -4,7 +4,7 @@ CREATE TABLE [dbo].[EmailTemplateInstellingen] (
     [Onderwerp]     NVARCHAR(500) NOT NULL,
     [BodyTemplate]  NVARCHAR(MAX) NOT NULL,
     [Actief]        BIT NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Actief] DEFAULT 1,
-    [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_ClubCode] DEFAULT 'VRC',
+    [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
     [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Inserted] DEFAULT GETUTCDATE(),
     [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Modified] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_EmailTemplateInstellingen] PRIMARY KEY CLUSTERED ([Id] ASC),

--- a/Database/dbo/Tables/Speeltijden.sql
+++ b/Database/dbo/Tables/Speeltijden.sql
@@ -4,6 +4,6 @@ CREATE TABLE [dbo].[Speeltijden] (
     [WedstrijdTotaal] INT          NOT NULL,
     [WedstrijdHelft]  INT          NOT NULL,
     [WedstrijdRust]   INT          NOT NULL,
-    [ClubCode]        NVARCHAR(20)  NOT NULL CONSTRAINT [DF_Speeltijden_ClubCode] DEFAULT 'VRC',
+    [ClubCode]        NVARCHAR(20)  NOT NULL CONSTRAINT [DF_Speeltijden_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
     CONSTRAINT [PK_Speeltijden] PRIMARY KEY CLUSTERED ([Leeftijd] ASC)
 ) ON [PRIMARY]

--- a/Database/dbo/Tables/TeamRegels.sql
+++ b/Database/dbo/Tables/TeamRegels.sql
@@ -8,6 +8,6 @@ CREATE TABLE [dbo].[TeamRegels] (
     [Prioriteit]        INT            NOT NULL CONSTRAINT [DF_TeamRegels_Prioriteit] DEFAULT 0,
     [Actief]            BIT            NOT NULL CONSTRAINT [DF_TeamRegels_Actief] DEFAULT 1,
     [Opmerking]         NVARCHAR(500)  NULL,
-    [ClubCode]          NVARCHAR(20)   NOT NULL CONSTRAINT [DF_TeamRegels_ClubCode] DEFAULT 'VRC',
+    [ClubCode]          NVARCHAR(20)   NOT NULL CONSTRAINT [DF_TeamRegels_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
     CONSTRAINT [PK_TeamRegels] PRIMARY KEY CLUSTERED ([Id] ASC)
 );

--- a/Database/dbo/Tables/TeamVoorkeurTijden.sql
+++ b/Database/dbo/Tables/TeamVoorkeurTijden.sql
@@ -5,7 +5,7 @@ CREATE TABLE [dbo].[TeamVoorkeurTijden] (
     [VoorkeurTijd]  TIME NOT NULL,
     [Prioriteit]    INT NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Prioriteit] DEFAULT 5,
     [Actief]        BIT NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Actief] DEFAULT 1,
-    [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_ClubCode] DEFAULT 'VRC',
+    [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
     [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Inserted] DEFAULT GETUTCDATE(),
     [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Modified] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_TeamVoorkeurTijden] PRIMARY KEY CLUSTERED ([Id] ASC)

--- a/Database/dbo/Tables/UitgeslotenEmailAdressen.sql
+++ b/Database/dbo/Tables/UitgeslotenEmailAdressen.sql
@@ -3,7 +3,7 @@ CREATE TABLE [dbo].[UitgeslotenEmailAdressen] (
     [EmailAdres]   NVARCHAR (200) NOT NULL,
     [Omschrijving] NVARCHAR (500) NULL,
     [Actief]       BIT            NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Actief]    DEFAULT 1,
-    [ClubCode]     NVARCHAR (20)  NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_ClubCode]  DEFAULT 'VRC',
+    [ClubCode]     NVARCHAR (20)  NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_ClubCode]  DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
     [mta_inserted] DATETIME2 (7)  NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Inserted] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_UitgeslotenEmailAdressen] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [UQ_UitgeslotenEmailAdressen_Adres] UNIQUE ([EmailAdres], [ClubCode])

--- a/Database/dbo/Tables/VeldBeschikbaarheid.sql
+++ b/Database/dbo/Tables/VeldBeschikbaarheid.sql
@@ -5,7 +5,7 @@ CREATE TABLE [dbo].[VeldBeschikbaarheid] (
     [BeschikbaarVanaf]     TIME               NOT NULL,
     [BeschikbaarTot]       TIME               NOT NULL,
     [GebruikZonsondergang] BIT                NOT NULL CONSTRAINT [DF_VeldBeschikbaarheid_Zon] DEFAULT 0,
-    [ClubCode]             NVARCHAR(20)       NOT NULL CONSTRAINT [DF_VeldBeschikbaarheid_ClubCode] DEFAULT 'VRC',
+    [ClubCode]             NVARCHAR(20)       NOT NULL CONSTRAINT [DF_VeldBeschikbaarheid_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
     CONSTRAINT [PK_VeldBeschikbaarheid] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [FK_VeldBeschikbaarheid_Velden] FOREIGN KEY ([VeldNummer]) REFERENCES [dbo].[Velden]([VeldNummer])
 );

--- a/Database/dbo/Tables/Velden.sql
+++ b/Database/dbo/Tables/Velden.sql
@@ -4,6 +4,6 @@ CREATE TABLE [dbo].[Velden] (
     [VeldType]        NVARCHAR(20)  NOT NULL CONSTRAINT [DF_Velden_Type] DEFAULT 'kunstgras',
     [HeeftKunstlicht] BIT           NOT NULL,
     [Actief]          BIT           NOT NULL CONSTRAINT [DF_Velden_Actief] DEFAULT 1,
-    [ClubCode]        NVARCHAR(20)  NOT NULL CONSTRAINT [DF_Velden_ClubCode] DEFAULT 'VRC',
+    [ClubCode]        NVARCHAR(20)  NOT NULL CONSTRAINT [DF_Velden_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
     CONSTRAINT [PK_Velden] PRIMARY KEY CLUSTERED ([VeldNummer] ASC)
 );

--- a/Database/planner/Tables/EmailVerwerking.sql
+++ b/Database/planner/Tables/EmailVerwerking.sql
@@ -13,7 +13,7 @@ CREATE TABLE [planner].[EmailVerwerking] (
     [VerstuurdNaar]         NVARCHAR(200)   NULL,
     [Status]                NVARCHAR(30)    NOT NULL CONSTRAINT [DF_EmailVerwerking_Status] DEFAULT 'Ontvangen',
     [FoutMelding]           NVARCHAR(1000)  NULL,
-    [ClubCode]              NVARCHAR(20)    NOT NULL CONSTRAINT [DF_EmailVerwerking_ClubCode] DEFAULT 'VRC',
+    [ClubCode]              NVARCHAR(20)    NOT NULL CONSTRAINT [DF_EmailVerwerking_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
     [mta_inserted]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Ins] DEFAULT GETUTCDATE(),
     [mta_modified]          DATETIME        NOT NULL CONSTRAINT [DF_EmailVerwerking_Mod] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_EmailVerwerking] PRIMARY KEY CLUSTERED ([Id] ASC),


### PR DESCRIPTION
## Samenvatting
- Alle C# INSERT-statements geverifieerd: ClubCode wordt in 9 van 9 gevallen expliciet meegegeven vanuit AppSettings
- DEFAULT 'VRC' constraints in 9 tabelbestanden + PostDeployment1.sql voorzien van commentaar dat dit uitsluitend voor backwards-compat bij migraties is
- Seed-data INSERTs in PostDeployment1.sql gemarkeerd als single-club initieel (vertrouwen bewust op DEFAULT)
- DEFAULT 'Sportpark Spitsbergen' in PostDeployment1.sql gemarkeerd als TODO voor issue #221

## Test plan
- [x] dotnet build groen (0 errors, 0 warnings)
- [x] Alle C# INSERTs bevatten expliciete ClubCode parameter

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)