### PR TITLE
fix(#231): sync trigger fire-and-forget — vermijdt 100s timeout

### DIFF
--- a/BlazorAdmin/Pages/Home.razor
+++ b/BlazorAdmin/Pages/Home.razor
@@ -106,10 +106,38 @@
     {
         syncing = true;
         syncResult = null;
+
+        var timestampVoor = status?.LastSyncTimestamp;
+
         var r = await Api.TriggerSyncAsync();
-        syncResult = r.Success
-            ? "Synchronisatie geslaagd."
-            : $"Synchronisatie mislukt: {r.ErrorMessage}";
+        if (!r.Success)
+        {
+            syncResult = $"Sync starten mislukt: {r.ErrorMessage}";
+            syncing = false;
+            return;
+        }
+
+        // 202 Accepted: sync draait op achtergrond — poll tot LastSyncTimestamp wijzigt
+        syncResult = "Synchronisatie gestart, even geduld…";
+        StateHasChanged();
+
+        var deadline = DateTime.UtcNow.AddMinutes(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(5000);
+            var statusResult = await Api.GetSyncStatusAsync();
+            if (statusResult.Success && statusResult.Data?.LastSyncTimestamp != timestampVoor)
+            {
+                status = statusResult.Data;
+                syncResult = "Synchronisatie voltooid.";
+                syncing = false;
+                StateHasChanged();
+                return;
+            }
+        }
+
+        // Na 10 min nog geen wijziging — sync loopt waarschijnlijk nog door
+        syncResult = "Synchronisatie loopt op de achtergrond. Herlaad de pagina later voor de actuele status.";
         syncing = false;
         await LoadAsync();
     }

--- a/FunctionApp/Admin/AdminSyncFunction.cs
+++ b/FunctionApp/Admin/AdminSyncFunction.cs
@@ -75,18 +75,28 @@ public static class AdminSyncFunction
             var sportlinkClientId = $"clientId={SystemUtilities.AppSettings.GetSetting("sportlinkClientId")}";
 
             int toWeekOffset = await SystemUtilities.SeasonHelper.GetSeasonEndWeekOffsetAsync(log);
-            log.LogInformation("AdminSyncTrigger: range -1 .. {To}", toWeekOffset);
+            log.LogInformation("AdminSyncTrigger: range -1 .. {To} — fire-and-forget gestart", toWeekOffset);
 
-            // Hergebruik bestaande sync-logica direct (geen HTTP, geen verschil met timer trigger)
-            await FetchAndStoreApiData.RunSyncAsync(-1, toWeekOffset, sportlinkApiUrl, sportlinkClientId, log);
-
-            return new OkObjectResult(new
+            // Fire-and-forget: sync draait op achtergrond (~5 min), client pollt /status op wijziging LastSyncTimestamp
+            _ = Task.Run(async () =>
             {
-                status = "ok",
+                try
+                {
+                    await FetchAndStoreApiData.RunSyncAsync(-1, toWeekOffset, sportlinkApiUrl, sportlinkClientId, log);
+                }
+                catch (Exception ex)
+                {
+                    log.LogError(ex, "Achtergrond sync mislukt");
+                }
+            });
+
+            return new ObjectResult(new
+            {
+                status = "gestart",
                 weekOffsetFrom = -1,
                 weekOffsetTo = toWeekOffset,
                 tijdstip = DateTime.UtcNow
-            });
+            }) { StatusCode = 202 };
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Probleem

'Nu synchroniseren' gaf altijd de foutmelding:
> Synchronisatie mislukt: net_http_request_timedout, 100

`AdminSyncTrigger` wachtte synchronous op 113 weekOffsets x ~3s = ~340s totaal. De Blazor HttpClient kapt dit na 100s af.

## Oplossing

**Server (`AdminSyncFunction.cs`):** `AdminSyncTrigger` start `RunSyncAsync` via `Task.Run` (fire-and-forget) en stuurt direct **202 Accepted** terug.

**Client (`Home.razor`):** Dashboard slaat de huidige `LastSyncTimestamp` op voor de trigger, en pollt daarna `/api/beheer/sync/status` elke 5 seconden. Zodra de timestamp wijzigt toont het 'Synchronisatie voltooid.' Na 10 minuten fallback-melding.

## Gewijzigde bestanden

- `FunctionApp/Admin/AdminSyncFunction.cs` — fire-and-forget Task.Run, 202 i.p.v. 200
- `BlazorAdmin/Pages/Home.razor` — poll-loop na trigger, max 10 min

## Test plan

- [x] Build FunctionApp — 0 fouten
- [x] Build BlazorAdmin — 0 fouten
- [ ] 'Nu synchroniseren' geeft direct feedback (binnen 3s)
- [ ] Knop blijft 'Synchroniseren...' tot sync klaar of timeout
- [ ] Na sync: 'Synchronisatie voltooid.' + bijgewerkte timestamp

Fixes #231