### PR TITLE
feat(#168): teambegeleiding opvragen — Admin UI + e-mail auto-reply

### DIFF
--- a/BlazorAdmin/Layout/NavMenu.razor
+++ b/BlazorAdmin/Layout/NavMenu.razor
@@ -38,6 +38,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="teambegeleiding">
+                <span class="bi bi-people-fill-nav-menu" aria-hidden="true"></span> Teambegeleiding
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="dagplanning">
                 <span class="bi bi-calendar2-week-fill-nav-menu" aria-hidden="true"></span> Dagplanning
             </NavLink>

--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -142,6 +142,21 @@ public class TeamRegelDto
     public string ClubCode { get; set; } = string.Empty;
 }
 
+// ── Teambegeleiding ──
+
+public class TeambegeleidingItem
+{
+    public string Naam { get; set; } = "";
+    public string Teamrol { get; set; } = "";
+}
+
+public class DoorsturenRequest
+{
+    public string TeamNaam { get; set; } = "";
+    public string? Onderwerp { get; set; }
+    public string Bericht { get; set; } = "";
+}
+
 // ── Speeltijden ──
 
 public class SpeeltijdDto

--- a/BlazorAdmin/Pages/Teambegeleiding.razor
+++ b/BlazorAdmin/Pages/Teambegeleiding.razor
@@ -1,0 +1,186 @@
+@page "/teambegeleiding"
+@inject AdminApiClient Api
+@using BlazorAdmin.Models
+
+<PageTitle>Teambegeleiding — Admin</PageTitle>
+
+<h1>Teambegeleiding</h1>
+<p class="text-muted">
+    Selecteer een team om de begeleiding op te zoeken. U kunt een vraag doorsturen —
+    de begeleider neemt rechtstreeks contact met u op.
+    <strong>Contactgegevens worden niet gedeeld conform AVG.</strong>
+</p>
+
+@if (_loadingTeams)
+{
+    <p>Teams laden...</p>
+}
+else if (_teamsError != null)
+{
+    <div class="alert alert-danger">@_teamsError</div>
+}
+else
+{
+    <div class="row mb-3">
+        <div class="col-md-4">
+            <label class="form-label">Team</label>
+            <select class="form-select" @onchange="OnTeamGekozen">
+                <option value="">— Kies een team —</option>
+                @foreach (var t in _teams)
+                {
+                    <option value="@t">@t</option>
+                }
+            </select>
+        </div>
+    </div>
+}
+
+@if (_loadingBegeleiders)
+{
+    <p>Begeleiding laden...</p>
+}
+else if (_selectedTeam != null && _begeleiders.Count > 0)
+{
+    <h3>Begeleiding van @_selectedTeam</h3>
+    <div class="row g-3 mb-4">
+        @foreach (var b in _begeleiders)
+        {
+            <div class="col-md-3">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h5 class="card-title">@b.Naam</h5>
+                        <span class="badge bg-secondary">@b.Teamrol</span>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+
+    @if (!_vraagFormulierZichtbaar)
+    {
+        <button class="btn btn-primary" @onclick="ToonVraagFormulier">Stel een vraag</button>
+    }
+    else
+    {
+        <div class="card mt-3 border-primary">
+            <div class="card-header bg-primary text-white">Vraag doorsturen naar begeleiding van @_selectedTeam</div>
+            <div class="card-body">
+                <p class="text-muted small">
+                    Uw vraag wordt doorgestuurd naar de begeleiding. De begeleider antwoordt rechtstreeks op uw e-mailadres.
+                    Hun e-mailadres wordt niet gedeeld.
+                </p>
+                <div class="mb-3">
+                    <label class="form-label">Onderwerp</label>
+                    <input class="form-control" @bind="_doorsturen.Onderwerp" placeholder="Optioneel" />
+                </div>
+                <div class="mb-3">
+                    <label class="form-label">Bericht <span class="text-danger">*</span></label>
+                    <textarea class="form-control" rows="4" @bind="_doorsturen.Bericht" placeholder="Uw vraag aan de begeleiding..."></textarea>
+                </div>
+                @if (_doorsturenError != null)
+                {
+                    <div class="alert alert-danger">@_doorsturenError</div>
+                }
+                @if (_doorsturenSuccess != null)
+                {
+                    <div class="alert alert-success">@_doorsturenSuccess</div>
+                }
+                <div class="d-flex gap-2">
+                    <button class="btn btn-primary" @onclick="VerstuurVraagAsync" disabled="@_doorsturenBezig">
+                        @if (_doorsturenBezig) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                        Versturen
+                    </button>
+                    <button class="btn btn-secondary" @onclick="SluitVraagFormulier">Annuleer</button>
+                </div>
+            </div>
+        </div>
+    }
+}
+else if (_selectedTeam != null && !_loadingBegeleiders)
+{
+    <div class="alert alert-info">Geen begeleiding gevonden voor @_selectedTeam.</div>
+}
+
+@code {
+    private List<string> _teams = new();
+    private List<TeambegeleidingItem> _begeleiders = new();
+    private string? _selectedTeam;
+    private bool _loadingTeams = true;
+    private bool _loadingBegeleiders;
+    private string? _teamsError;
+    private bool _vraagFormulierZichtbaar;
+    private DoorsturenRequest _doorsturen = new();
+    private bool _doorsturenBezig;
+    private string? _doorsturenError;
+    private string? _doorsturenSuccess;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var result = await Api.GetTeambegeleidingTeamsAsync();
+        if (result.Success)
+            _teams = result.Data ?? new();
+        else
+            _teamsError = result.ErrorMessage ?? "Ophalen teams mislukt";
+        _loadingTeams = false;
+    }
+
+    private async Task OnTeamGekozen(ChangeEventArgs e)
+    {
+        _selectedTeam = e.Value?.ToString();
+        _begeleiders.Clear();
+        _vraagFormulierZichtbaar = false;
+        _doorsturenSuccess = null;
+        _doorsturenError = null;
+
+        if (string.IsNullOrEmpty(_selectedTeam)) return;
+
+        _loadingBegeleiders = true;
+        var result = await Api.GetTeambegeleidingAsync(_selectedTeam);
+        if (result.Success)
+            _begeleiders = result.Data ?? new();
+        _loadingBegeleiders = false;
+    }
+
+    private void ToonVraagFormulier()
+    {
+        _doorsturen = new DoorsturenRequest { TeamNaam = _selectedTeam ?? "" };
+        _doorsturenError = null;
+        _doorsturenSuccess = null;
+        _vraagFormulierZichtbaar = true;
+    }
+
+    private void SluitVraagFormulier()
+    {
+        _vraagFormulierZichtbaar = false;
+        _doorsturenError = null;
+        _doorsturenSuccess = null;
+    }
+
+    private async Task VerstuurVraagAsync()
+    {
+        if (string.IsNullOrWhiteSpace(_doorsturen.Bericht))
+        {
+            _doorsturenError = "Vul een bericht in.";
+            return;
+        }
+
+        _doorsturenBezig = true;
+        _doorsturenError = null;
+        _doorsturen.TeamNaam = _selectedTeam ?? "";
+
+        var result = await Api.StuurTeambegeleidingBerichtAsync(_doorsturen);
+        _doorsturenBezig = false;
+
+        if (result.Success)
+        {
+            _doorsturenSuccess = $"Uw vraag over de begeleiding van {_selectedTeam} is doorgestuurd. " +
+                                  "De begeleider neemt rechtstreeks contact met u op. " +
+                                  "Contactgegevens worden niet gedeeld conform AVG.";
+            _vraagFormulierZichtbaar = false;
+        }
+        else
+        {
+            _doorsturenError = result.ErrorMessage ?? "Doorsturen mislukt. Probeer opnieuw.";
+        }
+    }
+}

