### PR TITLE
fix(#254): sync crash als 'accommodatie' niet ingesteld

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **Dagelijkse sync brak af als `accommodatie` niet ingesteld** (#254): `MarkeerVervallenGeplandeWedstrijden` gooit nu geen exception als de instelling ontbreekt — de stap wordt overgeslagen met een waarschuwing. De rest van de sync (teams, wedstrijden, uitslagen) loopt gewoon door.
 - **Deploy smoke test: curl timeout brak retry-loop af** (#264): `set -e` in GitHub Actions liet curl's exit code 28 (timeout) de hele step onmiddellijk beëindigen. Alle `curl`-aanroepen in de test-stap gebruiken nu `|| true` zodat timeouts niet meer de step afbreken en de retry-loop altijd doorloopt.
 - **FunctionApp target terug naar net9.0** (#264): vorige sessie had `net10.0` ingezet als target framework "voor lokale dev", maar het Azure Functions Linux Consumption Plan ondersteunt alleen `.NET 9`. Resultaat: 502 op alle endpoints na elke deploy. Gecorrigeerd naar `net9.0`; .NET 10 SDK kan `net9.0` projecten bouwen en uitvoeren.
 - **FunctionApp target framework**: `net9.0` expliciet vastgelegd als vereiste voor Azure Functions op Linux Consumption Plan — upgrade naar `net10.0` veroorzaakt een 503 bij eerste deploy. Geborgd in `CLAUDE.md` en projectgeheugen zodat deze fout niet opnieuw wordt gemaakt.

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -542,7 +542,12 @@ namespace SportlinkFunction.Planner
         /// </summary>
         public static async Task MarkeerVervallenGeplandeWedstrijdenAsync(ILogger log)
         {
-            var accommodatie = SystemUtilities.AppSettings.GetSetting("accommodatie") ?? throw new InvalidOperationException("Vereiste instelling 'accommodatie' ontbreekt in dbo.AppSettings");
+            var accommodatie = SystemUtilities.AppSettings.GetSetting("accommodatie");
+            if (string.IsNullOrWhiteSpace(accommodatie))
+            {
+                log.LogWarning("Instelling 'accommodatie' niet geconfigureerd — MarkeerVervallenGeplandeWedstrijden overgeslagen. Stel de accommodatienaam in via Admin GUI → Instellingen.");
+                return;
+            }
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
             using var cmd = new SqlCommand(@"


### PR DESCRIPTION
## Probleem

Dagelijkse sync (`FetchAndStoreApiData`, 04:00 UTC) brak elke nacht af met:

```
InvalidOperationException: Vereiste instelling 'accommodatie' ontbreekt in dbo.AppSettings
```

`MarkeerVervallenGeplandeWedstrijdenAsync` vereist de accommodatienaam om wedstrijden in `his.matches` te koppelen aan geplande wedstrijden in `planner.GeplandeWedstrijden`. Als de instelling niet is ingevuld via Admin GUI → Instellingen, crasht de hele sync.

## Oplossing

Als `accommodatie` niet geconfigureerd is, wordt de stap overgeslagen met een `LogWarning`. De kern-sync (teams, wedstrijden, uitslagen, plannerberichten) loopt altijd door.

## Noot

De club moet de accommodatienaam alsnog instellen via **Admin GUI → Instellingen** om het automatisch markeren van vervallen geplande wedstrijden te activeren.

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)