### PR TITLE
security(#269,#270): mailboxadres uit logs + SQL-injectie fix MergeStgToHis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Security
 
+- **AVG: coordinator-mailboxadres niet meer gelogd (#269)**: `EmailGraphService` logt niet langer het e-mailadres van de coordinator-mailbox in logregels bij inbox-polling (aanwezig bij "Geen emails gevonden", "X emails opgehaald" en foutmeldingen). Logs bevatten nu "coordinator-mailbox" als generieke omschrijving.
+- **SQL-injectie in MergeStgToHis opgelost (#270)**: schema- en tabelnamen werden als strings in de query-string gezet via string interpolatie. Vervangen door `SqlParameter`-objecten via `command.Parameters.AddWithValue()`. De stored procedures `sp_CreateTargetTableFromSource` en `sp_MergeStgToHis` ontvangen de parameters nu netjes via de parameterlijst.
 - **AVG: e-mailadres niet meer gelogd bij toevoegen uitsluitingsadres** (#248): `AdminUitgeslotenEmailFunction` logt nu alleen het ID van het nieuwe uitsluitingsadres, niet het e-mailadres zelf. Consistent met de delete-actie die ook alleen ID logt.
 - **AVG: Afzender gemaskeerd in email-log API** (#241): `/api/beheer/email-log` geeft `Afzender` terug als `***@domein.nl` in plaats van het volledige e-mailadres. De domein-informatie blijft beschikbaar voor debugging; het persoonsgegeven (lokaal deel) niet.
 - **Architectuurovertreding opgelost: ClubCode DEFAULT 'VRC' verwijderd** (#242): `DEFAULT 'VRC'` constraint verwijderd uit `planner.EmailVerwerking.ClubCode`. `CHECK (LEN(ClubCode) > 0)` toegevoegd. Migratie in `Script.PostDeployment1.sql` dropt de bestaande constraint in productie.

--- a/FunctionApp/Email/EmailGraphService.cs
+++ b/FunctionApp/Email/EmailGraphService.cs
@@ -47,7 +47,7 @@ public partial class EmailGraphService
 
             if (messages?.Value is null)
             {
-                _logger.LogInformation("Geen ongelezen emails gevonden in {Mailbox}", _mailbox);
+                _logger.LogInformation("Geen ongelezen emails gevonden in coordinator-mailbox");
                 return resultaat;
             }
 
@@ -75,12 +75,12 @@ public partial class EmailGraphService
                 }
             }
 
-            _logger.LogInformation("{Aantal} ongelezen email(s) opgehaald uit {Mailbox}",
-                resultaat.Count, _mailbox);
+            _logger.LogInformation("{Aantal} ongelezen email(s) opgehaald uit coordinator-mailbox",
+                resultaat.Count);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Fout bij ophalen van ongelezen emails uit {Mailbox}", _mailbox);
+            _logger.LogError(ex, "Fout bij ophalen van ongelezen emails uit coordinator-mailbox");
         }
 
         return resultaat;

--- a/FunctionApp/MergeStgToHis.cs
+++ b/FunctionApp/MergeStgToHis.cs
@@ -28,12 +28,16 @@ namespace SportlinkFunction
                 using (SqlConnection connection = new SqlConnection(DatabaseConfig.ConnectionString))
                 {
                     await connection.OpenAsync();
-                    string query = $@"
-                        EXECUTE [dbo].[sp_CreateTargetTableFromSource] '{_sourceSchema}','{_sourceTable}', '{_targetSchema}', '{_targetTable}';
-                        EXECUTE [dbo].[sp_MergeStgToHis] '{_sourceSchema}','{_sourceTable}', '{_targetSchema}', '{_targetTable}';";
+                    const string query = @"
+                        EXECUTE [dbo].[sp_CreateTargetTableFromSource] @srcSchema, @srcTable, @tgtSchema, @tgtTable;
+                        EXECUTE [dbo].[sp_MergeStgToHis] @srcSchema, @srcTable, @tgtSchema, @tgtTable;";
 
                     using (SqlCommand command = new SqlCommand(query, connection))
                     {
+                        command.Parameters.AddWithValue("@srcSchema", _sourceSchema);
+                        command.Parameters.AddWithValue("@srcTable",  _sourceTable);
+                        command.Parameters.AddWithValue("@tgtSchema", _targetSchema);
+                        command.Parameters.AddWithValue("@tgtTable",  _targetTable);
                         await command.ExecuteNonQueryAsync();
                     }
                     connection.Close(); 


### PR DESCRIPTION
## Summary

- **#269 — AVG: coordinator-mailboxadres niet meer gelogd**: `EmailGraphService` logt niet langer het e-mailadres van de coordinator-mailbox. Drie logregels (geen emails gevonden, X emails opgehaald, fout bij ophalen) bevatten nu de generieke tekst 'coordinator-mailbox' i.p.v. het concrete adres.
- **#270 — SQL-injectie: MergeStgToHis geparametriseerd**: Schema- en tabelnamen werden via string-interpolatie direct in de query gezet. Nu vervangen door `SqlParameter`-objecten via `AddWithValue()`. Beide stored procedures ontvangen de waarden via de parameterlijst.

## Test plan

- [ ] Controleer dat FunctionApp bouwt zonder fouten (`dotnet build`)
- [ ] CI Security Gate groen
- [ ] Deploy smoke test: health 200, admin 401

Closes #269, closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)