### PR TITLE
fix(#264): deploy smoke test afgebroken door curl exit code 28

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
           MAX=6
           WAIT=20
           for i in $(seq 1 $MAX); do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$URL")
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$URL" || echo "000")
             echo "Poging $i/$MAX — health: $STATUS"
             if [ "$STATUS" = "200" ]; then exit 0; fi
             if [ "$i" -lt "$MAX" ]; then echo "Wacht ${WAIT}s (cold start)..."; sleep $WAIT; fi
@@ -59,7 +59,7 @@ jobs:
       - name: "Smoke test: admin endpoint beveiligd (function key → 401)"
         run: |
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 \
-            "https://${{ vars.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/sync-matches?code=${{ secrets.AZURE_FUNCTION_KEY }}")
+            "https://${{ vars.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/sync-matches?code=${{ secrets.AZURE_FUNCTION_KEY }}" || echo "000")
           echo "sync-matches: $STATUS"
           if [ "$STATUS" != "401" ]; then echo "FOUT: verwacht 401, kreeg $STATUS"; exit 1; fi
 
@@ -69,7 +69,7 @@ jobs:
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 60 -X POST \
             "https://${{ vars.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/planner/check-availability?code=${{ secrets.AZURE_FUNCTION_KEY }}" \
             -H "Content-Type: application/json" \
-            -d '{"datum":"2026-12-01","leeftijdsCategorie":"JO13"}')
+            -d '{"datum":"2026-12-01","leeftijdsCategorie":"JO13"}' || echo "000")
           echo "check-availability: $STATUS"
           if [ "$STATUS" != "200" ]; then echo "⚠️ Database mogelijk niet bereikbaar (status $STATUS)"; exit 1; fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **Deploy smoke test: curl timeout brak retry-loop af** (#264): `set -e` in GitHub Actions liet curl's exit code 28 (timeout) de hele step onmiddellijk beëindigen. Alle `curl`-aanroepen in de test-stap gebruiken nu `|| echo "000"` zodat timeouts als "000" worden behandeld en de retry-loop altijd doorloopt.
 - **FunctionApp target framework**: `net9.0` expliciet vastgelegd als vereiste voor Azure Functions op Linux Consumption Plan — upgrade naar `net10.0` veroorzaakt een 503 bij eerste deploy. Geborgd in `CLAUDE.md` en projectgeheugen zodat deze fout niet opnieuw wordt gemaakt.
 
 ### Security


### PR DESCRIPTION
## Probleem

De smoke test in `deploy.yml` faalde consistent met exit code 28 (curl timeout). De test job liep slechts 33 seconden — één poging in plaats van de verwachte 6 retries.

**Oorzaak:** GitHub Actions voert `run`-stappen uit met `bash -e`. `STATUS=$(curl --max-time 30 ...)` propageerde curl's exit code 28 naar de shell, waardoor `set -e` de step onmiddellijk afbrak vóór de retry-loop kon doorlopen.

## Oplossing

`|| echo "000"` toegevoegd aan alle drie `curl`-aanroepen in de test-stap:
- Timeout of verbindingsfout → STATUS="000" → retry-loop gaat door
- Succesvolle respons → STATUS="200" → loop stopt met exit 0

## Test

Na merge zal de smoke test daadwerkelijk 6 pogingen uitvoeren (max ~280s). Als het function app bereikbaar is na cold start, passeert de test.

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)