### PR TITLE
fix(#290/#291): onnodige optimalisatiesuggesties + planner 500 + dry-run fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **Dagplanning: onnodige optimalisatiesuggesties onderdrukt** (#291/#290): planner genereert geen suggesties meer als er geen zinvol doel is. `veld5-ontlasten` is nooit zinvol op doordeweekse dagen (veld 1-4 niet beschikbaar). `strakker-plannen` is alleen zinvol als een gewenste eindtijd is opgegeven of het doel expliciet gekozen. Zonder doel én zonder gewenste eindtijd geeft de planner direct "Geen optimalisatie nodig" terug.
 - **Dagplanning HTTP 500 bij dagen zonder wedstrijden** (#291): `PlannerHtmlGenerator.GenereerHtml` riep `.Max()` aan op een lege lijst wanneer er geen wedstrijden gepland waren (bijv. zondag). Geeft nu een informatieve melding terug in plaats van een 500-fout.
 - **Dry-run email: teamconflict heeft nu eigen antwoordtekst** (#291): teamconflict verscheen voorheen als aanhangsel aan "geen veld beschikbaar" — terwijl het veld helemaal niet gecheckt werd bij een teamconflict. Teamconflict heeft nu een eigen berichttak zonder vermelding van veldgebrek.
 - **Dry-run planner response toonde geneste lege arrays** (#291): `JToken` (Newtonsoft) geserialiseerd via `System.Text.Json` gaf corrupt JSON terug. Opgelost door `JsonDocument.Parse(...).RootElement` te gebruiken in `EmailTestFunction`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **Dagplanning HTTP 500 bij dagen zonder wedstrijden** (#291): `PlannerHtmlGenerator.GenereerHtml` riep `.Max()` aan op een lege lijst wanneer er geen wedstrijden gepland waren (bijv. zondag). Geeft nu een informatieve melding terug in plaats van een 500-fout.
+- **Dry-run email: teamconflict heeft nu eigen antwoordtekst** (#291): teamconflict verscheen voorheen als aanhangsel aan "geen veld beschikbaar" — terwijl het veld helemaal niet gecheckt werd bij een teamconflict. Teamconflict heeft nu een eigen berichttak zonder vermelding van veldgebrek.
+- **Dry-run planner response toonde geneste lege arrays** (#291): `JToken` (Newtonsoft) geserialiseerd via `System.Text.Json` gaf corrupt JSON terug. Opgelost door `JsonDocument.Parse(...).RootElement` te gebruiken in `EmailTestFunction`.
 - **Feedback widget loop bij aanvulvragen** (#283): na het beantwoorden van OpenAI-aanvulvragen keerden dezelfde vragen terug bij "Opnieuw controleren". Backend accepteert nu direct zodra antwoorden zijn ingevuld (re-validatie overbodig — antwoorden vullen de gaten per definitie). Frontend bewaart bovendien bestaande antwoorden als vragen ongewijzigd terugkomen.
 
 ### Added

--- a/FunctionApp/Admin/EmailTestFunction.cs
+++ b/FunctionApp/Admin/EmailTestFunction.cs
@@ -88,7 +88,7 @@ public static class EmailTestFunction
                 dryRun = true,
                 opmerking = "Dit verstuurt niets en slaat niets op",
                 classificatie,
-                plannerResponse = Newtonsoft.Json.Linq.JToken.Parse(plannerResponseJson),
+                plannerResponse = System.Text.Json.JsonDocument.Parse(plannerResponseJson).RootElement,
                 voorbeeldAntwoord = new
                 {
                     onderwerp = voorbeeldOnderwerp,

--- a/FunctionApp/Email/BerichtResponseGenerator.cs
+++ b/FunctionApp/Email/BerichtResponseGenerator.cs
@@ -87,6 +87,15 @@ public static class BerichtResponseGenerator
             if (response.Waarschuwingen.Count > 0)
                 inhoud += "\nLet op: " + string.Join(" ", response.Waarschuwingen);
         }
+        else if (response.TeamConflict != null)
+        {
+            // Team heeft al een wedstrijd op deze datum — dit is de primaire reden.
+            // Veld-beschikbaarheid is niet gecheckt (early return in PlannerService),
+            // dus "geen veld beschikbaar" is hier feitelijk onjuist en misleidend.
+            inhoud = $"{aanhef} {voornaam},\n\n"
+                   + $"{response.Reden}\n\n"
+                   + $"Hierdoor kan op {datumTekst} geen oefenwedstrijd worden ingepland.";
+        }
         else
         {
             inhoud = $"{aanhef} {voornaam},\n\n"
@@ -177,6 +186,9 @@ public static class BerichtResponseGenerator
             }
             return sectie;
         }
+
+        if (response.TeamConflict != null)
+            return $"**{datumTekst}:** {response.Reden} Hierdoor kan op deze dag geen oefenwedstrijd worden ingepland.\n";
 
         var fallback = $"**{datumTekst}:** Helaas geen veld beschikbaar.";
         if (!string.IsNullOrEmpty(response.Reden))

--- a/FunctionApp/Planner/PlannerHtmlGenerator.cs
+++ b/FunctionApp/Planner/PlannerHtmlGenerator.cs
@@ -50,7 +50,11 @@ namespace SportlinkFunction.Planner
 
             // Bereken tijdlijn: start bij 08:30, eind bij laatste wedstrijd + 30 min
             int startMin = 8 * 60 + 30; // 08:30
-            var laatsteEind = wedstrijden.Max(w => w.EindTijd);
+
+            if (!wedstrijden.Any() && !suggesties.Any())
+                return $"<p style='margin:0;color:{TXT_DIM};font-family:sans-serif;'>Geen wedstrijden gepland op {datum.ToString("dddd d MMMM yyyy", nl)}.</p>";
+
+            var laatsteEind = wedstrijden.Any() ? wedstrijden.Max(w => w.EindTijd) : new TimeOnly(16, 0);
             // Voeg suggestie-eindtijden toe
             foreach (var s in suggesties)
             {

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -755,6 +755,15 @@ namespace SportlinkFunction.Planner
                 .OrderBy(o => o.AanvangsTijd).ThenBy(o => o.VeldNummer)
                 .ToList();
 
+            // Geen wedstrijden op deze dag (bijv. zondag) → informatieve response
+            if (bezettingen.Count == 0)
+            {
+                response.VoldoendeRuimte = true;
+                response.VoldoendeRuimteMelding = $"Geen wedstrijden gepland op {date.ToString("dddd d MMMM", nl)}.";
+                response.HtmlPlanner = $"<p style='color:#8b949e;font-family:sans-serif;'>Geen wedstrijden gepland op {date.ToString("dddd d MMMM yyyy", nl)}.</p>";
+                return response;
+            }
+
             // Huidige eindtijd bepalen
             var laatsteWedstrijd = bezettingen.OrderByDescending(o => o.EindTijd).FirstOrDefault();
             response.HuidigeEindtijd = laatsteWedstrijd?.EindTijd.ToString("HH:mm") ?? "—";

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -786,10 +786,26 @@ namespace SportlinkFunction.Planner
             // Buffer uit request of standaard
             int bufferMin = request.BufferMinuten ?? StandardBufferMinutes;
 
-            // Capaciteitsberekening: check of optimalisatie nodig is
+            // Capaciteitsberekening en optimalisatie-noodzaak analyse
             var capaciteit = BerekenCapaciteit(bezettingen, availableFields);
             response.CapaciteitOverzicht = capaciteit;
 
+            // Bepaal welke optimalisaties zinvol zijn voor deze specifieke dag en het opgegeven doel.
+            //
+            // veld5-ontlasten: zinvol als veld 1-4 beschikbaar zijn (zaterdag) én er wedstrijden op
+            //   veld 5 staan. Op doordeweekse dagen zijn veld 1-4 in gebruik voor training en zijn er
+            //   geen alternatieve velden — veld 5 is dan per definitie de juiste plek.
+            //
+            // strakker-plannen: zinvol als de gebruiker een gewenste eindtijd heeft opgegeven of
+            //   het doel expliciet op 'strakker-plannen' gezet heeft. Zonder die grenswaarde weet
+            //   de planner niet wat 'beter' is en genereert hij onnodig suggesties.
+            var doel = (request.Doel ?? "").ToLowerInvariant().Trim();
+            bool alleenVeld5Beschikbaar = availableFields.Count > 0 && !availableFields.Any(f => f.VeldNummer <= 4);
+            bool gewensteEindtijdOpgegeven = !string.IsNullOrEmpty(request.GewensteEindtijd);
+            bool veld5OntlastenZinvol = !alleenVeld5Beschikbaar && capaciteit.AantalWedstrijdenOpVeld5 > 0;
+            bool strakkerPlannenZinvol = gewensteEindtijdOpgegeven || doel == "strakker-plannen";
+
+            // Check 1: laag bezettingspercentage én geen veld 5 gebruik (bestaande check)
             if (capaciteit.AantalWedstrijdenOpVeld5 == 0 && capaciteit.BezettingsPercentage < MaxBezettingsPercentageVoorOverslaan)
             {
                 response.VoldoendeRuimte = true;
@@ -798,30 +814,46 @@ namespace SportlinkFunction.Planner
                     $"geen wedstrijden op veld 5, {capaciteit.BezettingsPercentage:F0}% bezet " +
                     $"({capaciteit.AantalLegeVelden} veld(en) ongebruikt). Geen optimalisatie nodig.";
                 response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(
-                    date, bezettingen, new List<OptimalisatieSuggestie>(), velden,
-                    request.Doel ?? "optimaliseren");
+                    date, bezettingen, new List<OptimalisatieSuggestie>(), velden, doel);
+                return response;
+            }
+
+            // Check 2: geen enkel optimalisatiedoel is zinvol voor deze dag
+            if (!veld5OntlastenZinvol && !strakkerPlannenZinvol)
+            {
+                string redenDetail = alleenVeld5Beschikbaar
+                    ? "doordeweekse dag — veld 1-4 niet beschikbaar, veld 5 is de enige optie en er is geen gewenste eindtijd opgegeven"
+                    : "geen wedstrijden op veld 5 en geen gewenste eindtijd opgegeven";
+                response.VoldoendeRuimte = true;
+                response.VoldoendeRuimteMelding = $"Geen optimalisatie nodig op {date.ToString("dddd d MMMM", nl)}: {redenDetail}.";
+                response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(
+                    date, bezettingen, new List<OptimalisatieSuggestie>(), velden, doel);
                 return response;
             }
 
             var suggesties = new List<OptimalisatieSuggestie>();
-            var doel = request.Doel?.ToLowerInvariant() ?? "";
 
             switch (doel)
             {
                 case "veld5-ontlasten":
-                    suggesties = OptimaliseerVeld5Ontlasten(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
+                    if (veld5OntlastenZinvol)
+                        suggesties = OptimaliseerVeld5Ontlasten(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
                     break;
                 case "strakker-plannen":
-                    suggesties = OptimaliseerStrakkerPlannen(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
+                    if (strakkerPlannenZinvol)
+                        suggesties = OptimaliseerStrakkerPlannen(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
                     break;
                 default:
-                    suggesties = OptimaliseerVeld5Ontlasten(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
-                    var strakkerSuggesties = OptimaliseerStrakkerPlannen(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
-                    // Voeg strakker-suggesties toe die niet al in veld5-suggesties zitten
-                    foreach (var s in strakkerSuggesties)
+                    if (veld5OntlastenZinvol)
+                        suggesties = OptimaliseerVeld5Ontlasten(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
+                    if (strakkerPlannenZinvol)
                     {
-                        if (!suggesties.Any(bestaand => bestaand.Wedstrijd == s.Wedstrijd))
-                            suggesties.Add(s);
+                        var strakkerSuggesties = OptimaliseerStrakkerPlannen(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
+                        foreach (var s in strakkerSuggesties)
+                        {
+                            if (!suggesties.Any(bestaand => bestaand.Wedstrijd == s.Wedstrijd))
+                                suggesties.Add(s);
+                        }
                     }
                     break;
             }


### PR DESCRIPTION
## Wat is er gewijzigd

### fix(#290) — Onnodige optimalisatiesuggesties onderdrukt

**Probleem:** De planner gaf optimalisatiesuggesties op dagen waarop dat zinloos of onmogelijk is:
- Doordeweeks (ma–do) zijn velden 1–4 bezet voor training; alleen veld 5 beschikbaar. De planner stelde dan voor om wedstrijden van veld 5 te verplaatsen naar velden die niet beschikbaar zijn.
- Als geen optimalisatiedoel was opgegeven én `gewensteEindtijd` leeg is, runde `strakker-plannen` alsnog.

**Fix (`PlannerService.cs`):**
- Nieuwe vlaggen `veld5OntlastenZinvol` (alleen zinvol als velden 1–4 beschikbaar zijn) en `strakkerPlannenZinvol` (alleen zinvol als `gewensteEindtijd` is opgegeven of doel expliciet is).
- Vroege return met `VoldoendeRuimte = true` als geen van beide zinvol is.
- `switch(doel)`-cases bewaakt per vlag — nooit een actie die niets kan bereiken.

### fix — HTTP 500 op dagen zonder wedstrijden (bijv. zondag)

**Probleem:** `OptimaliseerAsync` met 0 wedstrijden → `GenereerHtml` → `.Max()` op lege lijst → `InvalidOperationException`.

**Fix:**
- Vroege return in `OptimaliseerAsync` als `bezettingen.Count == 0` (service-level).
- Defensieve guard in `PlannerHtmlGenerator.GenereerHtml` vóór `.Max()` (generator-level).

### fix(#291) — Dry-run iteraties: planner 500 + teamconflict prioriteit + JSON serialisatie

- `BerichtResponseGenerator`: team-conflict krijgt eigen antwoord-branch (niet meer gecombineerd met "geen veld beschikbaar")
- `EmailTestFunction`: `JToken.Parse(...)` vervangen door `System.Text.Json.JsonDocument.Parse(...).RootElement` — voorkomt serialisatie-exception in dry-run response

## Test

- `dotnet build` — 0 errors, 0 warnings
- Scenario's getest:
  - Doordeweeks, alleen veld 5: geen onnodige suggesties ✓
  - Zondag zonder wedstrijden: geen 500, correcte melding ✓
  - Zaterdag met meerdere velden en gewensteEindtijd: strakker-plannen werkt ✓
  - Dry-run: geen serialisatie-exception ✓

Closes #290