### PR TITLE
feat(#208): AVG-retentie EmailVerwerking — anonimiseer na 30d, verwijder na 90d

### DIFF
--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -398,6 +398,39 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('planner.Em
     ALTER TABLE [planner].[EmailVerwerking] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_EmailVerwerking_ClubCode] DEFAULT 'VRC';
 GO
 
+-- ============================================================
+-- #208: AVG-retentie — planner.sp_CleanupEmailVerwerking aanmaken
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID('planner.sp_CleanupEmailVerwerking') AND type = 'P')
+BEGIN
+    EXEC(N'
+CREATE PROCEDURE [planner].[sp_CleanupEmailVerwerking]
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE [planner].[EmailVerwerking]
+    SET [Afzender]          = ''[geanonimiseerd]'',
+        [Onderwerp]         = ''[geanonimiseerd]'',
+        [VerstuurdNaar]     = NULL,
+        [EmailBody]         = NULL,
+        [AntwoordEmail]     = NULL,
+        [PlannerResponse]   = NULL,
+        [GeextraheerdeData] = NULL,
+        [mta_modified]      = GETUTCDATE()
+    WHERE [mta_inserted] < DATEADD(DAY, -30, GETUTCDATE())
+      AND [mta_inserted] >= DATEADD(DAY, -90, GETUTCDATE())
+      AND ([Afzender] <> ''[geanonimiseerd]''
+           OR [EmailBody] IS NOT NULL
+           OR [AntwoordEmail] IS NOT NULL
+           OR [PlannerResponse] IS NOT NULL
+           OR [GeextraheerdeData] IS NOT NULL);
+    DELETE FROM [planner].[EmailVerwerking]
+    WHERE [mta_inserted] < DATEADD(DAY, -90, GETUTCDATE());
+END;
+    ');
+END
+GO
+
 -- v2 — #84: EmailTemplateInstellingen
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.EmailTemplateInstellingen'))
 BEGIN

--- a/Database/planner/System Stored Procedures/sp_CleanupEmailVerwerking.sql
+++ b/Database/planner/System Stored Procedures/sp_CleanupEmailVerwerking.sql
@@ -1,0 +1,29 @@
+CREATE PROCEDURE [planner].[sp_CleanupEmailVerwerking]
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    -- Fase 1: anonimiseer PII in rijen van 30-90 dagen oud
+    -- Afzender en Onderwerp zijn NOT NULL → vervangen door placeholder.
+    -- Nullbare velden worden op NULL gezet.
+    UPDATE [planner].[EmailVerwerking]
+    SET [Afzender]          = '[geanonimiseerd]',
+        [Onderwerp]         = '[geanonimiseerd]',
+        [VerstuurdNaar]     = NULL,
+        [EmailBody]         = NULL,
+        [AntwoordEmail]     = NULL,
+        [PlannerResponse]   = NULL,
+        [GeextraheerdeData] = NULL,
+        [mta_modified]      = GETUTCDATE()
+    WHERE [mta_inserted] < DATEADD(DAY, -30, GETUTCDATE())
+      AND [mta_inserted] >= DATEADD(DAY, -90, GETUTCDATE())
+      AND ([Afzender] <> '[geanonimiseerd]'
+           OR [EmailBody] IS NOT NULL
+           OR [AntwoordEmail] IS NOT NULL
+           OR [PlannerResponse] IS NOT NULL
+           OR [GeextraheerdeData] IS NOT NULL);
+
+    -- Fase 2: verwijder rijen ouder dan 90 dagen
+    DELETE FROM [planner].[EmailVerwerking]
+    WHERE [mta_inserted] < DATEADD(DAY, -90, GETUTCDATE());
+END;

--- a/FunctionApp/Email/CleanupEmailVerwerkingFunction.cs
+++ b/FunctionApp/Email/CleanupEmailVerwerkingFunction.cs
@@ -1,0 +1,38 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+
+namespace SportlinkFunction.Email;
+
+public static class CleanupEmailVerwerkingFunction
+{
+    [Function("CleanupEmailVerwerking")]
+    public static async Task Run(
+        [TimerTrigger("0 0 3 * * 0")] TimerInfo myTimer,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("CleanupEmailVerwerking");
+        log.LogInformation("AVG-cleanup gestart: planner.EmailVerwerking (30d anonimiseren, 90d verwijderen)");
+
+        try
+        {
+            await SystemUtilities.WaitForDatabaseAsync(log);
+
+            var connStr = SystemUtilities.DatabaseConfig.ConnectionString;
+            await using var conn = new SqlConnection(connStr);
+            await conn.OpenAsync();
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "EXEC [planner].[sp_CleanupEmailVerwerking]";
+            cmd.CommandTimeout = 120;
+            await cmd.ExecuteNonQueryAsync();
+
+            log.LogInformation("AVG-cleanup EmailVerwerking geslaagd");
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "AVG-cleanup EmailVerwerking mislukt");
+            throw;
+        }
+    }
+}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -82,21 +82,34 @@ Persoonsgegevens worden opgeslagen in de lokale SQL Server (`avg.Teambegeleiding
 
 ### Laag 5 — Azure Function logs / Application Insights (AVG #210)
 
-**Beslissing:** e-mailadressen en e-mailonderwerpen worden **niet** naar Azure Function logs / Application Insights geschreven.
+Persoonsgegevens mogen **nooit** in logs of Application Insights terechtkomen.
 
-Reden: Azure Function logs (via Application Insights) kunnen e-mailadressen en onderwerpen van inkomende berichten bevatten. Onderwerpen kunnen persoonsgegevens bevatten (namen van personen, teamnamen). Het log is niet de juiste plek voor deze gegevens — de volledige data staat in `planner.EmailVerwerking` met een eigen retentiebeleid.
+**Wat wordt NIET gelogd:**
+- E-mailadressen (afzender, ontvanger)
+- Onderwerpregels van emails
+- Emailinhoud, AI-classificatieresultaten
 
-Wat niet gelogd wordt:
-- Ontvanger-e-mailadres bij verzenden
-- Afzender-e-mailadres bij filteren (uitgesloten adressen)
-- E-mailonderwerp bij verwerking of classificatie
+**Wat WEL wordt gelogd:**
+- MessageId (technische Graph API identifier, geen PII)
+- VerwerkingId (intern rowId)
+- Status en foutmeldingen zonder PII
 
-Wat wel gelogd wordt:
-- MessageId (niet-herleidbaar naar persoon zonder DB-toegang)
-- Verwerkings-ID (`planner.EmailVerwerking.Id`)
-- Status en foutmelding (zonder PII)
+**Application Insights retentie:** stel in op **30 dagen** via Azure Portal → Application Insights → Usage and estimated costs → Data retention. Standaard is 90 dagen.
 
-**Application Insights retentie:** stel Application Insights data retention in op 30 dagen (minimum) via Azure Portal → Application Insights → Usage and estimated costs → Data retention.
+---
+
+### Laag 6 — Automatische AVG-retentie (AVG #208)
+
+`planner.EmailVerwerking` bevat emailinhoud en afzendergegevens van clubleden.
+
+| Fase | Wanneer | Actie |
+|---|---|---|
+| Anonimiseren | 30–90 dagen na ontvangst | Afzender/Onderwerp → `[geanonimiseerd]`, EmailBody/AntwoordEmail/PlannerResponse/GeextraheerdeData → NULL |
+| Verwijderen | > 90 dagen na ontvangst | Hele rij verwijderd |
+
+De cleanup wordt wekelijks (zondagochtend 03:00 UTC) uitgevoerd door `CleanupEmailVerwerkingFunction`. De stored procedure `planner.sp_CleanupEmailVerwerking` is idempotent.
+
+`avg.Teambegeleiding` bevat persoonsgegevens van teambegeleiders. Er is geen automatische verwijdering — de tabel wordt bij elke import volledig vervangen (TRUNCATE + bulk insert). Importeer alleen aan het begin van een nieuw seizoen. Het importscript waarschuwt als de data ouder is dan 90 dagen.
 
 ---
 

--- a/exports/import-teambegeleiding-to-sql.ps1
+++ b/exports/import-teambegeleiding-to-sql.ps1
@@ -242,6 +242,24 @@ if ($DeleteCsvAfterImport) {
     Write-Host "  CSV bewaard lokaal. Gebruik -DeleteCsvAfterImport `$true om te verwijderen na import." -ForegroundColor Gray
 }
 
