### PR TITLE
chore: opt-in Node.js 24 voor GitHub Actions (deadline 2026-06-02)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 env:
   AZURE_FUNCTIONAPP_PACKAGE_PATH: FunctionApp
   DOTNET_VERSION: '10.0.x'
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -10,6 +10,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # ══════════════════════════════════════════════════════════════════════════════
 # BELANGRIJK: Als één of meer jobs hieronder falen, blokkeert de security-gate
 # job automatisch de merge. Zie SECURITY.md voor het protocol bij een fout.


### PR DESCRIPTION
## Summary

Voegt `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` toe aan beide workflow-bestanden om de verplichte Node.js 24 upgrade te activeren vóór de deadline van 2026-06-02.

De volgende actions draaien anders op het verouderde Node.js 20 runtime (dat per 2 juni 2026 uit de GitHub runners wordt verwijderd):
- \`actions/checkout@v4\`
- \`actions/setup-dotnet@v4\`
- \`azure/login@v2\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)