### PR TITLE
chore(#212): verwijder brede Database/*.sql uitsluiting uit gitleaks allowlist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -46,8 +46,8 @@ paths = [
   # Template-bestanden (bevatten geen echte data)
   '''sensitive-patterns\.template\.txt''',
   '''local\.settings\.template\.json''',
-  # Database-migratiegeschiedenis (geen secrets)
-  '''Database/.*\.sql''',
+  # Eerder was hier een brede uitsluiting voor Database/.*\.sql — verwijderd in #212.
+  # SQL-bestanden worden nu volledig gescand. Bij valse positieven: specifiek bestand toevoegen.
 ]
 # Historische commits met voorbeeldwaarden die patronen triggeren — geen echte PII.
 # Zie bijbehorende GitHub issue voor permanente strategie (filter-repo of accept).


### PR DESCRIPTION
## Samenvatting
- Brede `Database/.*\.sql` padsluiting verwijderd uit `.gitleaks.toml`
- Geverifieerd via grep: geen consumer-email, telefoonnummers of Sportlink member-codes in Database/*.sql
- SQL-bestanden worden nu volledig gescand door gitleaks
- Commentaar toegevoegd zodat toekomstige bijdragers weten waar eventuele specifieke exclusies bij moeten

## Test plan
- [x] dotnet build groen
- [ ] Security Gate (gitleaks) moet groen blijven — dit is de echte test van deze PR

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)