--- a/BlazorAdmin/Services/AdminApiClient.cs
+++ b/BlazorAdmin/Services/AdminApiClient.cs
@@ -130,6 +130,17 @@ public class AdminApiClient
         catch (Exception ex) { return ApiResult<string>.Fail(ex.Message); }
     }
 
+    // ── Teambegeleiding ──
+
+    public async Task<ApiResult<List<string>>> GetTeambegeleidingTeamsAsync()
+        => await GetAsync<List<string>>("api/beheer/teambegeleiding");
+
+    public async Task<ApiResult<List<TeambegeleidingItem>>> GetTeambegeleidingAsync(string team)
+        => await GetAsync<List<TeambegeleidingItem>>($"api/beheer/teambegeleiding/{Uri.EscapeDataString(team)}");
+
+    public async Task<ApiResult<object>> StuurTeambegeleidingBerichtAsync(DoorsturenRequest request)
+        => await PostAsync<object>("api/beheer/teambegeleiding/doorsturen", request);
+
     // ── Speeltijden ──
 
     public async Task<ApiResult<List<SpeeltijdDto>>> GetSpeeltijdenAsync()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **Teambegeleiding opvragen (#168):**
+  - Admin GUI-pagina `/teambegeleiding`: beheerders en gebruikers (user-rol) kunnen een team kiezen en de naam + rol van de begeleiders inzien. Een inline formulier stuurt een vraag door aan de begeleiding — het e-mailadres van de coach wordt nooit getoond (AVG art. 6.1.f). Reply-To is het e-mailadres van de aanvrager; de coach antwoordt rechtstreeks.
+  - E-mail auto-reply: inkomende berichten met "wie is de trainer/coach van [team]?" worden automatisch geclassificeerd als `TeamContactOpvragen`, doorgestuurd naar de coach (BCC coördinator) en beantwoord met "uw vraag is doorgestuurd, contactgegevens worden niet gedeeld".
+  - Nieuwe API-endpoints: `GET /api/beheer/teambegeleiding`, `GET /api/beheer/teambegeleiding/{team}`, `POST /api/beheer/teambegeleiding/doorsturen`.
+  - Nieuw Auth-niveau `RequireAuthenticated()` in EasyAuthHelper: admin- én user-rol hebben toegang tot teambegeleiding.
 - **Speeltijden beheer in Admin GUI** (#291): nieuwe pagina `/instellingen/speeltijden` waarmee beheerders speeltijden per leeftijdscategorie kunnen inzien, toevoegen, bewerken en verwijderen. Het veld "Totaal (incl. rust)" is de totale veldblokkeertijd die de planner direct gebruikt — rust wordt niet apart opgeteld in code. API-endpoints: `GET/POST /api/beheer/speeltijden` en `PUT/DELETE /api/beheer/speeltijden/{leeftijd}`.
 - **Speeltijden DB leidend voor veldplanning** (#291): de planner gebruikt uitsluitend `dbo.Speeltijden.WedstrijdTotaal` voor de berekening van wedstrijdduur. De Sportlink API-waarde `Duration` (die geen rust bevat) wordt niet meer gebruikt. Ontbrekende leeftijdscategorie geeft nu een duidelijke foutmelding met verwijzing naar de beheerpagina in plaats van een stille fallback naar 105 minuten.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -719,6 +719,8 @@ Browser (beheerder)
 | `GET/PUT/POST/DELETE /api/beheer/velden`, `/veldbeschikbaarheid` | `AdminVeldBeschikbaarheidFunction.cs` |
 | `GET/POST/PUT/DELETE /api/beheer/voorkeurstijden`, `/teamregels` | `AdminVoorkeurTijdenFunction.cs` |
 | `GET /api/beheer/email-log` | `AdminEmailLogFunction.cs` |
+| `GET/POST /api/beheer/teambegeleiding`, `/{team}`, `/doorsturen` | `AdminTeambegeleidingFunction.cs` |
+| `GET/POST/PUT/DELETE /api/beheer/speeltijden`, `/{leeftijd}` | `AdminSpeeltijdenFunction.cs` |
 | `POST /api/test/email` | `EmailTestFunction.cs` |
 | `POST /api/feedback/validate`, `/submit` | `FeedbackFunction.cs` |
 

--- a/FunctionApp/Admin/AdminTeambegeleidingFunction.cs
+++ b/FunctionApp/Admin/AdminTeambegeleidingFunction.cs
@@ -1,0 +1,203 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+using Newtonsoft.Json;
+using SportlinkFunction.Email;
+
+namespace SportlinkFunction.Admin;
+
+/// <summary>
+/// Admin API voor teambegeleiding (#168).
+/// AVG: Emailadres en Telefoonnummer worden NOOIT in een API-response teruggestuurd.
+/// Emailadres wordt uitsluitend server-side gebruikt als SMTP-bestemming.
+/// </summary>
+public static class AdminTeambegeleidingFunction
+{
+    /// <summary>
+    /// GET /api/beheer/teambegeleiding — lijst van alle teams waarvoor begeleiding beschikbaar is.
+    /// </summary>
+    [Function("AdminTeambegeleidingTeams")]
+    public static async Task<IActionResult> GetTeams(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "beheer/teambegeleiding")] HttpRequest req,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("AdminTeambegeleidingTeams");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
+        var authResult = EasyAuthHelper.RequireAuthenticated(req);
+        if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
+        try
+        {
+            await SystemUtilities.WaitForDatabaseAsync(log);
+            using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+            await connection.OpenAsync();
+            using var command = new SqlCommand(
+                "SELECT DISTINCT [Team] FROM [avg].[Teambegeleiding] WHERE [Team] IS NOT NULL ORDER BY [Team]",
+                connection);
+            using var reader = await command.ExecuteReaderAsync();
+            var teams = new List<string>();
+            while (await reader.ReadAsync())
+                teams.Add(reader.GetString(0));
+            return new OkObjectResult(teams);
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij ophalen teams uit teambegeleiding");
+            return new ObjectResult(new { error = "Ophalen mislukt" }) { StatusCode = 500 };
+        }
+    }
+
+    /// <summary>
+    /// GET /api/beheer/teambegeleiding/{team} — begeleiders voor een specifiek team.
+    /// Response bevat alleen Naam en Teamrol — GEEN e-mailadres of telefoonnummer.
+    /// </summary>
+    [Function("AdminTeambegeleidingGet")]
+    public static async Task<IActionResult> GetBegeleiders(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "beheer/teambegeleiding/{team}")] HttpRequest req,
+        string team,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("AdminTeambegeleidingGet");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
+        var authResult = EasyAuthHelper.RequireAuthenticated(req);
+        if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
+        try
+        {
+            await SystemUtilities.WaitForDatabaseAsync(log);
+            using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+            await connection.OpenAsync();
+            using var command = new SqlCommand(@"
+                SELECT [Naam], [Teamrol]
+                FROM [avg].[Teambegeleiding]
+                WHERE [Team] = @team
+                ORDER BY
+                    CASE WHEN [Teamrol] LIKE '%Trainer%' THEN 1
+                         WHEN [Teamrol] LIKE '%Coach%' THEN 2
+                         WHEN [Teamrol] LIKE '%Teamleider%' THEN 3
+                         ELSE 4 END,
+                    [Naam]
+            ", connection);
+            command.Parameters.AddWithValue("@team", team);
+            using var reader = await command.ExecuteReaderAsync();
+            var list = new List<object>();
+            while (await reader.ReadAsync())
+            {
+                list.Add(new
+                {
+                    Naam = reader.IsDBNull(0) ? "" : reader.GetString(0),
+                    Teamrol = reader.IsDBNull(1) ? "" : reader.GetString(1)
+                });
+            }
+            return new OkObjectResult(list);
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij ophalen begeleiders (team niet gelogd — AVG)");
+            return new ObjectResult(new { error = "Ophalen mislukt" }) { StatusCode = 500 };
+        }
+    }
+
+    /// <summary>
+    /// POST /api/beheer/teambegeleiding/doorsturen — stuurt een vraag door naar de begeleiding.
+    /// Coach-email wordt server-side opgezocht en nooit in de response opgenomen (AVG).
+    /// </summary>
+    [Function("AdminTeambegeleidingDoorsturen")]
+    public static async Task<IActionResult> Doorsturen(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "beheer/teambegeleiding/doorsturen")] HttpRequest req,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("AdminTeambegeleidingDoorsturen");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
+        var authResult = EasyAuthHelper.RequireAuthenticated(req);
+        if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
+        try
+        {
+            await SystemUtilities.WaitForDatabaseAsync(log);
+
+            using var bodyReader = new StreamReader(req.Body);
+            var body = await bodyReader.ReadToEndAsync();
+            var dto = JsonConvert.DeserializeObject<DoorsturenRequest>(body);
+            if (dto == null || string.IsNullOrWhiteSpace(dto.TeamNaam))
+                return new BadRequestObjectResult(new { error = "TeamNaam is vereist" });
+            if (string.IsNullOrWhiteSpace(dto.Bericht))
+                return new BadRequestObjectResult(new { error = "Bericht is vereist" });
+
+            // Naam + email aanvrager uit Entra claims (server-side — nooit in response)
+            var aanvragerNaam = EasyAuthHelper.GetCallerName(req) ?? "een club-gebruiker";
+            var aanvragerEmail = EasyAuthHelper.GetCallerEmail(req);
+
+            // Coach-email server-side ophalen (NOOIT in response)
+            string? coachEmail = null;
+            using (var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString))
+            {
+                await connection.OpenAsync();
+                using var cmd = new SqlCommand(@"
+                    SELECT TOP 1 [Emailadres]
+                    FROM [avg].[Teambegeleiding]
+                    WHERE [Team] = @team
+                      AND [Emailadres] IS NOT NULL
+                    ORDER BY
+                        CASE WHEN [Teamrol] LIKE '%Trainer%' THEN 1
+                             WHEN [Teamrol] LIKE '%Coach%' THEN 2
+                             WHEN [Teamrol] LIKE '%Teamleider%' THEN 3
+                             ELSE 4 END
+                ", connection);
+                cmd.Parameters.AddWithValue("@team", dto.TeamNaam);
+                var result = await cmd.ExecuteScalarAsync();
+                coachEmail = result as string;
+            }
+
+            // Coördinator-email ophalen uit AppSettings
+            var coordinatorEmail = SystemUtilities.AppSettings.GetSetting("plannerEmailAdres");
+
+            if (string.IsNullOrEmpty(coachEmail))
+            {
+                // Geen coach gevonden: stuur naar coördinator als fallback
+                if (string.IsNullOrEmpty(coordinatorEmail))
+                    return new ObjectResult(new { error = "Geen begeleider en geen coördinator geconfigureerd" }) { StatusCode = 503 };
+                coachEmail = coordinatorEmail;
+                log.LogWarning("Geen coach-email gevonden voor team — doorgestuurd naar coordinator");
+            }
+
+            var graphClient = context.InstanceServices.GetService<GraphServiceClient>();
+            if (graphClient == null)
+            {
+                log.LogWarning("Graph SDK niet geconfigureerd — e-mail doorsturen niet mogelijk");
+                return new ObjectResult(new { error = "E-mail service niet geconfigureerd" }) { StatusCode = 503 };
+            }
+
+            var loggerFactory = context.InstanceServices.GetRequiredService<ILoggerFactory>();
+            var emailService = new EmailGraphService(graphClient, loggerFactory.CreateLogger<EmailGraphService>());
+
+            var subject = $"[{dto.TeamNaam}] Vraag van {aanvragerNaam}";
+            var htmlBody = $@"<p>Er is een vraag binnengekomen over de begeleiding van <strong>{System.Net.WebUtility.HtmlEncode(dto.TeamNaam)}</strong>.</p>
+<p><strong>Vraagsteller:</strong> {System.Net.WebUtility.HtmlEncode(aanvragerNaam)}</p>
+<p><strong>Onderwerp:</strong> {System.Net.WebUtility.HtmlEncode(dto.Onderwerp ?? "")}</p>
+<hr />
+<p>{System.Net.WebUtility.HtmlEncode(dto.Bericht).Replace("\n", "<br />")}</p>
+<hr />
+<p><em>U kunt direct antwoorden op dit bericht — uw antwoord gaat naar de vraagsteller.</em></p>";
+
+            await emailService.StuurTeamContactDoorAsync(coachEmail, subject, htmlBody, aanvragerEmail, coordinatorEmail);
+
+            return new OkObjectResult(new
+            {
+                success = true,
+                bericht = $"Uw vraag over de begeleiding van {dto.TeamNaam} is doorgestuurd. De begeleider neemt rechtstreeks contact met u op."
+            });
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij doorsturen teambegeleiding-vraag (geen PII gelogd — AVG)");
+            return new ObjectResult(new { error = "Doorsturen mislukt" }) { StatusCode = 500 };
+        }
+    }
+
+    private record DoorsturenRequest(string TeamNaam, string? Onderwerp, string Bericht);
+}

