### PR TITLE
feat(#238): AVG-bewaartermijn avg.Teambegeleiding — SP + maandelijkse timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **AVG-bewaartermijn avg.Teambegeleiding** (#238): `sp_CleanupTeambegeleiding` stored procedure verwijdert rijen ouder dan 1 jaar (vangnet als importscript langere tijd niet gedraaid heeft). Maandelijkse timer trigger `CleanupTeambegeleiding` (1e van de maand, 04:00 UTC). Bewaartermijn gedocumenteerd in `exports/README.md`.
 - **Kostenbeleid als meest prominente architectuurregel in CLAUDE.md** (#255): expliciete gratis-eerst eis voor alle Azure-resources; verplichting om vóór elke feature-toevoeging én deployment actuele Microsoft-prijsdocumentatie te controleren via Microsoft Learn MCP; harde stop-deployment regel bij gedetecteerde prijswijziging; geverifieerde tabel van gratis vs. potentieel-betaalde resources; verificatiechecklist als deployment-gate.
 - **Build-teller versioning voor lokale ontwikkeling**: vierde versiecomponent (`2.2.0.x`) automatisch ophoogbaar via `Bump-Build.ps1`. Zichtbaar in health-endpoint (`GET /api/health` geeft nu ook `version` terug) en in de Feedback-modal van de Admin GUI. `.\Bump-Build.ps1 -NewPatch` verhoogt de patch-versie voor nieuwe functionaliteit.
 - **Documentatie-index**: alle documentatie geconsolideerd in `docs/` met een nieuwe [inhoudsopgave (docs/INDEX.md)](docs/INDEX.md) ingedeeld per doelgroep (beheerders, developers, architectuur, security). README toont de documentatietabel prominent.

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -462,6 +462,19 @@ BEGIN
 END
 GO
 
+-- #238: avg.sp_CleanupTeambegeleiding — AVG-vangnet: verwijder rijen ouder dan 1 jaar
+IF NOT EXISTS (SELECT 1 FROM sys.objects WHERE object_id = OBJECT_ID('avg.sp_CleanupTeambegeleiding') AND type = 'P')
+BEGIN
+    EXEC('
+CREATE PROCEDURE [avg].[sp_CleanupTeambegeleiding]
+AS
+BEGIN
+    SET NOCOUNT ON;
+    DELETE FROM [avg].[Teambegeleiding]
+    WHERE [mta_imported] < DATEADD(YEAR, -1, GETUTCDATE());
+END');
+END
+GO
 
 -- v2 — #84: EmailTemplateInstellingen
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.EmailTemplateInstellingen'))

--- a/Database/avg/System Stored Procedures/sp_CleanupTeambegeleiding.sql
+++ b/Database/avg/System Stored Procedures/sp_CleanupTeambegeleiding.sql
@@ -1,0 +1,12 @@
+CREATE PROCEDURE [avg].[sp_CleanupTeambegeleiding]
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    -- Verwijder rijen ouder dan 1 jaar.
+    -- Vangnet voor het geval het importscript (TRUNCATE + herinsert) langere tijd
+    -- niet gedraaid heeft. Actieve begeleiders worden bij elke import ververst
+    -- en hebben altijd een recente mta_imported.
+    DELETE FROM [avg].[Teambegeleiding]
+    WHERE [mta_imported] < DATEADD(YEAR, -1, GETUTCDATE());
+END;

--- a/FunctionApp/Email/CleanupTeambegeleidingFunction.cs
+++ b/FunctionApp/Email/CleanupTeambegeleidingFunction.cs
@@ -1,0 +1,38 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+
+namespace SportlinkFunction.Email;
+
+public static class CleanupTeambegeleidingFunction
+{
+    [Function("CleanupTeambegeleiding")]
+    public static async Task Run(
+        [TimerTrigger("0 0 4 1 * *")] TimerInfo myTimer,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("CleanupTeambegeleiding");
+        log.LogInformation("AVG-cleanup gestart: avg.Teambegeleiding (rijen ouder dan 1 jaar verwijderen)");
+
+        try
+        {
+            await SystemUtilities.WaitForDatabaseAsync(log);
+
+            var connStr = SystemUtilities.DatabaseConfig.ConnectionString;
+            await using var conn = new SqlConnection(connStr);
+            await conn.OpenAsync();
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = "EXEC [avg].[sp_CleanupTeambegeleiding]";
+            cmd.CommandTimeout = 120;
+            await cmd.ExecuteNonQueryAsync();
+
+            log.LogInformation("AVG-cleanup Teambegeleiding geslaagd");
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "AVG-cleanup Teambegeleiding mislukt");
+            throw;
+        }
+    }
+}

--- a/exports/README.md
+++ b/exports/README.md
@@ -195,6 +195,19 @@ Wijzigingen in `exports/` gaan **altijd rechtstreeks naar `main`** — nooit via
 
 ---
 
+## AVG-bewaartermijn
+
+`avg.Teambegeleiding` hanteert een bewaartermijn van **1 jaar** vanaf de laatste import (`mta_imported`).
+
+**Hoe het werkt:**
+- Het importscript doet een TRUNCATE + volledige herinsert. Bij elke import krijgen alle actieve begeleiders een verse `mta_imported`.
+- Personen die niet meer actief zijn, verdwijnen automatisch bij de volgende import via de TRUNCATE.
+- De `CleanupTeambegeleiding` Azure Function (maandelijks, 1e van de maand 04:00 UTC) verwijdert als vangnet alle rijen ouder dan 1 jaar — dit beschermt tegen het scenario waarbij het importscript een langere tijd niet draait.
+
+**Aanbeveling:** voer het importscript minimaal **1× per seizoen** uit (seizoensstart ≈ augustus). Dit garandeert dat de data actueel is én dat de bewaartermijn correct verloopt.
+
+---
+
 ## AVG/GDPR-regels
 
 - De CSV mag alleen **tijdelijk lokaal** staan op de machine van de beheerder


### PR DESCRIPTION
## Wijzigingen

### Database — `avg.sp_CleanupTeambegeleiding`
Nieuwe stored procedure: DELETE WHERE `mta_imported < DATEADD(YEAR, -1, GETUTCDATE())`.

Idempotent in `Script.PostDeployment1.sql` via `IF NOT EXISTS` check.

### FunctionApp — `CleanupTeambegeleidingFunction`
Maandelijkse timer trigger (`0 0 4 1 * *` = 1e van de maand, 04:00 UTC). Roept `avg.sp_CleanupTeambegeleiding` aan.

### Logica bewaartermijn
- TRUNCATE-import vernieuwt `mta_imported` voor alle actieve begeleiders → actieve personen worden nooit verwijderd
- Personen die niet meer actief zijn verdwijnen bij de volgende import via TRUNCATE
- Cleanup SP is een AVG-vangnet voor het geval het importscript langere tijd niet draait

### Documentatie
Bewaartermijn (1 jaar) en aanbeveling (1× per seizoen importeren) toegevoegd aan `exports/README.md`.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)