### PR TITLE
fix: kalender nl-NL, team-dropdowns, contactgegevens, planner no-op, email templates (#300 #285 #288 #289 #299 #301 #287)

### DIFF
--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -148,6 +148,8 @@ public class TeambegeleidingItem
 {
     public string Naam { get; set; } = "";
     public string Teamrol { get; set; } = "";
+    public string? Emailadres { get; set; }
+    public string? Telefoonnummer { get; set; }
 }
 
 public class DoorsturenRequest

--- a/BlazorAdmin/Pages/EmailTemplates.razor
+++ b/BlazorAdmin/Pages/EmailTemplates.razor
@@ -89,9 +89,21 @@ else
                 {
                     <select class="form-select" value="@editing.TemplateKey" @onchange="OnTemplateKeyChange">
                         <option value="">— kies een type —</option>
-                        <option value="beschikbaarheid_check">beschikbaarheid_check — vraag over veldbeschikbaarheid</option>
-                        <option value="herplan_verzoek">herplan_verzoek — verzoek om wedstrijd te verplaatsen</option>
-                        <option value="bevestiging">bevestiging — bevestiging van een eerder voorstel</option>
+                        <optgroup label="Beschikbaarheid">
+                            <option value="beschikbaarheid_check">beschikbaarheid_check — antwoord op veld-/tijdvraag</option>
+                        </optgroup>
+                        <optgroup label="Herplanning">
+                            <option value="herplan_verzoek">herplan_verzoek — antwoord op herplanningsverzoek</option>
+                        </optgroup>
+                        <optgroup label="Bevestiging">
+                            <option value="bevestiging">bevestiging — bevestiging van eerder voorstel</option>
+                        </optgroup>
+                        <optgroup label="Teambegeleiding">
+                            <option value="team_contact_opvragen">team_contact_opvragen — auto-reply na doorsturen begeleiding</option>
+                        </optgroup>
+                        <optgroup label="Overig">
+                            <option value="buiten_scope">buiten_scope — antwoord op niet-herkend verzoek</option>
+                        </optgroup>
                     </select>
                     <small class="form-text text-muted">
                         Kies de template die de code zal gebruiken als override. Lege DB-rij = hardcoded default blijft actief.
@@ -220,6 +232,14 @@ else
                 onderwerp = "Bevestiging wedstrijd {{datum}} — {{team}} vs {{tegenstander}}";
                 body = "Beste {{aanhef}},\n\nHierbij bevestigen wij de wedstrijd op {{datum}} om {{aanvangstijd}}.\n\nThuisteam: {{team}}\nTegenstander: {{tegenstander}}\n\nTot dan!";
                 break;
+            case "team_contact_opvragen":
+                onderwerp = "Uw vraag over de begeleiding van {{team}}";
+                body = "Beste {{voornaam}},\n\nUw vraag over de begeleiding van {{team}} is doorgestuurd. De begeleider neemt rechtstreeks contact met u op.";
+                break;
+            case "buiten_scope":
+                onderwerp = "Uw bericht ontvangen";
+                body = "Beste {{voornaam}},\n\nBedankt voor uw bericht. Uw vraag valt buiten het bereik van de automatische verwerking. Neem contact op met de club voor verdere hulp.";
+                break;
         }
 
         if (!string.IsNullOrWhiteSpace(onderwerp)) editing.Onderwerp = onderwerp;
@@ -251,9 +271,11 @@ else
 
     private static (string label, string css) GetCategorie(string key) => key switch
     {
-        var k when k.StartsWith("beschikbaarheid") => ("BeschikbaarheidCheck", "bg-info text-dark"),
-        var k when k.StartsWith("herplan")         => ("HerplanVerzoek", "bg-warning text-dark"),
+        var k when k.StartsWith("beschikbaarheid") => ("Beschikbaarheid", "bg-info text-dark"),
+        var k when k.StartsWith("herplan")         => ("Herplanning", "bg-warning text-dark"),
         var k when k.StartsWith("bevestig")        => ("Bevestiging", "bg-success"),
+        var k when k.StartsWith("team_contact")    => ("Teambegeleiding", "bg-primary"),
+        var k when k.StartsWith("buiten_scope")    => ("Buiten scope", "bg-secondary"),
         _                                           => ("Overig", "bg-secondary"),
     };
 }

