### PR TITLE
fix(#306): DB retry-window verdubbeld — 10→20 pogingen (5 min totaal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **DB connection retry window verdubbeld (#306):** `WaitForDatabaseAsync` verhoogd van 10 naar 20 retries (15s per poging = 5 min totaal). Voorkomt dat de dagelijkse timer-sync mislukt als Azure SQL Free Tier langer dan 2,5 min nodig heeft om te hervatten na auto-pause.
 - **Kalender weekstart op maandag (#300):** `<html lang="en">` was de oorzaak van zondag-als-eerste-dag in alle datumkiezers en kalenders. Gewijzigd naar `lang="nl"` + `CultureInfo("nl-NL")` in `Program.cs`.
 - **Planner: no-op suggesties onderdrukt (#301):** De planner toonde verplaatsingen die de eindtijd niet verbeterden (bijv. MO15-2 eerder naar veld 5 terwijl de dag toch eindigt op 20:20 door een andere wedstrijd). Na het genereren van suggesties wordt nu de gesimuleerde nieuwe eindtijd vergeleken met de huidige; zijn er geen verbeterd → "de huidige planning is al optimaal".
 - **Teambegeleiding: e-mail en telefoon zichtbaar op kaartje (#299):** Beheerders zien nu het e-mailadres en telefoonnummer van elke begeleider op de `/teambegeleiding`-pagina. Klikbare `mailto:` en `tel:`-links. Onder de kaartjes staat een kopieerknop voor de Outlook-ontvangersregel (`"Naam" <email>; ...`).

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -99,8 +99,8 @@ namespace SportlinkFunction
         {
             bool isDatabaseAvailable = false;
             int retryCount = 0;
-            int maxRetries = 10;
-            int delayBetweenRetries = 15000; // 15 seconds — Azure SQL Serverless auto-resume takes 30-90s
+            int maxRetries = 20;
+            int delayBetweenRetries = 15000; // 15 seconds — Azure SQL Serverless auto-resume takes 30-90s; 20 retries = 5 min total
 
             while (!isDatabaseAvailable && retryCount < maxRetries)
             {


### PR DESCRIPTION
## Samenvatting

- Azure SQL Free Tier pauzeert na inactiviteit; hervatten duurt soms >2,5 min
- De oude `WaitForDatabaseAsync` had 10×15s = 150s retry-window — te krap
- Nieuwe waarde: 20×15s = 300s (5 min) — ruim genoeg voor alle auto-pause scenario's

## Oorzaak #306

Timer `FetchAndStoreApiData` (dagelijks 04:00 UTC) startte, maar de DB deed er >150s over om te hervatten. Na 10 mislukte pogingen werd een exception gegooid en via de auto-reporter issue #306 aangemaakt.

## Test plan

- [x] `dotnet build FunctionApp/fa-dev-sportlink-01.csproj -c Debug` — Build succeeded, 0 warnings
- [ ] Timer-functie draait normaal bij volgende 04:00 run (observeer in Azure Monitoring)

Fixes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)