--- a/FunctionApp/Admin/EasyAuthHelper.cs
+++ b/FunctionApp/Admin/EasyAuthHelper.cs
@@ -51,6 +51,78 @@ internal static class EasyAuthHelper
     }
 
     /// <summary>
+    /// Controleert of de aanroeper geauthenticeerd is en de 'admin' of 'user' rol heeft.
+    /// Returns null als OK, anders een 401/403 result.
+    /// </summary>
+    public static IActionResult? RequireAuthenticated(HttpRequest req)
+    {
+        var siteName = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+        if (string.IsNullOrEmpty(siteName))
+            return null;
+
+        if (!req.Headers.TryGetValue("X-MS-CLIENT-PRINCIPAL", out var encoded) ||
+            string.IsNullOrEmpty(encoded))
+            return new UnauthorizedResult();
+
+        try
+        {
+            var json = Encoding.UTF8.GetString(Convert.FromBase64String(encoded!));
+            var principal = JsonSerializer.Deserialize<ClientPrincipal>(json, _opts);
+            var hasRole = principal?.Claims?.Any(c =>
+                string.Equals(c.Typ, "roles", StringComparison.OrdinalIgnoreCase) &&
+                (string.Equals(c.Val, "admin", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(c.Val, "user", StringComparison.OrdinalIgnoreCase))) ?? false;
+            return hasRole ? null : new ObjectResult(new { error = "Forbidden" }) { StatusCode = 403 };
+        }
+        catch { return new UnauthorizedResult(); }
+    }
+
+    /// <summary>
+    /// Haalt de weergavenaam van de aanroeper op uit de Entra ID claims.
+    /// Geeft null terug in lokale ontwikkeling of als de claim ontbreekt.
+    /// </summary>
+    public static string? GetCallerName(HttpRequest req)
+    {
+        if (!req.Headers.TryGetValue("X-MS-CLIENT-PRINCIPAL", out var encoded) ||
+            string.IsNullOrEmpty(encoded))
+            return null;
+
+        try
+        {
+            var json = Encoding.UTF8.GetString(Convert.FromBase64String(encoded!));
+            var principal = JsonSerializer.Deserialize<ClientPrincipal>(json, _opts);
+            return principal?.Claims?
+                .FirstOrDefault(c => string.Equals(c.Typ, "name", StringComparison.OrdinalIgnoreCase))
+                ?.Val;
+        }
+        catch { return null; }
+    }
+
+    /// <summary>
+    /// Haalt het e-mailadres van de aanroeper op uit de Entra ID claims.
+    /// Uitsluitend voor server-side gebruik (Reply-To in doorstuur-email). Nooit in response terugsturen.
+    /// </summary>
+    public static string? GetCallerEmail(HttpRequest req)
+    {
+        if (!req.Headers.TryGetValue("X-MS-CLIENT-PRINCIPAL", out var encoded) ||
+            string.IsNullOrEmpty(encoded))
+            return null;
+
+        try
+        {
+            var json = Encoding.UTF8.GetString(Convert.FromBase64String(encoded!));
+            var principal = JsonSerializer.Deserialize<ClientPrincipal>(json, _opts);
+            return principal?.Claims?
+                .FirstOrDefault(c =>
+                    string.Equals(c.Typ, "preferred_username", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(c.Typ, "upn", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(c.Typ, "email", StringComparison.OrdinalIgnoreCase))
+                ?.Val;
+        }
+        catch { return null; }
+    }
+
+    /// <summary>
     /// Leest x-correlation-id uit de request header, of genereert een nieuwe GUID.
     /// Schrijft het ID terug in de response header voor end-to-end tracing.
     /// </summary>

--- a/FunctionApp/Email/BerichtAiService.cs
+++ b/FunctionApp/Email/BerichtAiService.cs
@@ -66,7 +66,8 @@ public class BerichtAiService
             - beschikbaarheid_check: iemand vraagt of een datum/tijd/veld beschikbaar is (bijv. voor een oefenwedstrijd of veldreservering). Ook als er MEERDERE datums worden gevraagd voor hetzelfde team.
             - herplan_verzoek: iemand wil een bestaande wedstrijd verplaatsen naar een andere datum/tijd
             - bevestiging: een antwoord op een eerder voorstel ("ja dat is goed", "akkoord", etc.)
-            - buiten_scope: alles wat niet over veldbeschikbaarheid of herplannen gaat, OF als de email over meerdere VERSCHILLENDE teams gaat en het onduidelijk is welke wedstrijd bedoeld wordt
+            - team_contact_opvragen: iemand vraagt wie de trainer, coach, begeleider of teamleider is van een specifiek team. Bijv. "wie is de trainer van JO13-4?", "contactgegevens begeleiding MO15", "wie kan ik bereiken voor VRC 5?"
+            - buiten_scope: alles wat niet over veldbeschikbaarheid, herplannen of teambegeleiding gaat, OF als de email over meerdere VERSCHILLENDE teams gaat en het onduidelijk is welke wedstrijd bedoeld wordt
 
             Geef ALTIJD een JSON response met exact dit formaat:
             {
@@ -186,6 +187,7 @@ public class BerichtAiService
         "beschikbaarheid_check" => VerzoekType.BeschikbaarheidCheck,
         "herplan_verzoek" => VerzoekType.HerplanVerzoek,
         "bevestiging" => VerzoekType.Bevestiging,
+        "team_contact_opvragen" => VerzoekType.TeamContactOpvragen,
         _ => VerzoekType.BuitenScope
     };
 

--- a/FunctionApp/Email/BerichtModels.cs
+++ b/FunctionApp/Email/BerichtModels.cs
@@ -6,6 +6,7 @@ public enum VerzoekType
     BeschikbaarheidCheck,
     HerplanVerzoek,
     Bevestiging,
+    TeamContactOpvragen,  // #168: "wie is de trainer/coach van [team]?"
     BuitenScope
 }
 

--- a/FunctionApp/Email/BerichtResponseGenerator.cs
+++ b/FunctionApp/Email/BerichtResponseGenerator.cs
@@ -368,6 +368,25 @@ public static class BerichtResponseGenerator
         return WrapMetReviewEnHandtekening(inhoud, classificatie, email);
     }
 
+    // ── Teambegeleiding doorsturen ──
+
+    public static (string onderwerp, string body) BouwTeamContactAutoReply(
+        BerichtClassificatie classificatie, InkomendBericht email)
+    {
+        var aanhef = GetTijdsgebondenAanhef();
+        var voornaam = ExtractVoornaam(email.AfzenderNaam);
+        var teamTekst = !string.IsNullOrWhiteSpace(classificatie.TeamNaam)
+            ? $"de begeleiding van {classificatie.TeamNaam}"
+            : "de begeleiding van het opgegeven team";
+
+        var inhoud = $"{aanhef} {voornaam},\n\n"
+                   + $"Uw vraag over {teamTekst} is doorgestuurd. "
+                   + "De begeleider neemt rechtstreeks contact met u op. "
+                   + "Contactgegevens worden niet gedeeld conform AVG.";
+
+        return WrapMetReviewEnHandtekening(inhoud, classificatie, email);
+    }
+
     // ── Bevestiging ──
 
     public static (string onderwerp, string body) BouwBevestigingAntwoord(

--- a/FunctionApp/Email/EmailGraphService.cs
+++ b/FunctionApp/Email/EmailGraphService.cs
@@ -221,6 +221,49 @@ public partial class EmailGraphService
     }
 
     /// <summary>
+    /// Stuurt een teambegeleiding-vraag door naar de coach.
+    /// Coach e-mailadres blijft server-side; aanvrager ziet het nooit (AVG art. 6.1.f).
+    /// - To: coach e-mailadres (server-side lookup)
+    /// - Reply-To: e-mailadres van aanvrager (Entra)
+    /// - BCC: coördinator (uit AppSettings)
+    /// </summary>
+    public async Task StuurTeamContactDoorAsync(
+        string coachEmail, string subject, string body,
+        string? aanvragerEmail, string? coordinatorEmail)
+    {
+        try
+        {
+            var message = new Message
+            {
+                Subject = subject,
+                Body = new ItemBody { ContentType = BodyType.Html, Content = body },
+                ToRecipients = [new Recipient { EmailAddress = new EmailAddress { Address = coachEmail } }]
+            };
+
+            if (!string.IsNullOrEmpty(aanvragerEmail))
+            {
+                message.ReplyTo = [new Recipient { EmailAddress = new EmailAddress { Address = aanvragerEmail } }];
+            }
+
+            if (!string.IsNullOrEmpty(coordinatorEmail))
+            {
+                message.BccRecipients = [new Recipient { EmailAddress = new EmailAddress { Address = coordinatorEmail } }];
+            }
+
+            await _graphClient.Users[_mailbox]
+                .SendMail
+                .PostAsync(new SendMailPostRequestBody { Message = message });
+
+            _logger.LogInformation("Teambegeleiding-vraag doorgestuurd (AVG: geen namen/emailadressen gelogd)");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Fout bij doorsturen teambegeleiding-vraag (AVG: geen adressen gelogd)");
+            throw;
+        }
+    }
+
+    /// <summary>
     /// Verwijdert HTML-tags uit tekst en normaliseert whitespace.
     /// </summary>
     private static string StripHtml(string html)

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -250,6 +250,14 @@ public class EmailProcessorFunction
             await StuurTeamleiderNotificatieAsync(
                 graphService, classificatie.TeamNaam, classificatie.Datum, reviewMode, log);
         }
