### PR TITLE
feat(#258): correlation-ID propagatie in alle admin-endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **Correlation-ID tracing in alle admin-endpoints** (#258): alle 29 HTTP-functies in `FunctionApp/Admin/` en `FunctionApp/Feedback/` lezen nu `x-correlation-id` uit de request header (of genereren een nieuwe GUID) en sturen deze terug in elke response header. De ID is ook beschikbaar als `CorrelationId` in de Application Insights log-scope voor end-to-end tracing via KQL.
 - **AVG-bewaartermijn avg.Teambegeleiding** (#238): `sp_CleanupTeambegeleiding` stored procedure verwijdert rijen ouder dan 1 jaar (vangnet als importscript langere tijd niet gedraaid heeft). Maandelijkse timer trigger `CleanupTeambegeleiding` (1e van de maand, 04:00 UTC). Bewaartermijn gedocumenteerd in `exports/README.md`.
 - **Kostenbeleid als meest prominente architectuurregel in CLAUDE.md** (#255): expliciete gratis-eerst eis voor alle Azure-resources; verplichting om vóór elke feature-toevoeging én deployment actuele Microsoft-prijsdocumentatie te controleren via Microsoft Learn MCP; harde stop-deployment regel bij gedetecteerde prijswijziging; geverifieerde tabel van gratis vs. potentieel-betaalde resources; verificatiechecklist als deployment-gate.
 - **Build-teller versioning voor lokale ontwikkeling**: vierde versiecomponent (`2.2.0.x`) automatisch ophoogbaar via `Bump-Build.ps1`. Zichtbaar in health-endpoint (`GET /api/health` geeft nu ook `version` terug) en in de Feedback-modal van de Admin GUI. `.\Bump-Build.ps1 -NewPatch` verhoogt de patch-versie voor nieuwe functionaliteit.

--- a/FunctionApp/Admin/AdminEmailLogFunction.cs
+++ b/FunctionApp/Admin/AdminEmailLogFunction.cs
@@ -24,8 +24,10 @@ public static class AdminEmailLogFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminEmailLogGet");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);

--- a/FunctionApp/Admin/AdminSettingsFunction.cs
+++ b/FunctionApp/Admin/AdminSettingsFunction.cs
@@ -60,8 +60,10 @@ public static class AdminSettingsFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminSettingsGet");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
@@ -113,8 +115,10 @@ public static class AdminSettingsFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminSettingsPut");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             using var bodyReader = new StreamReader(req.Body);
@@ -244,8 +248,10 @@ public static class AdminSettingsFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminGeocodeGet");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         var plaatsnaam = req.Query["plaatsnaam"].ToString().Trim();
         if (string.IsNullOrWhiteSpace(plaatsnaam))
             return new BadRequestObjectResult(new { error = "plaatsnaam is verplicht" });

--- a/FunctionApp/Admin/AdminSyncFunction.cs
+++ b/FunctionApp/Admin/AdminSyncFunction.cs
@@ -20,8 +20,10 @@ public static class AdminSyncFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminSyncStatus");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
@@ -61,8 +63,10 @@ public static class AdminSyncFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminSyncTrigger");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);

--- a/FunctionApp/Admin/AdminTeamsFunction.cs
+++ b/FunctionApp/Admin/AdminTeamsFunction.cs
@@ -18,8 +18,10 @@ public static class AdminTeamsFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminTeamsGet");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);

--- a/FunctionApp/Admin/AdminTemplatesFunction.cs
+++ b/FunctionApp/Admin/AdminTemplatesFunction.cs
@@ -23,8 +23,10 @@ public static class AdminTemplatesFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminTemplatesGet");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
@@ -70,8 +72,10 @@ public static class AdminTemplatesFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminTemplatesPut");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         if (string.IsNullOrWhiteSpace(key))
             return new BadRequestObjectResult(new { error = "Template key ontbreekt" });
 
@@ -138,8 +142,10 @@ public static class AdminTemplatesFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminTemplatesReset");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         if (string.IsNullOrWhiteSpace(key))
             return new BadRequestObjectResult(new { error = "Template key ontbreekt" });
 

--- a/FunctionApp/Admin/AdminUitgeslotenEmailFunction.cs
+++ b/FunctionApp/Admin/AdminUitgeslotenEmailFunction.cs
@@ -18,8 +18,10 @@ public static class AdminUitgeslotenEmailFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminUitgeslotenEmailGet");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
@@ -70,8 +72,10 @@ public static class AdminUitgeslotenEmailFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminUitgeslotenEmailPost");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
@@ -117,8 +121,10 @@ public static class AdminUitgeslotenEmailFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminUitgeslotenEmailDelete");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);

--- a/FunctionApp/Admin/AdminVeldBeschikbaarheidFunction.cs
+++ b/FunctionApp/Admin/AdminVeldBeschikbaarheidFunction.cs
@@ -18,8 +18,10 @@ public static class AdminVeldBeschikbaarheidFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminVeldBeschikbaarheidGet");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
@@ -65,8 +67,10 @@ public static class AdminVeldBeschikbaarheidFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminVeldBeschikbaarheidPut");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             using var bodyReader = new StreamReader(req.Body);
@@ -111,8 +115,10 @@ public static class AdminVeldBeschikbaarheidFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminVeldenGet");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
@@ -145,8 +151,10 @@ public static class AdminVeldBeschikbaarheidFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminVeldBeschikbaarheidPost");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             using var bodyReader = new StreamReader(req.Body);
@@ -206,8 +214,10 @@ public static class AdminVeldBeschikbaarheidFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminVeldBeschikbaarheidDelete");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);

--- a/FunctionApp/Admin/AdminVoorkeurTijdenFunction.cs
+++ b/FunctionApp/Admin/AdminVoorkeurTijdenFunction.cs
@@ -18,8 +18,10 @@ public static class AdminVoorkeurTijdenFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminVoorkeurTijdenGet");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
@@ -69,8 +71,10 @@ public static class AdminVoorkeurTijdenFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminVoorkeurTijdenPost");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             using var bodyReader = new StreamReader(req.Body);
@@ -113,8 +117,10 @@ public static class AdminVoorkeurTijdenFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminVoorkeurTijdenPut");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             using var bodyReader = new StreamReader(req.Body);
@@ -161,8 +167,10 @@ public static class AdminVoorkeurTijdenFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminVoorkeurTijdenDelete");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
@@ -197,8 +205,10 @@ public static class AdminVoorkeurTijdenFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminTeamRegelsGet");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
@@ -245,8 +255,10 @@ public static class AdminVoorkeurTijdenFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminTeamRegelsPost");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             using var bodyReader = new StreamReader(req.Body);
@@ -296,8 +308,10 @@ public static class AdminVoorkeurTijdenFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminTeamRegelsPut");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             using var bodyReader = new StreamReader(req.Body);
@@ -348,8 +362,10 @@ public static class AdminVoorkeurTijdenFunction
         FunctionContext context)
     {
         var log = context.GetLogger("AdminTeamRegelsDelete");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);

--- a/FunctionApp/Admin/EasyAuthHelper.cs
+++ b/FunctionApp/Admin/EasyAuthHelper.cs
@@ -50,6 +50,20 @@ internal static class EasyAuthHelper
         }
     }
 
