### PR TITLE
fix(#264): FunctionApp terug naar net9.0 — 502 na elke deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
           MAX=6
           WAIT=20
           for i in $(seq 1 $MAX); do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$URL" || echo "000")
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$URL" || true)
             echo "Poging $i/$MAX — health: $STATUS"
             if [ "$STATUS" = "200" ]; then exit 0; fi
             if [ "$i" -lt "$MAX" ]; then echo "Wacht ${WAIT}s (cold start)..."; sleep $WAIT; fi
@@ -59,7 +59,7 @@ jobs:
       - name: "Smoke test: admin endpoint beveiligd (function key → 401)"
         run: |
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 \
-            "https://${{ vars.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/sync-matches?code=${{ secrets.AZURE_FUNCTION_KEY }}" || echo "000")
+            "https://${{ vars.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/sync-matches?code=${{ secrets.AZURE_FUNCTION_KEY }}" || true)
           echo "sync-matches: $STATUS"
           if [ "$STATUS" != "401" ]; then echo "FOUT: verwacht 401, kreeg $STATUS"; exit 1; fi
 
@@ -69,7 +69,7 @@ jobs:
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 60 -X POST \
             "https://${{ vars.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/planner/check-availability?code=${{ secrets.AZURE_FUNCTION_KEY }}" \
             -H "Content-Type: application/json" \
-            -d '{"datum":"2026-12-01","leeftijdsCategorie":"JO13"}' || echo "000")
+            -d '{"datum":"2026-12-01","leeftijdsCategorie":"JO13"}' || true)
           echo "check-availability: $STATUS"
           if [ "$STATUS" != "200" ]; then echo "⚠️ Database mogelijk niet bereikbaar (status $STATUS)"; exit 1; fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
-- **Deploy smoke test: curl timeout brak retry-loop af** (#264): `set -e` in GitHub Actions liet curl's exit code 28 (timeout) de hele step onmiddellijk beëindigen. Alle `curl`-aanroepen in de test-stap gebruiken nu `|| echo "000"` zodat timeouts als "000" worden behandeld en de retry-loop altijd doorloopt.
+- **Deploy smoke test: curl timeout brak retry-loop af** (#264): `set -e` in GitHub Actions liet curl's exit code 28 (timeout) de hele step onmiddellijk beëindigen. Alle `curl`-aanroepen in de test-stap gebruiken nu `|| true` zodat timeouts niet meer de step afbreken en de retry-loop altijd doorloopt.
+- **FunctionApp target terug naar net9.0** (#264): vorige sessie had `net10.0` ingezet als target framework "voor lokale dev", maar het Azure Functions Linux Consumption Plan ondersteunt alleen `.NET 9`. Resultaat: 502 op alle endpoints na elke deploy. Gecorrigeerd naar `net9.0`; .NET 10 SDK kan `net9.0` projecten bouwen en uitvoeren.
 - **FunctionApp target framework**: `net9.0` expliciet vastgelegd als vereiste voor Azure Functions op Linux Consumption Plan — upgrade naar `net10.0` veroorzaakt een 503 bij eerste deploy. Geborgd in `CLAUDE.md` en projectgeheugen zodat deze fout niet opnieuw wordt gemaakt.
 
 ### Security

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Probleem

Na elke deploy retourneert de Azure Function 502 op alle endpoints (inclusief `/api/health`). Oorzaak: commit `4d2fde0` (vorige sessie) had `TargetFramework` in `fa-dev-sportlink-01.csproj` gewijzigd naar `net10.0` "voor lokale dev".

Azure Functions op het **Linux Consumption Plan** ondersteunt alleen `.NET 9`. De Azure portal runtime staat op `DOTNET-ISOLATED|9.0`. Mismatch → 502.

Dit is de **derde** keer dat deze fout wordt gemaakt (#162, sessie 2026-05-24, nu). Geborgd in CLAUDE.md en projectgeheugen.

## Fix

- `TargetFramework` terug naar `net9.0` in `FunctionApp/fa-dev-sportlink-01.csproj`
- `|| echo "000"` → `|| true` in `deploy.yml` smoke test (curl schrijft al "000" als http_code bij timeout, dubbele output "000000" matchte nooit "200")

## Test

Na merge: smoke test health → 200 verwacht (na cold start max ~4m).

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)