+
+        // Stuur vraag door naar coach bij team-contact-opvragen (#168)
+        if (classificatie.Type == VerzoekType.TeamContactOpvragen
+            && !string.IsNullOrWhiteSpace(classificatie.TeamNaam))
+        {
+            await StuurTeamContactBerichtDoorAsync(
+                graphService, classificatie.TeamNaam, email, reviewMode, log);
+        }
     }
 
     private static async Task StuurTeamleiderNotificatieAsync(
@@ -294,6 +302,43 @@ public class EmailProcessorFunction
         catch (Exception ex)
         {
             log.LogWarning(ex, "Fout bij versturen teamleider-notificatie voor {Team} — hoofdverwerking niet onderbroken", teamNaam);
+        }
+    }
+
+    private static async Task StuurTeamContactBerichtDoorAsync(
+        EmailGraphService graphService, string teamNaam, InkomendBericht email,
+        string? reviewMode, ILogger log)
+    {
+        try
+        {
+            var coach = await SportlinkFunction.Planner.PlannerDataAccess.GetTeamleiderContactAsync(teamNaam);
+            if (coach == null)
+            {
+                log.LogInformation("Geen coach gevonden voor {Team} — doorsturen overgeslagen", teamNaam);
+                return;
+            }
+
+            var coordinatorEmail = SystemUtilities.AppSettings.GetSetting("coordinatorEmail");
+            var subject = $"[{teamNaam}] vraag van {email.AfzenderNaam}";
+            var body = $"Er is een vraag binnengekomen over de begeleiding van {teamNaam}.\n\n"
+                     + $"Vraag van: {email.AfzenderNaam}\n\n"
+                     + $"---\n{email.Body}\n---\n\n"
+                     + "U kunt direct antwoorden op dit bericht — uw antwoord gaat naar de vraagsteller.";
+
+            var coachOntvanger = string.Equals(reviewMode, "true", StringComparison.OrdinalIgnoreCase)
+                ? Environment.GetEnvironmentVariable("EmailReviewRecipient") ?? coach.Emailadres
+                : coach.Emailadres;
+
+            // AVG: Reply-To = email.Afzender zodat coach rechtstreeks kan antwoorden
+            // BCC coördinator voor audit; coach-email nooit in logs
+            await graphService.StuurTeamContactDoorAsync(
+                coachOntvanger, subject, body, email.Afzender, coordinatorEmail);
+
+            log.LogInformation("Teambegeleiding-vraag doorgestuurd voor {Team}", teamNaam);
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "Fout bij doorsturen teambegeleiding-vraag voor {Team} — hoofdverwerking niet onderbroken", teamNaam);
         }
     }
 

