### PR TITLE
fix(#239): git hooks check in Test-App.ps1 + pre-commit allowlist fix

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -75,7 +75,7 @@ for doc in "${DOC_PATTERNS[@]}"; do
     if echo "$file" | grep -qE "^${doc}"; then
       email_hits=$(git show ":$file" 2>/dev/null \
         | grep -oiP '[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}' \
-        | grep -viP '@(github\.com|anthropic\.com|example\.(com|nl|org))$' || true)
+        | grep -viP '@(github\.com|anthropic\.com|example\.(com|nl|org)|voorbeeld\.nl)$' || true)
       if [ -n "$email_hits" ]; then
         echo ""
         echo "BLOCKED: Emailadres in documentatiebestand (AVG)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **Git hooks check in Test-App.ps1** (#239): `Test-App.ps1` controleert nu of `core.hooksPath` is ingesteld op `.githooks` en of `sensitive-patterns.txt` aanwezig is. Ontbrekende configuratie geeft een waarschuwing (niet een fout, want CI dekt de fallback).
 - **Dagelijkse sync brak af als `accommodatie` niet ingesteld** (#254): `MarkeerVervallenGeplandeWedstrijden` gooit nu geen exception als de instelling ontbreekt — de stap wordt overgeslagen met een waarschuwing. De rest van de sync (teams, wedstrijden, uitslagen) loopt gewoon door.
 - **Deploy smoke test: curl timeout brak retry-loop af** (#264): `set -e` in GitHub Actions liet curl's exit code 28 (timeout) de hele step onmiddellijk beëindigen. Alle `curl`-aanroepen in de test-stap gebruiken nu `|| true` zodat timeouts niet meer de step afbreken en de retry-loop altijd doorloopt.
 - **FunctionApp target terug naar net9.0** (#264): vorige sessie had `net10.0` ingezet als target framework "voor lokale dev", maar het Azure Functions Linux Consumption Plan ondersteunt alleen `.NET 9`. Resultaat: 502 op alle endpoints na elke deploy. Gecorrigeerd naar `net9.0`; .NET 10 SDK kan `net9.0` projecten bouwen en uitvoeren.

--- a/scripts/dev/Test-App.ps1
+++ b/scripts/dev/Test-App.ps1
@@ -24,6 +24,22 @@ function Write-Fixed($msg) { Write-Host "  [FIX] $msg" -ForegroundColor Yellow ;
 function Write-Section($msg) { Write-Host "`n=== $msg ===" -ForegroundColor Cyan }
 
 # ──────────────────────────────────────────────────────────────────────
+# 0. GIT HOOKS controle
+# ──────────────────────────────────────────────────────────────────────
+Write-Section "Git hooks"
+$hooksPath = git config core.hooksPath 2>$null
+if ($hooksPath -ne ".githooks") {
+    Write-Warning "Git hooks niet geactiveerd! Voer uit: git config core.hooksPath .githooks"
+} else {
+    $patternsFile = Join-Path $root ".githooks\sensitive-patterns.txt"
+    if (-not (Test-Path $patternsFile)) {
+        Write-Warning "sensitive-patterns.txt ontbreekt. Kopieer van .githooks\sensitive-patterns.template.txt"
+    } else {
+        Write-Ok "Git hooks actief (.githooks)"
+    }
+}
+
+# ──────────────────────────────────────────────────────────────────────
 # 1. CONNECTION STRING ophalen
 # ──────────────────────────────────────────────────────────────────────
 Write-Section "Database verbinding"


### PR DESCRIPTION
## Wijzigingen

### Test-App.ps1 — sectie 0: Git hooks check
`Test-App.ps1` controleert nu of git hooks geconfigureerd zijn (sectie 0, vóór alle andere checks):
- `git config core.hooksPath` ≠ `.githooks` → `Write-Warning`
- `sensitive-patterns.txt` ontbreekt → `Write-Warning`

Bewust geen hard exit: de GitHub Actions security gate is de fallback voor CI-omgevingen.

### Pre-commit hook — allowlist @voorbeeld.nl
Het email-patroon in de pre-commit hook stond niet consistent met `security-scan.yml`. `@voorbeeld.nl` was wél toegestaan in CI maar niet in de lokale hook. Gecorrigeerd.

### Lokale configuratie
`git config core.hooksPath .githooks` uitgevoerd op het huidige systeem.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)