### PR TITLE
security(#210): verwijder PII uit Azure Function logs

### DIFF
--- a/FunctionApp/Email/BerichtAiService.cs
+++ b/FunctionApp/Email/BerichtAiService.cs
@@ -121,7 +121,7 @@ public class BerichtAiService
     /// </summary>
     public async Task<BerichtClassificatie> ClassificeerBerichtAsync(string body, string subject, string afzender)
     {
-        _logger.LogInformation("Bericht classificatie gestart voor onderwerp: {Subject}", subject);
+        _logger.LogInformation("Bericht classificatie gestart (onderwerp niet gelogd — AVG #210)");
 
         var userPrompt = $"Vandaag is {DateTime.Now:yyyy-MM-dd} ({DateTime.Now:dddd}).\n\nVan: {afzender}\nOnderwerp: {subject}\n\n{body}";
 
@@ -149,7 +149,7 @@ public class BerichtAiService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Fout bij het classificeren van bericht met onderwerp: {Subject}", subject);
+            _logger.LogError(ex, "Fout bij het classificeren van bericht (onderwerp niet gelogd — AVG #210)");
             throw;
         }
     }

--- a/FunctionApp/Email/EmailGraphService.cs
+++ b/FunctionApp/Email/EmailGraphService.cs
@@ -212,13 +212,11 @@ public partial class EmailGraphService
                     Message = message
                 });
 
-            _logger.LogInformation("Antwoord verstuurd naar {Ontvanger} met onderwerp '{Onderwerp}'",
-                to, subject);
+            _logger.LogInformation("Antwoord verstuurd (ontvanger en onderwerp niet gelogd — AVG #210)");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Fout bij versturen van antwoord naar {Ontvanger} met onderwerp '{Onderwerp}'",
-                to, subject);
+            _logger.LogError(ex, "Fout bij versturen van antwoord (ontvanger en onderwerp niet gelogd — AVG #210)");
         }
     }
 

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -99,8 +99,8 @@ public class EmailProcessorFunction
             catch (Exception ex)
             {
                 fouten++;
-                log.LogError(ex, "Fout bij verwerken van email {MessageId}: {Onderwerp}",
-                    email.MessageId, email.Onderwerp);
+                log.LogError(ex, "Fout bij verwerken van email {MessageId} (onderwerp niet gelogd — AVG #210)",
+                    email.MessageId);
                 try { await UpdateFoutAsync(email.MessageId, ex.Message); }
                 catch { /* fout bij fout-logging mag niet cascaderen */ }
             }
@@ -127,7 +127,7 @@ public class EmailProcessorFunction
 
         if (uitgeslotenAdressen.Contains(email.Afzender))
         {
-            log.LogInformation("Email {MessageId} van uitgesloten adres ({Afzender}), overslaan", email.MessageId, email.Afzender);
+            log.LogInformation("Email {MessageId} van uitgesloten adres, overslaan (afzender niet gelogd — AVG #210)", email.MessageId);
             await graphService.MarkAsReadAsync(email.MessageId);
             return;
         }
@@ -181,8 +181,8 @@ public class EmailProcessorFunction
         await UpdateAntwoordVerstuurdAsync(verwerkingId, ontvanger, antwoordBody);
         await graphService.MarkAsReadAsync(email.MessageId);
 
-        log.LogInformation("Email {Id} volledig verwerkt, antwoord verstuurd naar {Ontvanger}",
-            verwerkingId, ontvanger);
+        log.LogInformation("Email {Id} volledig verwerkt, antwoord verstuurd (ontvanger niet gelogd — AVG #210)",
+            verwerkingId);
 
         // Stuur interne notificatie naar teamleider bij herplanverzoeken van externe afzender (#66)
         if (classificatie.Type == VerzoekType.HerplanVerzoek

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -80,6 +80,24 @@ Bepaalde bestandstypen worden nooit getrackt door git, ongeacht wat er gedaan wo
 
 Persoonsgegevens worden opgeslagen in de lokale SQL Server (`avg.Teambegeleiding`), niet in bestanden. De `avg`-schema is bedoeld voor AVG-beschermde data en de toegang moet beperkt zijn tot bevoegde gebruikers.
 
+### Laag 5 — Azure Function logs / Application Insights (AVG #210)
+
+**Beslissing:** e-mailadressen en e-mailonderwerpen worden **niet** naar Azure Function logs / Application Insights geschreven.
+
+Reden: Azure Function logs (via Application Insights) kunnen e-mailadressen en onderwerpen van inkomende berichten bevatten. Onderwerpen kunnen persoonsgegevens bevatten (namen van personen, teamnamen). Het log is niet de juiste plek voor deze gegevens — de volledige data staat in `planner.EmailVerwerking` met een eigen retentiebeleid.
+
+Wat niet gelogd wordt:
+- Ontvanger-e-mailadres bij verzenden
+- Afzender-e-mailadres bij filteren (uitgesloten adressen)
+- E-mailonderwerp bij verwerking of classificatie
+
+Wat wel gelogd wordt:
+- MessageId (niet-herleidbaar naar persoon zonder DB-toegang)
+- Verwerkings-ID (`planner.EmailVerwerking.Id`)
+- Status en foutmelding (zonder PII)
+
+**Application Insights retentie:** stel Application Insights data retention in op 30 dagen (minimum) via Azure Portal → Application Insights → Usage and estimated costs → Data retention.
+
 ---
 
 ## Wat te doen bij een gefaalde check


### PR DESCRIPTION
## Samenvatting
- E-mailadressen (afzender/ontvanger) en e-mailonderwerpen niet meer gelogd naar Application Insights
- 7 LogInformation/LogError aanroepen aangepast in EmailGraphService.cs, BerichtAiService.cs, EmailProcessorFunction.cs
- MessageId en verwerkings-ID zijn voldoende voor debugging (verwijst naar planner.EmailVerwerking)
- SECURITY.md bijgewerkt: nieuwe sectie 'Laag 5' beschrijft logging-beslissing + Application Insights retentie-instructie (30 dagen)

## Aanvullende actie vereist
- Azure Portal → Application Insights → Data retention instellen op 30 dagen (zie SECURITY.md)

## Test plan
- [x] dotnet build groen (0 errors, 0 warnings)

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)