--- a/FunctionApp/Processing/BerichtPipeline.cs
+++ b/FunctionApp/Processing/BerichtPipeline.cs
@@ -199,6 +199,19 @@ public static class BerichtPipeline
                 }
                 return JsonConvert.SerializeObject(new { error = "Onvoldoende gegevens voor herplanverzoek (team en datum nodig)" });
 
+            case VerzoekType.TeamContactOpvragen:
+                if (!string.IsNullOrWhiteSpace(classificatie.TeamNaam))
+                {
+                    var contact = await PlannerDataAccess.GetTeamleiderContactAsync(classificatie.TeamNaam);
+                    return JsonConvert.SerializeObject(new
+                    {
+                        teamContactOpgevraagd = true,
+                        teamNaam = classificatie.TeamNaam,
+                        coachGevonden = contact != null
+                    });
+                }
+                return JsonConvert.SerializeObject(new { teamContactOpgevraagd = true, teamNaam = (string?)null, coachGevonden = false });
+
             case VerzoekType.Bevestiging:
                 return JsonConvert.SerializeObject(new { status = "Bevestiging ontvangen", opmerking = "Bevestigingen vereisen handmatige afhandeling door de coördinator" });
 
@@ -274,6 +287,9 @@ public static class BerichtPipeline
                 var herplanOpties = herplanData["herplanOpties"]?.ToObject<HerplanCheckResponse>();
                 return BerichtResponseGenerator.BouwHerplanAntwoord(
                     wedstrijd, herplanOpties, classificatie, bericht);
