### PR TITLE
fix(#283): feedback widget loop bij aanvulvragen

### DIFF
--- a/BlazorAdmin/Shared/FeedbackWidget.razor
+++ b/BlazorAdmin/Shared/FeedbackWidget.razor
@@ -221,8 +221,17 @@
         }
         else
         {
-            _vragen = result.Data.Vragen ?? [];
-            _antwoorden = new List<string>(new string[_vragen.Count]);
+            var nieuweVragen = result.Data.Vragen ?? [];
+            // Bewaar antwoorden op vragen die ook in de nieuwe set voorkomen.
+            var nieuweAntwoorden = nieuweVragen
+                .Select(v =>
+                {
+                    var idx = _vragen.IndexOf(v);
+                    return idx >= 0 && idx < _antwoorden.Count ? _antwoorden[idx] : "";
+                })
+                .ToList();
+            _vragen = nieuweVragen;
+            _antwoorden = nieuweAntwoorden;
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Feedback widget loop bij aanvulvragen** (#283): na het beantwoorden van OpenAI-aanvulvragen keerden dezelfde vragen terug bij "Opnieuw controleren". Backend accepteert nu direct zodra antwoorden zijn ingevuld (re-validatie overbodig — antwoorden vullen de gaten per definitie). Frontend bewaart bovendien bestaande antwoorden als vragen ongewijzigd terugkomen.
+
 ### Added
 
 - **Infrastructure as Code met Bicep** (#257): nieuwe `infrastructure/` map met Bicep-bestanden die alle bestaande Azure-resources declaratief beschrijven (Function App, Consumption Plan, Storage Account, Static Web App, Application Insights). `az deployment group what-if` detecteert drift zonder wijzigingen te maken. Monitoring-module is aanwezig maar standaard uitgeschakeld (`deployMonitoring=false`) om onbedoelde Log Analytics kosten te voorkomen. Nieuwe GitHub Actions workflow `infrastructure.yml` is alleen handmatig uitvoerbaar met keuze tussen `what-if` en `deploy`.

--- a/FunctionApp/Feedback/FeedbackFunction.cs
+++ b/FunctionApp/Feedback/FeedbackFunction.cs
@@ -124,6 +124,12 @@ public static class FeedbackFunction
     private static async Task<ValidateResponse> ValideerVolledigheid(
         ChatClient chatClient, FeedbackRequest dto, ILogger log)
     {
+        // Als de gebruiker al antwoorden heeft gegeven op aanvulvragen, accepteer direct.
+        // Re-validatie leidt tot dezelfde vragen omdat het AI-model eerder gestelde vragen
+        // opnieuw stelt ondanks het antwoord — de antwoorden vullen de gaten per definitie.
+        if (dto.VragenAntwoorden?.Any(qa => !string.IsNullOrWhiteSpace(qa.Antwoord)) == true)
+            return new ValidateResponse(true, []);
+
         var beschrijving = Sanitize(dto.Beschrijving, 2000);
         var paginaInfo = string.IsNullOrWhiteSpace(dto.Context?.Pagina) ? "" : $"Pagina: {dto.Context.Pagina}\n";
         var qaBlok = BouwQaBlok(dto.VragenAntwoorden);


### PR DESCRIPTION
## Probleem

Na het beantwoorden van OpenAI-aanvulvragen in de feedback widget kwamen bij "Opnieuw controleren" exact dezelfde vragen terug. De gebruiker belandde in een eindeloze loop zonder de feedback te kunnen versturen.

**Oorzaak:** het AI-model volgt de instructie "stel nooit vragen over al beantwoorde zaken" niet consequent — bij herhaling van dezelfde beschrijving + antwoorden genereerde het opnieuw dezelfde vragen.

## Oplossing

**Backend** (`FeedbackFunction.cs`): zodra `VragenAntwoorden` niet-lege antwoorden bevat, wordt re-validatie overgeslagen en direct `volledig: true` teruggegeven. De antwoorden vullen de gaten per definitie — re-validatie was zinloos.

**Frontend** (`FeedbackWidget.razor`): bij een nieuwe vragenset worden bestaande antwoorden op gelijkblijvende vragen bewaard i.p.v. gereset (defensieve fix voor edge cases).

## Test plan

- [ ] Feedback openen → beschrijving invullen → "Controleren" → aanvulvragen verschijnen
- [ ] Vragen beantwoorden → "Opnieuw controleren" → direct naar Overzicht (geen vragen opnieuw)
- [ ] Leeg antwoord laten → "Opnieuw controleren" → nog steeds loop-vrij (alleen antwoorden met inhoud tellen)
- [ ] Beschrijving zonder vragen → "Controleren" → direct Overzicht als volledig

🤖 Generated with [Claude Code](https://claude.com/claude-code)