+    /// <summary>
+    /// Leest x-correlation-id uit de request header, of genereert een nieuwe GUID.
+    /// Schrijft het ID terug in de response header voor end-to-end tracing.
+    /// </summary>
+    public static string ExtractOrCreateCorrelationId(HttpRequest req)
+    {
+        var correlationId = req.Headers.TryGetValue("x-correlation-id", out var incoming) && !string.IsNullOrWhiteSpace(incoming)
+            ? incoming.ToString()
+            : Guid.NewGuid().ToString("N");
+
+        req.HttpContext.Response.Headers["x-correlation-id"] = correlationId;
+        return correlationId;
+    }
+
     private sealed class ClientPrincipal
     {
         [JsonPropertyName("claims")]

--- a/FunctionApp/Admin/EmailTestFunction.cs
+++ b/FunctionApp/Admin/EmailTestFunction.cs
@@ -35,8 +35,10 @@ public static class EmailTestFunction
         FunctionContext context)
     {
         var log = context.GetLogger("EmailTestDryRun");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
 
         if (!TryAcquireSlot())
         {

--- a/FunctionApp/Feedback/FeedbackFunction.cs
+++ b/FunctionApp/Feedback/FeedbackFunction.cs
@@ -38,8 +38,10 @@ public static class FeedbackFunction
         FunctionContext context)
     {
         var log = context.GetLogger("FeedbackValidate");
+        var correlationId = SportlinkFunction.Admin.EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = SportlinkFunction.Admin.EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
         try
         {
             var body = await new StreamReader(req.Body).ReadToEndAsync();
@@ -70,8 +72,10 @@ public static class FeedbackFunction
         FunctionContext context)
     {
         var log = context.GetLogger("FeedbackSubmit");
+        var correlationId = SportlinkFunction.Admin.EasyAuthHelper.ExtractOrCreateCorrelationId(req);
         var authResult = SportlinkFunction.Admin.EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
 
         if (!TryAcquireSubmitSlot())
             return new ObjectResult(new { error = $"Limiet bereikt: maximaal {MaxSubmissiesPerVenster} meldingen per 10 minuten." }) { StatusCode = 429 };


### PR DESCRIPTION
## Summary

- Alle 29 HTTP-functies in \`FunctionApp/Admin/\` en \`FunctionApp/Feedback/\` ondersteunen nu end-to-end request-tracing via \`x-correlation-id\` header
- Nieuwe \`EasyAuthHelper.ExtractOrCreateCorrelationId()\` helper leest inkomende header of genereert nieuwe GUID, zet response header, en geeft correlationId terug voor \`ILogger.BeginScope()\`
- Elke response bevat \`x-correlation-id\` header — ook 401/403 auth-fouten

## Definitie van gedaan

- [x] POST naar \`/api/beheer/settings\` — \`x-correlation-id\` in response header
- [x] Inkomende \`x-correlation-id: test-123\` header wordt doorgegeven in response
- [x] \`dotnet build\` — geen fouten of warnings
- [x] CHANGELOG.md bijgewerkt

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)