+
+            case VerzoekType.TeamContactOpvragen:
+                return BerichtResponseGenerator.BouwTeamContactAutoReply(classificatie, bericht);
 
             case VerzoekType.Bevestiging:
                 return BerichtResponseGenerator.BouwBevestigingAntwoord(bericht, classificatie);

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,7 +9,8 @@ Twee beveiligingsniveaus:
 | Niveau | Sleutel | Wie | Endpoints |
 |--------|---------|-----|-----------|
 | **Function** | Function key (`?code=`) | Automate, integraties | Alle planner endpoints |
-| **Admin** | Master key (`?code=`) | Alleen coördinator | sync-matches, populate-sunset |
+| **Admin** | Easy Auth Bearer + admin-rol | Alleen coördinator | Alle `/api/beheer/*` endpoints |
+| **Admin+User** | Easy Auth Bearer + admin- of user-rol | Coördinator + club-gebruikers | `/api/beheer/teambegeleiding/*` |
 
 Zonder geldige sleutel → 401 Unauthorized (kost niets, geen verwerking).
 
@@ -27,6 +28,10 @@ Zonder geldige sleutel → 401 Unauthorized (kost niets, geen verwerking).
 | `POST` | `/planner/herplan-check` | Function | Herplan-alternatieven simuleren |
 | `POST` | `/planner/herplan-bevestig` | Function | Herplanverzoek registreren |
 | `POST` | `/planner/optimaliseer` | Easy Auth (admin) | Planning optimaliseren (HTML/email/JSON) |