+# ── Verouderde data-check (AVG #208) ──────────────────────────────────────────
+$connCheck = New-Object System.Data.SqlClient.SqlConnection($connectionStr)
+$connCheck.Open()
+try {
+    $cmdCheck             = $connCheck.CreateCommand()
+    $cmdCheck.CommandText = "SELECT MIN(mta_imported) FROM [avg].[Teambegeleiding]"
+    $oudsteImport = $cmdCheck.ExecuteScalar()
+    if ($oudsteImport -ne [DBNull]::Value -and $oudsteImport -ne $null) {
+        $dagOud = ([datetime]::UtcNow - [datetime]$oudsteImport).Days
+        if ($dagOud -gt 90) {
+            Write-Host "`n  ⚠️  WAARSCHUWING (AVG #208): de geïmporteerde data in avg.Teambegeleiding" -ForegroundColor Yellow
+            Write-Host "     is $dagOud dagen oud. Overweeg een verse export via club.sportlink.com." -ForegroundColor Yellow
+        }
+    }
+} finally {
+    $connCheck.Close()
+}
+
 # ── Rapport ───────────────────────────────────────────────────────────────────
 Write-Host "`nKlaar!" -ForegroundColor Cyan
 Write-Host "  Geïmporteerd : $($table.Rows.Count) personen" -ForegroundColor White


### PR DESCRIPTION
## Summary
- Nieuwe SP `planner.sp_CleanupEmailVerwerking`: fase 1 anonimiseert PII-velden (afzender, onderwerp, body etc.) na 30 dagen, fase 2 verwijdert de rij na 90 dagen
- `CleanupEmailVerwerkingFunction`: weekelijkse timer trigger (zondag 03:00 UTC) die de SP aanroept
- `PostDeployment1.sql`: migratie die de SP aanmaakt als deze nog niet bestaat
- Import-script: waarschuwing als `avg.Teambegeleiding` data ouder dan 90 dagen bevat
- `SECURITY.md`: lagen 5 (logging/Application Insights) en 6 (automatische retentie) gedocumenteerd

## AVG/GDPR
Sluit issue #208 af: `planner.EmailVerwerking` bevatte e-mailadressen, onderwerpregels en emailinhoud zonder retentiebeleid. De 30/90-dagengrens volgt de minimale bewaartermijn die past bij de operationele behoefte (wedstrijdplanning loopt per seizoensweek).

## Test plan
- [ ] `dotnet build` slaagt (✅ geverifieerd lokaal)
- [ ] SP aanmaken en handmatig uitvoeren op testdatabase
- [ ] Na merge: CI Security Gate groen

Closes #208

🤖 Generated with [Claude Code](https://claude.ai/claude-code)