--- a/BlazorAdmin/Pages/Instellingen.razor
+++ b/BlazorAdmin/Pages/Instellingen.razor
@@ -22,16 +22,14 @@ else
                 <label class="form-label">Clubnaam</label>
                 <input class="form-control" value="@settings!.ClubName" disabled />
                 <small class="form-text text-muted">
-                    Staat in AI-systeem-prompt en e-mailtemplates. Wijzigen via SQL:
-                    <code>UPDATE [dbo].[AppSettings] SET [ClubName] = '...'</code>
+                    Staat in AI-systeem-prompt en e-mailtemplates. Contacteer de systeembeheerder om deze waarde te wijzigen.
                 </small>
             </div>
             <div class="col-md-6 mb-3">
                 <label class="form-label">ClubCode</label>
                 <input class="form-control" value="@settings.ClubCode" disabled />
                 <small class="form-text text-muted">
-                    Unieke identifier voor multi-club ondersteuning — staat als filter in elke database-query.
-                    Wijzigen via SQL: <code>UPDATE [dbo].[AppSettings] SET [ClubCode] = '...'</code>
+                    Unieke identifier voor multi-club ondersteuning — staat als filter in elke database-query. Contacteer de systeembeheerder om deze waarde te wijzigen.
                 </small>
             </div>
         </div>

--- a/BlazorAdmin/Pages/Teambegeleiding.razor
+++ b/BlazorAdmin/Pages/Teambegeleiding.razor
@@ -1,14 +1,14 @@
 @page "/teambegeleiding"
 @inject AdminApiClient Api
+@inject IJSRuntime JS
 @using BlazorAdmin.Models
 
 <PageTitle>Teambegeleiding — Admin</PageTitle>
 
 <h1>Teambegeleiding</h1>
 <p class="text-muted">
-    Selecteer een team om de begeleiding op te zoeken. U kunt een vraag doorsturen —
-    de begeleider neemt rechtstreeks contact met u op.
-    <strong>Contactgegevens worden niet gedeeld conform AVG.</strong>
+    Selecteer een team om de begeleiding op te zoeken. U kunt ook een vraag doorsturen —
+    de begeleider antwoordt rechtstreeks op uw e-mailadres.
 </p>
 
 @if (_loadingTeams)