+| `GET` | `/beheer/teambegeleiding` | **Admin+User** | Alle teams met begeleiding in database |
+| `GET` | `/beheer/teambegeleiding/{team}` | **Admin+User** | Begeleiders van team (naam + rol, nooit e-mail) |
+| `POST` | `/beheer/teambegeleiding/doorsturen` | **Admin+User** | Vraag doorsturen naar coach (BCC coördinator) |
+| `GET/POST/PUT/DELETE` | `/beheer/speeltijden` en `/{leeftijd}` | **Admin** | Speeltijden per leeftijdscategorie beheren |
 
 ---
 

--- a/docs/EMAIL-VERWERKING.md
+++ b/docs/EMAIL-VERWERKING.md
@@ -22,8 +22,9 @@ Inkomend email (ongelezen in Graph-mailbox)
         │
         ├─ BuitenScope ──→ label "Geen AI antwoord" + mark as read → STOP
         │
-        ├─ BeschikbaarheidCheck ──→ PlannerService → template (zie §2)
+        ├─ BeschikbaarheidCheck  ──→ PlannerService → template (zie §2)
         ├─ HerplanVerzoek        ──→ PlannerService → template (zie §2)
+        ├─ TeamContactOpvragen   ──→ GetTeamleiderContactAsync → StuurTeamContactDoorAsync (BCC coördinator, Reply-To afzender) → auto-reply "doorgestuurd"
         └─ Bevestiging           ──→ template "Bedankt voor je bevestiging"
                 │
                 ▼
@@ -356,6 +357,7 @@ Met vriendelijke groet, ...
 | J | Bevestiging | Afzender bevestigt eerder voorstel | "Bedankt voor je bevestiging" |
 | K | (alle) | Technische fout tijdens verwerking | "Fout opgetreden, coördinator op hoogte" |
 | L | BeschikbaarheidCheck | Geen teamnaam én geen leeftijdscategorie | Vraag om ontbrekende informatie |
+| N | TeamContactOpvragen | "Wie is de trainer/coach van [team]?" | Auto-reply "uw vraag is doorgestuurd" + coach ontvangt vraag (BCC coördinator, Reply-To = afzender) |
 | — | BuitenScope | Email gaat niet over planning | Geen antwoord — label "Geen AI antwoord" |
 
 ---

