### PR TITLE
chore(#285): versie 2.2.1 + hot reload BlazorAdmin via dotnet watch

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.2.0</Version>
-    <AssemblyVersion>2.2.0.1</AssemblyVersion>
-    <FileVersion>2.2.0.1</FileVersion>
+    <Version>2.2.1</Version>
+    <AssemblyVersion>2.2.1.0</AssemblyVersion>
+    <FileVersion>2.2.1.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Changed
+
+- **Versie 2.2.1** — PATCH-bump voor feedback widget bugfix (#284).
+- **Start-Debug.ps1: BlazorAdmin met hot reload** (#285): `dotnet watch run` vervangt `dotnet run`. Wijzigingen in `.razor`, `.cs` en `.css` worden automatisch herladen zonder herstart van de service. Nieuw `-NoWatch` vlag voor omgevingen zonder hot reload. Duidelijke melding dat FunctionApp géén hot reload ondersteunt (Azure Functions isolated worker limitatie) en herstart vereist na C#-wijzigingen.
+
 ### Fixed
 
 - **Feedback widget loop bij aanvulvragen** (#283): na het beantwoorden van OpenAI-aanvulvragen keerden dezelfde vragen terug bij "Opnieuw controleren". Backend accepteert nu direct zodra antwoorden zijn ingevuld (re-validatie overbodig — antwoorden vullen de gaten per definitie). Frontend bewaart bovendien bestaande antwoorden als vragen ongewijzigd terugkomen.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,8 +158,19 @@ ITERATIE:
   c. .\scripts\dev\Test-App.ps1 -Fix
      → exit 1 zonder -Fix te herstellen? Fix code, ga terug naar a.
 
-  d. Start services (achtergrond, volgorde is verplicht):
-       # 1. Azurite (vereist door func start)
+  d. Start services via Start-Debug.ps1 (aanbevolen — regelt hot reload automatisch):
+       .\scripts\dev\Start-Debug.ps1
+       Start-Sleep -Seconds 15
+
+       # Hot reload gedrag (vastgelegd in Start-Debug.ps1):
+       # - BlazorAdmin :5242 → HOT RELOAD via 'dotnet watch'. Wijzigingen in .razor/.cs/.css
+       #   worden automatisch doorgevoerd; browser ververst zonder herstart.
+       # - FunctionApp :7094 → GEEN hot reload. Azure Functions isolated worker ondersteunt
+       #   dit niet. Na elke C#-wijziging in FunctionApp: services stoppen en herstart uitvoeren.
+       #   Zie: scripts/dev/Start-Debug.ps1 (commentaarblok bovenaan voor details)
+
+       # Alternatief (handmatig, als Start-Debug.ps1 niet beschikbaar):
+       # 1. Azurite
        $azuriteRunning = [bool](Get-NetTCPConnection -LocalPort 10000 -State Listen -ErrorAction SilentlyContinue)
        if (-not $azuriteRunning) {
            $azuriteDir = Join-Path $env:TEMP 'azurite'
@@ -167,11 +178,11 @@ ITERATIE:
            Start-Process powershell -ArgumentList "-NoExit -Command azurite --location '$azuriteDir'"
            Start-Sleep -Seconds 3
        }
-       # 2. FunctionApp
+       # 2. FunctionApp (geen hot reload — herstart na codewijziging)
        Start-Process powershell -ArgumentList "-NoExit -Command Set-Location FunctionApp; func start --port 7094"
-       # 3. BlazorAdmin (alleen als project bestaat)
+       # 3. BlazorAdmin met hot reload
        if (Test-Path "BlazorAdmin/BlazorAdmin.csproj") {
-           Start-Process powershell -ArgumentList "-NoExit -Command Set-Location BlazorAdmin; dotnet run --launch-profile http"
+           Start-Process powershell -ArgumentList "-NoExit -Command Set-Location BlazorAdmin; dotnet watch run --launch-profile http"
        }
        Start-Sleep -Seconds 15
 

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.2.0</Version>
-    <AssemblyVersion>2.2.0.1</AssemblyVersion>
-    <FileVersion>2.2.0.1</FileVersion>
+    <Version>2.2.1</Version>
+    <AssemblyVersion>2.2.1.0</AssemblyVersion>
+    <FileVersion>2.2.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/scripts/dev/Start-Debug.ps1
+++ b/scripts/dev/Start-Debug.ps1
@@ -3,9 +3,17 @@
 # Vereisten: .NET 10 SDK, Azure Functions Core Tools v4, Azurite, SQL Server met SportlinkSqlDb.
 #
 # Gebruik:
-#   .\Start-Debug.ps1          → Azurite + FunctionApp + BlazorAdmin
+#   .\Start-Debug.ps1          → Azurite + FunctionApp + BlazorAdmin (met hot reload)
 #   .\Start-Debug.ps1 -Swa     → bovenstaande + SWA emulator op http://localhost:4280
-#                                 (vereist: npm install -g @azure/static-web-apps-cli)
+#   .\Start-Debug.ps1 -NoWatch → BlazorAdmin zonder hot reload (dotnet run i.p.v. dotnet watch)
+#
+# Hot reload gedrag:
+#   BlazorAdmin  :5242  → HOT RELOAD actief via 'dotnet watch'. Wijzigingen in .razor/.cs/.css
+#                          worden automatisch herladen zonder herstart. Browser ververst vanzelf.
+#   FunctionApp  :7094  → GEEN hot reload. Azure Functions isolated worker ondersteunt dit niet.
+#                          Na een codewijziging in FunctionApp: sluit het venster en herstart
+#                          Start-Debug.ps1. Alternatief: dotnet build in het FunctionApp-venster
+#                          gevolgd door func start --port 7094.
 #
 # Poorten:
 #   Azurite      :10000 (blob), :10001 (queue), :10002 (table)
@@ -14,7 +22,8 @@
 #   SWA emulator :4280  → http://localhost:4280  (met auth-emulatie en routeregels)
 
 param(
-    [switch]$Swa   # Start ook de Azure SWA emulator (vereist swa CLI)
+    [switch]$Swa,      # Start ook de Azure SWA emulator (vereist swa CLI)
+    [switch]$NoWatch   # Gebruik dotnet run i.p.v. dotnet watch voor BlazorAdmin
 )
 
 $root = Resolve-Path (Join-Path $PSScriptRoot "..\..")
@@ -33,7 +42,6 @@ foreach ($port in @(7094, 5242, 4280)) {
     }
 }
 
-# Wacht kort tot poorten vrijgekomen zijn
 Start-Sleep -Seconds 2
 
 # --- Azurite ---
@@ -53,17 +61,26 @@ if ($azuriteRunning) {
 
 # --- FunctionApp ---
 Write-Host "FunctionApp starten op http://localhost:7094 ..." -ForegroundColor Cyan
+Write-Host "  ⚠  FunctionApp heeft GEEN hot reload. Na codewijzigingen: venster sluiten + Start-Debug.ps1 opnieuw." -ForegroundColor DarkYellow
 Start-Process powershell -ArgumentList @(
     '-NoExit', '-Command',
-    "Set-Location '$root\FunctionApp'; Write-Host 'FunctionApp — poort 7094' -ForegroundColor Cyan; func start --port 7094"
+    "Set-Location '$root\FunctionApp'; Write-Host 'FunctionApp — poort 7094  (geen hot reload — herstart vereist na codewijziging)' -ForegroundColor Cyan; func start --port 7094"
 ) -WindowStyle Normal
 
 # --- BlazorAdmin ---
-Write-Host "BlazorAdmin starten op http://localhost:5242 ..." -ForegroundColor Cyan
-Start-Process powershell -ArgumentList @(
-    '-NoExit', '-Command',
-    "Set-Location '$root\BlazorAdmin'; Write-Host 'BlazorAdmin — poort 5242' -ForegroundColor Cyan; dotnet run --launch-profile http"
-) -WindowStyle Normal
+if ($NoWatch) {
+    Write-Host "BlazorAdmin starten op http://localhost:5242 (geen hot reload) ..." -ForegroundColor Cyan
+    Start-Process powershell -ArgumentList @(
+        '-NoExit', '-Command',
+        "Set-Location '$root\BlazorAdmin'; Write-Host 'BlazorAdmin — poort 5242  (geen hot reload)' -ForegroundColor Cyan; dotnet run --launch-profile http"
+    ) -WindowStyle Normal
+} else {
+    Write-Host "BlazorAdmin starten op http://localhost:5242 (hot reload actief) ..." -ForegroundColor Cyan
+    Start-Process powershell -ArgumentList @(
+        '-NoExit', '-Command',
+        "Set-Location '$root\BlazorAdmin'; Write-Host 'BlazorAdmin — poort 5242  (hot reload: wijzigingen in .razor/.cs/.css herladen automatisch)' -ForegroundColor Green; dotnet watch run --launch-profile http"
+    ) -WindowStyle Normal
+}
 
 # --- SWA emulator (optioneel) ---
 if ($Swa) {
@@ -85,8 +102,12 @@ if ($Swa) {
 # --- Samenvatting ---
 Write-Host ""
 Write-Host "Gestart:" -ForegroundColor Green
-Write-Host "  FunctionApp   http://localhost:7094/api/health" -ForegroundColor White
-Write-Host "  BlazorAdmin   http://localhost:5242  (direct, LocalDev admin)" -ForegroundColor White
+Write-Host "  FunctionApp   http://localhost:7094/api/health  (herstart vereist na C#-wijziging)" -ForegroundColor White
+if ($NoWatch) {
+    Write-Host "  BlazorAdmin   http://localhost:5242  (geen hot reload)" -ForegroundColor White
+} else {
+    Write-Host "  BlazorAdmin   http://localhost:5242  (hot reload actief — browser ververst automatisch)" -ForegroundColor Green
+}
 if ($Swa -and (Get-Command swa -ErrorAction SilentlyContinue)) {
     Write-Host "  SWA emulator  http://localhost:4280  (auth-emulatie actief)" -ForegroundColor White
     Write-Host ""
@@ -94,5 +115,6 @@ if ($Swa -and (Get-Command swa -ErrorAction SilentlyContinue)) {
     Write-Host "Mock-login: http://localhost:4280/.auth/login/aad  (vul username + rol 'admin' in)" -ForegroundColor DarkGray
 }
 Write-Host ""
-Write-Host "Wacht ~15 seconden tot alle services klaar zijn, daarna: .\Test-App.ps1" -ForegroundColor DarkGray
+Write-Host "Wacht ~15 seconden tot alle services klaar zijn." -ForegroundColor DarkGray
+Write-Host "Hot reload status: BlazorAdmin=JA (.razor/.cs/.css), FunctionApp=NEE (herstart vereist)" -ForegroundColor DarkGray
 Write-Host "Sluit de aparte vensters om te stoppen." -ForegroundColor DarkGray


### PR DESCRIPTION
## Wijzigingen

**Versie 2.2.1** — PATCH-bump voor feedback widget bugfix (#284).

**Hot reload voor BlazorAdmin:**
- `Start-Debug.ps1` gebruikt nu `dotnet watch run` i.p.v. `dotnet run`
- Wijzigingen in `.razor`, `.cs`, `.css` worden automatisch herladen; browser ververst vanzelf
- Nieuw `-NoWatch` vlag om hot reload uit te schakelen indien gewenst

**FunctionApp: geen hot reload (gedocumenteerd):**
- Azure Functions isolated worker ondersteunt hot reload niet
- Na C#-wijziging in FunctionApp: `Start-Debug.ps1` opnieuw uitvoeren
- Gedocumenteerd in Start-Debug.ps1 (header) en CLAUDE.md (verificatielus stap d)

## Achtergrond

Tijdens testen bleef de browser "loading" tonen na een code-update + PR-merge. Oorzaak: de lopende `dotnet run` process serveerde oude binaries. Met `dotnet watch` wordt dit automatisch opgelost voor BlazorAdmin. Voor FunctionApp (Azure Functions host) is herstart structureel vereist.

## Test plan

- [ ] `Start-Debug.ps1` starten → BlazorAdmin venster toont "hot reload" melding
- [ ] Kleine wijziging in een `.razor` bestand → browser ververst automatisch zonder herstart
- [ ] Health endpoint toont `"version": "2.2.1.0"`
- [ ] `Start-Debug.ps1 -NoWatch` → BlazorAdmin start zonder watch

🤖 Generated with [Claude Code](https://claude.com/claude-code)