@@ -42,19 +42,46 @@ else
 else if (_selectedTeam != null && _begeleiders.Count > 0)
 {
     <h3>Begeleiding van @_selectedTeam</h3>
-    <div class="row g-3 mb-4">
+    <div class="row g-3 mb-3">
         @foreach (var b in _begeleiders)
         {
             <div class="col-md-3">
                 <div class="card h-100">
                     <div class="card-body">
                         <h5 class="card-title">@b.Naam</h5>
-                        <span class="badge bg-secondary">@b.Teamrol</span>
+                        <span class="badge bg-secondary mb-2">@b.Teamrol</span>
+                        @if (!string.IsNullOrWhiteSpace(b.Emailadres))
+                        {
+                            <div class="small mt-1">
+                                <a href="mailto:@b.Emailadres">@b.Emailadres</a>
+                            </div>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(b.Telefoonnummer))
+                        {
+                            <div class="small mt-1 text-muted">
+                                <a href="tel:@b.Telefoonnummer">@b.Telefoonnummer</a>
+                            </div>
+                        }
                     </div>
                 </div>
             </div>
         }
     </div>
+
+    @* Outlook-kopieerregel (#299) *@
+    @if (!string.IsNullOrEmpty(OutlookRegel))
+    {
+        <div class="mb-4">
+            <label class="form-label text-muted small">Kopieer naar Outlook (Aan-veld)</label>
+            <div class="input-group">
+                <input class="form-control form-control-sm font-monospace" value="@OutlookRegel" readonly />
+                <button class="btn btn-outline-secondary btn-sm" @onclick="() => KopieerNaarKlembordAsync(OutlookRegel)"
+                        title="Kopieer naar klembord">
+                    @(_gekopieerd ? "✓ Gekopieerd" : "Kopieer")
+                </button>
+            </div>
+        </div>
+    }
 
     @if (!_vraagFormulierZichtbaar)
     {
@@ -67,7 +94,6 @@ else if (_selectedTeam != null && _begeleiders.Count > 0)
             <div class="card-body">
                 <p class="text-muted small">
                     Uw vraag wordt doorgestuurd naar de begeleiding. De begeleider antwoordt rechtstreeks op uw e-mailadres.
-                    Hun e-mailadres wordt niet gedeeld.
                 </p>
                 <div class="mb-3">
                     <label class="form-label">Onderwerp</label>
@@ -113,6 +139,11 @@ else if (_selectedTeam != null && !_loadingBegeleiders)
     private bool _doorsturenBezig;
     private string? _doorsturenError;
     private string? _doorsturenSuccess;
+    private bool _gekopieerd;
+
+    private string OutlookRegel => string.Join("; ", _begeleiders
+        .Where(b => !string.IsNullOrWhiteSpace(b.Emailadres))
+        .Select(b => $"\"{b.Naam}\" <{b.Emailadres}>"));
 
     protected override async Task OnInitializedAsync()
     {
@@ -131,6 +162,7 @@ else if (_selectedTeam != null && !_loadingBegeleiders)
         _vraagFormulierZichtbaar = false;
         _doorsturenSuccess = null;
         _doorsturenError = null;
+        _gekopieerd = false;
 
         if (string.IsNullOrEmpty(_selectedTeam)) return;
 
@@ -139,6 +171,16 @@ else if (_selectedTeam != null && !_loadingBegeleiders)
         if (result.Success)
             _begeleiders = result.Data ?? new();
         _loadingBegeleiders = false;
+    }
+
+    private async Task KopieerNaarKlembordAsync(string tekst)
+    {
+        await JS.InvokeVoidAsync("blazorHelpers.copyToClipboard", tekst);
+        _gekopieerd = true;
+        StateHasChanged();
+        await Task.Delay(2000);
+        _gekopieerd = false;
+        StateHasChanged();
     }
 
     private void ToonVraagFormulier()
@@ -173,9 +215,7 @@ else if (_selectedTeam != null && !_loadingBegeleiders)
 
         if (result.Success)
         {
-            _doorsturenSuccess = $"Uw vraag over de begeleiding van {_selectedTeam} is doorgestuurd. " +
-                                  "De begeleider neemt rechtstreeks contact met u op. " +
-                                  "Contactgegevens worden niet gedeeld conform AVG.";
+            _doorsturenSuccess = $"Uw vraag over de begeleiding van {_selectedTeam} is doorgestuurd. De begeleider neemt rechtstreeks contact met u op.";
             _vraagFormulierZichtbaar = false;
         }
         else

--- a/BlazorAdmin/Pages/Voorkeurstijden.razor
+++ b/BlazorAdmin/Pages/Voorkeurstijden.razor
@@ -67,7 +67,13 @@ else
             <div class="row">
                 <div class="col-md-4 mb-3">
                     <label class="form-label">Team</label>
-                    <input class="form-control" @bind="editing.TeamNaam" />
+                    <select class="form-select" @bind="editing.TeamNaam">
+                        <option value="">— Kies een team —</option>
+                        @foreach (var t in teams)
+                        {
+                            <option value="@t">@t</option>
+                        }
+                    </select>
                 </div>
                 <div class="col-md-3 mb-3">
                     <label class="form-label">Dag</label>
@@ -122,33 +128,28 @@ else
                 <th>Regeltype</th>
                 <th>Waarde</th>
                 <th>Opmerking</th>
-                <th>Actief</th>
                 <th></th>
             </tr>
         </thead>
         <tbody>
-            @foreach (var r in teamRegels)
+            @foreach (var r in ActieveTeamRegels)
             {
-                <tr class="@(!r.Actief ? "text-muted" : "")">
+                <tr>
                     <td>@r.TeamNaam</td>
                     <td>@RegelTypeNederlands(r.RegelType)</td>
                     <td>@RegelWaarde(r)</td>
                     <td>@r.Opmerking</td>
-                    <td>@(r.Actief ? "ja" : "nee")</td>
                     <td>
                         <button class="btn btn-sm btn-primary" @onclick="() => EditRegel(r)">Bewerken</button>
-                        @if (r.Actief)
-                        {
-                            <button class="btn btn-sm btn-outline-danger ms-1" @onclick="() => DeleteRegelAsync(r.Id)">
-                                Verwijderen
-                            </button>
-                        }
+                        <button class="btn btn-sm btn-outline-danger ms-1" @onclick="() => DeleteRegelAsync(r.Id)">
+                            Verwijderen
+                        </button>
                     </td>
                 </tr>
             }
-            @if (teamRegels.Count == 0)
+            @if (ActieveTeamRegels.Count == 0)
             {
-                <tr><td colspan="6" class="text-muted">Geen teamregels gevonden.</td></tr>
+                <tr><td colspan="5" class="text-muted">Geen teamregels gevonden.</td></tr>
             }
         </tbody>
     </table>
@@ -161,7 +162,13 @@ else
             <div class="row">
                 <div class="col-md-4 mb-3">
                     <label class="form-label">Team</label>
-                    <input class="form-control" @bind="editingRegel.TeamNaam" placeholder="bijv. VRC 1" />
+                    <select class="form-select" @bind="editingRegel.TeamNaam">
+                        <option value="">— Kies een team —</option>
+                        @foreach (var t in teams)
+                        {
+                            <option value="@t">@t</option>
+                        }
+                    </select>
                 </div>
                 <div class="col-md-4 mb-3">
                     <label class="form-label">Regeltype</label>
@@ -229,6 +236,7 @@ else
 @code {
     private List<VoorkeurTijdDto> items = new();
     private List<TeamRegelDto> teamRegels = new();
+    private List<string> teams = new();
     private VoorkeurTijdDto? editing;
     private TeamRegelDto? editingRegel;
     private bool isNew;
@@ -243,11 +251,16 @@ else
             ? items
             : items.Where(i => i.TeamNaam.Contains(filterTeam, StringComparison.OrdinalIgnoreCase)).ToList();
 
+    // #288: alleen actieve teamregels tonen in de tabel
+    private List<TeamRegelDto> ActieveTeamRegels => teamRegels.Where(r => r.Actief).ToList();
+
     protected override async Task OnInitializedAsync() => await LoadAsync();
 
     private async Task LoadAsync()
     {
         loading = true;
+        var teamsResult = await Api.GetTeamsAsync();
+        teams = teamsResult.Success ? teamsResult.Data ?? new() : new();
         var r = await Api.GetVoorkeurTijdenAsync();
         items = r.Success ? r.Data ?? new() : new();
         var regelsResult = await Api.GetTeamRegelsAsync();

--- a/BlazorAdmin/Program.cs
+++ b/BlazorAdmin/Program.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
@@ -6,6 +7,11 @@ using BlazorAdmin;
 using BlazorAdmin.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+// Kalenderweek begint op maandag, datumnotatie NL (issue #300)
+var nlCulture = new CultureInfo("nl-NL");
+CultureInfo.DefaultThreadCurrentCulture = nlCulture;
+CultureInfo.DefaultThreadCurrentUICulture = nlCulture;
 builder.RootComponents.Add<App>("#app");
 builder.RootComponents.Add<HeadOutlet>("head::after");
 

--- a/BlazorAdmin/Services/AdminApiClient.cs
+++ b/BlazorAdmin/Services/AdminApiClient.cs
@@ -46,6 +46,11 @@ public class AdminApiClient
     public async Task<ApiResult<object>> ResetTemplateAsync(string key)
         => await PostAsync<object>($"api/beheer/templates/{Uri.EscapeDataString(key)}/reset", new { });
 
+    // ── Teams ──
+
+    public async Task<ApiResult<List<string>>> GetTeamsAsync()
+        => await GetAsync<List<string>>("api/beheer/teams");
+
     // ── Voorkeurstijden ──
 
     public async Task<ApiResult<List<VoorkeurTijdDto>>> GetVoorkeurTijdenAsync(string? team = null)

--- a/BlazorAdmin/wwwroot/index.html
+++ b/BlazorAdmin/wwwroot/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="nl">
 
 <head>
     <meta charset="utf-8" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+
+- **E-mailtemplates koppeling aan pipeline (#287):** `BouwTemplateAntwoord` raadpleegt nu de database vóór elke hardcoded fallback via `EmailTemplateService.GetTemplateAsync`. Als een beheerder een template heeft aangemaakt voor `beschikbaarheid_check`, `herplan_verzoek`, `bevestiging`, `team_contact_opvragen` of `buiten_scope`, wordt die DB-versie gebruikt in plaats van de hardcoded standaard. Dropdown in de Admin GUI uitgebreid met alle actieve template-keys, ingedeeld per categorie.
+
+### Fixed
+
+- **Kalender weekstart op maandag (#300):** `<html lang="en">` was de oorzaak van zondag-als-eerste-dag in alle datumkiezers en kalenders. Gewijzigd naar `lang="nl"` + `CultureInfo("nl-NL")` in `Program.cs`.
+- **Planner: no-op suggesties onderdrukt (#301):** De planner toonde verplaatsingen die de eindtijd niet verbeterden (bijv. MO15-2 eerder naar veld 5 terwijl de dag toch eindigt op 20:20 door een andere wedstrijd). Na het genereren van suggesties wordt nu de gesimuleerde nieuwe eindtijd vergeleken met de huidige; zijn er geen verbeterd → "de huidige planning is al optimaal".
+- **Teambegeleiding: e-mail en telefoon zichtbaar op kaartje (#299):** Beheerders zien nu het e-mailadres en telefoonnummer van elke begeleider op de `/teambegeleiding`-pagina. Klikbare `mailto:` en `tel:`-links. Onder de kaartjes staat een kopieerknop voor de Outlook-ontvangersregel (`"Naam" <email>; ...`).
+- **Voorkeurstijden: team-dropdown (#289):** De vrije tekstinvoer voor het teamveld in het voorkeur- en teamregelformulier is vervangen door een dropdown gevuld vanuit `GET /api/beheer/teams` (`his.teams`). Voorkomt typfouten en inconsistenties.
+- **Voorkeurstijden: inactieve teamregels verborgen (#288):** Inactieve teamregels worden niet meer getoond in de lijst — alleen actieve regels zijn zichtbaar en bewerkbaar.
+- **Instellingen: SQL-instructies verwijderd (#285):** De rode "Wijzigen via SQL: UPDATE ..." helpteksten onder ClubNaam en ClubCode zijn verwijderd en vervangen door "Contacteer de systeembeheerder om deze waarde te wijzigen."
+
 ---
 
 ## [2.3.0] — 2026-05-24

--- a/FunctionApp/Admin/AdminTeambegeleidingFunction.cs
+++ b/FunctionApp/Admin/AdminTeambegeleidingFunction.cs
@@ -11,9 +11,10 @@ using SportlinkFunction.Email;
 namespace SportlinkFunction.Admin;
 
 /// <summary>
-/// Admin API voor teambegeleiding (#168).
-/// AVG: Emailadres en Telefoonnummer worden NOOIT in een API-response teruggestuurd.
-/// Emailadres wordt uitsluitend server-side gebruikt als SMTP-bestemming.
+/// Admin API voor teambegeleiding (#168, #299).
+/// /teambegeleiding/{team} geeft Naam, Teamrol, Emailadres en Telefoonnummer terug
+/// aan de ingelogde beheerder (admin/user-rol) — pagina is afgeschermd achter Entra ID Easy Auth.
+/// E-mail doorstuur-pipeline gebruikt Emailadres uitsluitend server-side; nooit in auto-reply body.
 /// </summary>
 public static class AdminTeambegeleidingFunction
 {
@@ -53,7 +54,7 @@ public static class AdminTeambegeleidingFunction
 
     /// <summary>
     /// GET /api/beheer/teambegeleiding/{team} — begeleiders voor een specifiek team.
-    /// Response bevat alleen Naam en Teamrol — GEEN e-mailadres of telefoonnummer.
+    /// Response bevat Naam, Teamrol, Emailadres en Telefoonnummer — alleen voor ingelogde beheerders (#299).
     /// </summary>
     [Function("AdminTeambegeleidingGet")]
     public static async Task<IActionResult> GetBegeleiders(
@@ -72,7 +73,7 @@ public static class AdminTeambegeleidingFunction
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
             using var command = new SqlCommand(@"
-                SELECT [Naam], [Teamrol]
+                SELECT [Naam], [Teamrol], [Emailadres], [Telefoonnummer]
                 FROM [avg].[Teambegeleiding]
                 WHERE [Team] = @team
                 ORDER BY
@@ -90,7 +91,9 @@ public static class AdminTeambegeleidingFunction
                 list.Add(new
                 {
                     Naam = reader.IsDBNull(0) ? "" : reader.GetString(0),
-                    Teamrol = reader.IsDBNull(1) ? "" : reader.GetString(1)
+                    Teamrol = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                    Emailadres = reader.IsDBNull(2) ? null : reader.GetString(2),
+                    Telefoonnummer = reader.IsDBNull(3) ? null : reader.GetString(3)
                 });
             }
             return new OkObjectResult(list);

--- a/FunctionApp/Admin/EmailTestFunction.cs
+++ b/FunctionApp/Admin/EmailTestFunction.cs
@@ -81,7 +81,7 @@ public static class EmailTestFunction
 
             BerichtPipeline.ValideerDagDatum(classificatie, body, onderwerp);
             var plannerResponseJson = await BerichtPipeline.VerwerkMetPlannerAsync(classificatie, fakeEmail, log);
-            var (voorbeeldOnderwerp, voorbeeldBody) = BerichtPipeline.BouwTemplateAntwoord(classificatie, plannerResponseJson, fakeEmail);
+            var (voorbeeldOnderwerp, voorbeeldBody) = await BerichtPipeline.BouwTemplateAntwoord(classificatie, plannerResponseJson, fakeEmail, log);
 
             return new OkObjectResult(new
             {

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -227,8 +227,8 @@ public class EmailProcessorFunction
         await UpdatePlannerResponseAsync(verwerkingId, plannerResponseJson);
         await UpdateStatusAsync(verwerkingId, EmailStatus.Verwerkt, null);
 
-        var (onderwerp, antwoordBody) = BerichtPipeline.BouwTemplateAntwoord(
-            classificatie, plannerResponseJson, email);
+        var (onderwerp, antwoordBody) = await BerichtPipeline.BouwTemplateAntwoord(
+            classificatie, plannerResponseJson, email, log);
 
         var reviewMode = Environment.GetEnvironmentVariable("EmailReviewMode");
         var ontvanger = string.Equals(reviewMode, "true", StringComparison.OrdinalIgnoreCase)

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -871,6 +871,32 @@ namespace SportlinkFunction.Planner
 
             suggesties = VerdeelExtraBuffer(suggesties, bezettingen, availableFields, velden, vasteWedstrijden, allTeamRules, gewensteEindtijd);
 
+            // Check 3: suggesties verbeteren de eindtijd niet — no-op onderdrukken (#301)
+            // Bereken de nieuwe eindtijd na toepassing van de suggesties. Als die niet eerder is
+            // dan de huidige eindtijd, zijn de suggesties zinloos en worden ze onderdrukt.
+            if (suggesties.Count > 0 && bezettingen.Count > 0)
+            {
+                var huidigeMax = bezettingen.Max(b => b.EindTijd);
+                var nieuweMax = bezettingen.Select(b =>
+                {
+                    var sug = suggesties.FirstOrDefault(s => s.Wedstrijd == b.Wedstrijd?.Trim());
+                    if (sug != null && TimeOnly.TryParse(sug.NieuweTijd, out var nieuwStart))
+                        return TimeOnly.FromTimeSpan(nieuwStart.ToTimeSpan() + (b.EindTijd.ToTimeSpan() - b.AanvangsTijd.ToTimeSpan()));
+                    return b.EindTijd;
+                }).Max();
+
+                if (nieuweMax >= huidigeMax)
+                {
+                    response.VoldoendeRuimte = true;
+                    response.VoldoendeRuimteMelding =
+                        $"Geen optimalisatie nodig op {date.ToString("dddd d MMMM", nl)}: " +
+                        "de huidige planning is al optimaal — verplaatsingen leveren geen eerdere eindtijd op.";
+                    response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(
+                        date, bezettingen, new List<OptimalisatieSuggestie>(), velden, doel);
+                    return response;
+                }
+            }
+
             response.Suggesties = suggesties;
             response.AantalVerplaatsingen = suggesties.Count;
             response.AantalVanVeld5Verplaatst = suggesties.Count(s => s.HuidigVeldNummer == 5);

--- a/FunctionApp/Processing/BerichtPipeline.cs
+++ b/FunctionApp/Processing/BerichtPipeline.cs
@@ -222,11 +222,14 @@ public static class BerichtPipeline
 
     /// <summary>
     /// Bouwt het antwoord via templates op basis van het classificatietype en PlannerService response.
+    /// Probeert eerst een DB-override op te halen via EmailTemplateService (#287).
+    /// Valt terug op hardcoded defaults als er geen override is.
     /// </summary>
-    public static (string onderwerp, string body) BouwTemplateAntwoord(
+    public static async Task<(string onderwerp, string body)> BouwTemplateAntwoord(
         BerichtClassificatie classificatie,
         string plannerResponseJson,
-        InkomendBericht bericht)
+        InkomendBericht bericht,
+        ILogger? log = null)
     {
         switch (classificatie.Type)
         {
@@ -260,6 +263,11 @@ public static class BerichtPipeline
                     return BerichtResponseGenerator.BouwMultiDatumBeschikbaarheidAntwoord(
                         resultaten, classificatie, bericht);
                 }
+
+                var beschikbaarheidTemplate = await Email.EmailTemplateService.GetTemplateAsync("beschikbaarheid_check", log);
+                if (beschikbaarheidTemplate != null)
+                    return BerichtResponseGenerator.BouwAangepasteAntwoord(beschikbaarheidTemplate, classificatie, bericht);
+
                 var checkResponse = JsonConvert.DeserializeObject<CheckAvailabilityResponse>(plannerResponseJson);
                 return BerichtResponseGenerator.BouwBeschikbaarheidAntwoord(
                     checkResponse ?? new CheckAvailabilityResponse(), classificatie, bericht);
@@ -284,17 +292,30 @@ public static class BerichtPipeline
                         wedstrijd, gewensteDatum, beschikbaarheid, classificatie, bericht);
                 }
 
+                var herplanTemplate = await Email.EmailTemplateService.GetTemplateAsync("herplan_verzoek", log);
+                if (herplanTemplate != null)
+                    return BerichtResponseGenerator.BouwAangepasteAntwoord(herplanTemplate, classificatie, bericht);
+
                 var herplanOpties = herplanData["herplanOpties"]?.ToObject<HerplanCheckResponse>();
                 return BerichtResponseGenerator.BouwHerplanAntwoord(
                     wedstrijd, herplanOpties, classificatie, bericht);
 
             case VerzoekType.TeamContactOpvragen:
+                var teamContactTemplate = await Email.EmailTemplateService.GetTemplateAsync("team_contact_opvragen", log);
+                if (teamContactTemplate != null)
+                    return BerichtResponseGenerator.BouwAangepasteAntwoord(teamContactTemplate, classificatie, bericht);
                 return BerichtResponseGenerator.BouwTeamContactAutoReply(classificatie, bericht);
 
             case VerzoekType.Bevestiging:
+                var bevestigingTemplate = await Email.EmailTemplateService.GetTemplateAsync("bevestiging", log);
+                if (bevestigingTemplate != null)
+                    return BerichtResponseGenerator.BouwAangepasteAntwoord(bevestigingTemplate, classificatie, bericht);
                 return BerichtResponseGenerator.BouwBevestigingAntwoord(bericht, classificatie);
 
             default:
+                var buitenScopeTemplate = await Email.EmailTemplateService.GetTemplateAsync("buiten_scope", log);
+                if (buitenScopeTemplate != null)
+                    return BerichtResponseGenerator.BouwAangepasteAntwoord(buitenScopeTemplate, classificatie, bericht);
                 return BerichtResponseGenerator.BouwBuitenScopeAntwoord(bericht);
         }
     }


### PR DESCRIPTION
## Samenvatting

Batch van 7 UI- en pipeline-fixes uit de v2.3 backlog.

### Wijzigingen

- **#300** — BlazorAdmin kalender begint op maandag: `lang="nl"` in `index.html` + `nl-NL` culture in `Program.cs`
- **#285** — SQL-hints verwijderd uit Instellingen-pagina (ClubNaam + ClubCode); vervangen door "Contacteer de systeembeheerder"
- **#288** — Teamregels-tabel toont nu alleen actieve regels (`Actief=true` filter)
- **#289** — Voorkeurstijden + teamregels: team-dropdown gevuld via `/api/beheer/teams` i.p.v. vrij tekstveld
- **#299** — Teambegeleiding GUI toont email + telefoonnummer op begeleiders-kaarten; Outlook-kopierregel (`"Naam" <email>`) met klembordknop toegevoegd
- **#301** — Planner: no-op onderdrukken wanneer gegenereerde suggesties de eindtijd niet verbeteren
- **#287** — Email template pipeline: `BouwTemplateAntwoord` is nu async en roept `GetTemplateAsync` aan; DB-overrides worden daadwerkelijk gebruikt; `EmailTemplates.razor` dropdown aangevuld met alle 5 template-keys + prefill-defaults

## Testplan

- [ ] Kalender in voorkeurstijden/planner toont maandag als eerste dag
- [ ] Instellingen-pagina toont geen SQL-snippet meer voor ClubNaam/ClubCode
- [ ] Teamregels-tabel: inactieve regels niet zichtbaar
- [ ] Voorkeurstijden: team-dropdown gevuld met bestaande teams
- [ ] Teambegeleiding: e-mail + telefoon zichtbaar op kaarten; Outlook-knop kopieert naar klembord
- [ ] Planner: geen lege suggesties-lijst als verplaatsingen geen verbetering opleveren
- [ ] EmailTemplates: alle 5 keys selecteerbaar; DB-override wordt gebruikt in dry-run

Closes #300, #285, #288, #289, #299, #301, #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)