--- a/docs/v2-admin-handleiding.md
+++ b/docs/v2-admin-handleiding.md
@@ -395,3 +395,51 @@ Het script doorloopt:
 Exitcode 0 = alles groen. Exitcode 1 = minimaal één check gefaald.
 
 **Wanneer uitvoeren:** Altijd vóór een commit of oplevering. `dotnet build` slaagt ≠ werkt.
+
+---
+
+## 10. Teambegeleiding-pagina (`/teambegeleiding`)
+
+De pagina `/teambegeleiding` stelt beheerders én gebruikers met de **user-rol** in staat team-contactgegevens op te zoeken en vragen door te sturen aan de begeleiding.
+
+### Functionaliteit
+
+1. **Team selecteren** — dropdown met alle teams waarvoor begeleiding beschikbaar is (uit `avg.Teambegeleiding`)
+2. **Begeleiders inzien** — kaarten per begeleider met naam en teamrol. E-mailadressen en telefoonnummers worden **nooit getoond** (AVG art. 6.1.f)
+3. **Vraag doorsturen** — klik "Stel een vraag" → vul Onderwerp (optioneel) en Bericht in → "Versturen"
+   - To: coach (opgezoekt server-side uit `avg.Teambegeleiding`)
+   - Reply-To: e-mailadres van de aanvrager (automatisch uit Entra ID)
+   - BCC: coördinator (uit `dbo.AppSettings.coordinatorEmail`)
+   - Coach antwoordt rechtstreeks naar aanvrager — aanvrager ziet nooit het coach-adres
+
+### API-endpoints
+
+| Endpoint | Beschrijving |
+|---|---|
+| `GET /api/beheer/teambegeleiding` | Alle teams met begeleiding |
+| `GET /api/beheer/teambegeleiding/{team}` | Begeleiders van team (naam + rol, nooit contactgegevens) |
+| `POST /api/beheer/teambegeleiding/doorsturen` | Doorsturen van vraag naar coach |
+
+Auth: `RequireAuthenticated()` — toegankelijk voor zowel admin- als user-rol.
+
+---
+
+## 11. Speeltijden-pagina (`/instellingen/speeltijden`)
+
+De pagina `/instellingen/speeltijden` (alleen admin-rol) beheert de speeltijden per leeftijdscategorie. De planner gebruikt uitsluitend `dbo.Speeltijden.WedstrijdTotaal` voor de berekening van veldblokkeertijden — de Sportlink API-waarde `Duration` wordt niet meer gebruikt.
+
+Het veld **Totaal (incl. rust)** is de totale veldblokkeertijd die de planner direct gebruikt. Rust wordt **niet** apart opgeteld in code — WedstrijdTotaal = speeltijd + rust + buffer.
+
+### Categorieregels
+- Categorie `1-99` = Senioren mannen; `VR` = Senioren vrouwen → beide 115 minuten
+- MO-categorieën hebben dezelfde WedstrijdTotaal als de equivalente JO-categorie
+- Ontbrekende categorie → foutmelding met verwijzing naar deze pagina
+
+### API-endpoints
+
+| Endpoint | Beschrijving |
+|---|---|
+| `GET /api/beheer/speeltijden` | Alle speeltijden voor de club |
+| `POST /api/beheer/speeltijden` | Nieuwe speeltijd toevoegen |
+| `PUT /api/beheer/speeltijden/{leeftijd}` | Speeltijd bijwerken |
+| `DELETE /api/beheer/speeltijden/{leeftijd}` | Speeltijd verwijderen |


### PR DESCRIPTION
## Summary

- Nieuwe Admin GUI-pagina `/teambegeleiding` (admin + user-rol): team selecteren → begeleiders zien (naam + rol, nooit e-mailadres) → vraag doorsturen naar coach via BCC-patroon
- Drie nieuwe API-endpoints: `GET /api/beheer/teambegeleiding`, `/{team}`, `POST /api/beheer/teambegeleiding/doorsturen`
- Nieuw `EasyAuthHelper.RequireAuthenticated()` voor admin- én user-rol toegang
- E-mail pipeline: AI classificeert `team_contact_opvragen` → `TeamContactOpvragen` intent → auto-reply + coach-forward (Reply-To = afzender, BCC coördinator) — AVG-compliant
- `EmailGraphService.StuurTeamContactDoorAsync()` voor BCC-doorstuurpatroon
- Docs bijgewerkt: `docs/API.md`, `docs/EMAIL-VERWERKING.md`, `docs/v2-admin-handleiding.md`, `CLAUDE.md`

## AVG-check

- `avg.Teambegeleiding.Emailadres` nooit in API-response → alleen server-side SMTP-bestemming
- Log-statements bevatten geen namen of e-mailadressen
- BCC-patroon: aanvrager ziet nooit het e-mailadres van de coach
- `GetCallerEmail()` in EasyAuthHelper is server-side only, nooit in response-body

## Test plan

- [ ] `dotnet build` groen (beide projecten)
- [ ] `Test-App.ps1` exit 0 (31 checks)
- [ ] `GET /api/beheer/teambegeleiding/{team}` geeft `[{naam, teamrol}]`, geen emailadres
- [ ] `POST /api/beheer/teambegeleiding/doorsturen` stuurt e-mail naar coach, BCC coördinator
- [ ] Blazor `/teambegeleiding` laadt teams, toont begeleiders, doorsturen werkt
- [ ] User-rol (niet alleen admin) heeft toegang
- [ ] E-mail "wie is de trainer van JO13-4?" classificeert als `TeamContactOpvragen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)