### PR TITLE
feat(#24): real-time Sportlink API fallback voor plannerbeschikbaarheid

### DIFF
--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -23,6 +23,7 @@ public class AppSettingsDto
     public double? AccommodatieLongitude { get; set; }
     public string? FetchScheduleLeesbaar { get; set; }
     public List<string>? VolgendeMomenten { get; set; }
+    public bool UseRealtimeApi { get; set; } = true;
 }
 
 public class GeocodeResultDto

--- a/BlazorAdmin/Pages/Instellingen.razor
+++ b/BlazorAdmin/Pages/Instellingen.razor
@@ -124,6 +124,22 @@ else
             </div>
         </div>
 
+        <div class="row">
+            <div class="col-md-6 mb-3">
+                <div class="form-check form-switch mt-2">
+                    <input class="form-check-input" type="checkbox" id="useRealtimeApi"
+                           @bind="settings.UseRealtimeApi" />
+                    <label class="form-check-label" for="useRealtimeApi">
+                        Real-time Sportlink API raadplegen
+                    </label>
+                </div>
+                <small class="form-text text-muted">
+                    Aan: de planner checkt beschikbaarheid direct bij de Sportlink API (meest actueel).
+                    Uit: alleen de lokale database wordt gebruikt (sneller, werkt zonder API-verbinding).
+                </small>
+            </div>
+        </div>
+
         <button type="submit" class="btn btn-primary" disabled="@saving">
             @(saving ? "Opslaan..." : "Opslaan")
         </button>
@@ -315,6 +331,7 @@ else
                 ["CoordinatorNaam"] = settings.CoordinatorNaam,
                 ["CoordinatorFunctie"] = settings.CoordinatorFunctie,
                 ["FetchSchedule"] = settings.FetchSchedule,
+                ["UseRealtimeApi"] = settings.UseRealtimeApi ? "1" : "0",
             }
         };
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **Real-time Sportlink API voor plannerbeschikbaarheid (#24):** De planner raadpleegt nu standaard de live Sportlink `/programma`-API bij het berekenen van veldbeschikbaarheid, in plaats van uitsluitend de lokale database. Voordeel: altijd actuele veldocupatie, ook als de nachtelijke sync nog niet is gelopen. Bij een API-fout (time-out, netwerkprobleem) valt de planner automatisch terug op de database. De nieuwe instelling "Real-time Sportlink API raadplegen" op de Instellingen-pagina schakelt dit gedrag per club aan of uit.
+
 - **E-mailtemplates koppeling aan pipeline (#287):** `BouwTemplateAntwoord` raadpleegt nu de database vóór elke hardcoded fallback via `EmailTemplateService.GetTemplateAsync`. Als een beheerder een template heeft aangemaakt voor `beschikbaarheid_check`, `herplan_verzoek`, `bevestiging`, `team_contact_opvragen` of `buiten_scope`, wordt die DB-versie gebruikt in plaats van de hardcoded standaard. Dropdown in de Admin GUI uitgebreid met alle actieve template-keys, ingedeeld per categorie.
 
 ### Fixed

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -106,6 +106,16 @@ BEGIN
 END
 GO
 
+-- AppSettings: UseRealtimeApi kolom toevoegen (idempotent)
+IF NOT EXISTS (
+    SELECT 1 FROM [sys].[columns]
+    WHERE [object_id] = OBJECT_ID('[dbo].[AppSettings]') AND [name] = 'UseRealtimeApi'
+)
+BEGIN
+    ALTER TABLE [dbo].[AppSettings] ADD [UseRealtimeApi] BIT NOT NULL DEFAULT 1
+END
+GO
+
 -- AppSettings: email-integratie velden vullen
 IF EXISTS (SELECT 1 FROM [dbo].[AppSettings] WHERE [PlannerAfzenderNaam] IS NULL)
 BEGIN

--- a/Database/dbo/Tables/AppSettings.sql
+++ b/Database/dbo/Tables/AppSettings.sql
@@ -16,5 +16,6 @@
 	[EmailVoetnoot]			NVARCHAR(MAX)	NULL,	-- vrij te bewerken voettekst die onder alle uitgaande e-mails wordt geplaatst
 	[AccommodatiePlaats]	NVARCHAR(100)	NULL,	-- plaatsnaam voor geocoding en zonsondergangsberekening
 	[AccommodatieLatitude]	FLOAT			NULL,	-- breedtegraad WGS84 (decimaal)
-	[AccommodatieLongitude]	FLOAT			NULL	-- lengtegraad WGS84 (decimaal)
+	[AccommodatieLongitude]	FLOAT			NULL,	-- lengtegraad WGS84 (decimaal)
+	[UseRealtimeApi]		BIT				NOT NULL DEFAULT 1	-- 1=real-time Sportlink API raadplegen bij planner-checks, 0=alleen DB
 	)

--- a/FunctionApp/Admin/AdminSettingsFunction.cs
+++ b/FunctionApp/Admin/AdminSettingsFunction.cs
@@ -42,7 +42,8 @@ public static class AdminSettingsFunction
         "HerplanDeadlineDagen", "BufferMinuten",
         "PlannerAfzenderNaam", "CoordinatorNaam", "CoordinatorFunctie", "PlannerEmailAdres",
         "Accommodatie", "FetchSchedule", "EmailVoetnoot",
-        "AccommodatiePlaats", "AccommodatieLatitude", "AccommodatieLongitude"
+        "AccommodatiePlaats", "AccommodatieLatitude", "AccommodatieLongitude",
+        "UseRealtimeApi"
     };
 
     private const string ManagementApiVersion = "2022-03-01";
@@ -78,7 +79,8 @@ public static class AdminSettingsFunction
                     [LastSyncTimestamp], [FetchSchedule], [PlannerAfzenderNaam], [CoordinatorNaam],
                     [CoordinatorFunctie], [PlannerEmailAdres], [HerplanDeadlineDagen],
                     [BufferMinuten], [EmailVoetnoot], [AccommodatiePlaats],
-                    [AccommodatieLatitude], [AccommodatieLongitude]
+                    [AccommodatieLatitude], [AccommodatieLongitude],
+                    ISNULL([UseRealtimeApi], 1) AS [UseRealtimeApi]
                 FROM [dbo].[AppSettings]", connection);
 
             using var reader = await command.ExecuteReaderAsync();

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -189,6 +189,100 @@ namespace SportlinkFunction.Planner
             return results;
         }
 
+        // Lookup: VeldNaam (trimmed, 6 chars) → VeldNummer. Gebruikt door SportlinkApiClient.
+        public static async Task<Dictionary<string, int>> GetVeldenLookupAsync()
+        {
+            var result = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            using var conn = new SqlConnection(ConnectionString);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(
+                "SELECT [VeldNaam], [VeldNummer] FROM [dbo].[Velden] WHERE [Actief] = 1", conn);
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+                result[reader.GetString(0).TrimEnd()] = reader.GetInt32(1);
+            return result;
+        }
+
+        // Lookup: Leeftijd → Speeltijd. Gebruikt door SportlinkApiClient.
+        public static async Task<Dictionary<string, Speeltijd>> GetSpeeltijdenLookupAsync()
+        {
+            var result = new Dictionary<string, Speeltijd>(StringComparer.OrdinalIgnoreCase);
+            using var conn = new SqlConnection(ConnectionString);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(
+                "SELECT [Leeftijd], [Veldafmeting], [WedstrijdTotaal] FROM [dbo].[Speeltijden]", conn);
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+                result[reader.GetString(0)] = new Speeltijd
+                {
+                    Leeftijd       = reader.GetString(0),
+                    Veldafmeting   = reader.GetDecimal(1),
+                    WedstrijdTotaal = reader.GetInt32(2)
+                };
+            return result;
+        }
+
+        // Lookup: teamnaam → Speeltijden-sleutel (bijv. "JO13", "MO15", "G", "VR").
+        // Gebruikt door SportlinkApiClient om /programma-records te mappen zonder SQL view.
+        public static async Task<Dictionary<string, string>> GetTeamLeeftijdLookupAsync(string clubCode)
+        {
+            var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            using var conn = new SqlConnection(ConnectionString);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(@"
+                SELECT [teamnaam],
+                       REPLACE(REPLACE(REPLACE([leeftijdscategorie], 'Onder ', 'JO'), 'Meisjes ', 'MO'), 'Vrouwen', 'VR')
+                FROM [his].[teams]
+                WHERE [leeftijdscategorie] IS NOT NULL AND [leeftijdscategorie] <> ''", conn);
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                var naam = reader.GetString(0);
+                var key  = reader.GetString(1);
+                result[naam] = key;
+            }
+            return result;
+        }
+
+        // Alleen planner-ingeplande wedstrijden (zonder his.matches). Gebruikt door SportlinkApiClient
+        // om te combineren met real-time API-data.
+        public static async Task<List<BestaandeWedstrijd>> GetGeplandeWedstrijdenOnlyAsync(DateOnly date)
+        {
+            var results = new List<BestaandeWedstrijd>();
+            using var conn = new SqlConnection(ConnectionString);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(@"
+                SELECT gw.[Datum], gw.[AanvangsTijd], gw.[EindTijd],
+                       gw.[VeldNummer], gw.[VeldDeelGebruik], gw.[LeeftijdsCategorie],
+                       gw.[TeamNaam],
+                       COALESCE(gw.[TeamNaam], '') + ' - ' + COALESCE(gw.[Tegenstander], '') AS Wedstrijd,
+                       v.[VeldNaam], 'Planner' AS Bron
+                FROM [planner].[GeplandeWedstrijden] gw
+                LEFT JOIN [dbo].[Velden] v ON v.[VeldNummer] = gw.[VeldNummer]
+                WHERE gw.[Datum] = @date
+                  AND gw.[Status] <> 'Geannuleerd'
+                  AND gw.[IsVervallen] = 0", conn);
+            cmd.Parameters.AddWithValue("@date", date.ToDateTime(TimeOnly.MinValue));
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                results.Add(new BestaandeWedstrijd
+                {
+                    Datum             = DateOnly.FromDateTime(reader.GetDateTime(0)),
+                    AanvangsTijd      = TimeOnly.FromTimeSpan(reader.GetTimeSpan(1)),
+                    EindTijd          = TimeOnly.FromDateTime(reader.GetDateTime(2)),
+                    VeldNummer        = reader.GetInt32(3),
+                    VeldDeelGebruik   = reader.GetDecimal(4),
+                    LeeftijdsCategorie = reader.IsDBNull(5) ? null : reader.GetString(5),
+                    TeamNaam          = reader.IsDBNull(6) ? null : reader.GetString(6),
+                    Wedstrijd         = reader.IsDBNull(7) ? null : reader.GetString(7),
+                    VeldSubpositie    = null,
+                    Bron              = "Planner"
+                });
+            }
+            return results;
+        }
+
         public static async Task<List<TeamRegel>> GetTeamRulesAsync(string teamNaam)
         {
             var results = new List<TeamRegel>();

--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -195,7 +195,7 @@ namespace SportlinkFunction.Planner
                     var browserUrl = $"{req.Scheme}://{req.Host}/api/planner/optimaliseer?format=html";
                     var emailHtml = PlannerHtmlGenerator.GenereerEmailHtml(
                         DateOnly.Parse(request.Datum),
-                        await PlannerDataAccess.GetFieldOccupationsAsync(DateOnly.Parse(request.Datum)),
+                        await SportlinkApiClient.GetFieldOccupationsWithApiAsync(DateOnly.Parse(request.Datum), log),
                         response.Suggesties,
                         await PlannerDataAccess.GetVeldenAsync(),
                         request.Doel ?? "veld5-ontlasten",

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -104,8 +104,8 @@ namespace SportlinkFunction.Planner
                 return response;
             }
 
-            // Stap 4: Alle huidige veldbezettingen laden
-            var occupations = await PlannerDataAccess.GetFieldOccupationsAsync(date);
+            // Stap 4: Alle huidige veldbezettingen laden (real-time API of DB als fallback)
+            var occupations = await SportlinkApiClient.GetFieldOccupationsWithApiAsync(date, log);
             var velden = await PlannerDataAccess.GetVeldenAsync();
 
             // Stap 5: Teamspecifieke regels laden
@@ -687,7 +687,7 @@ namespace SportlinkFunction.Planner
                         field.BeschikbaarTot = sunset.Value;
                 }
 
-                var occupations = await PlannerDataAccess.GetFieldOccupationsAsync(date);
+                var occupations = await SportlinkApiClient.GetFieldOccupationsWithApiAsync(date, log);
 
                 foreach (var field in availableFields)
                 {
@@ -749,8 +749,8 @@ namespace SportlinkFunction.Planner
                 return response;
             }
 
-            // Data laden
-            var occupations = await PlannerDataAccess.GetFieldOccupationsAsync(date);
+            // Data laden (real-time API of DB als fallback)
+            var occupations = await SportlinkApiClient.GetFieldOccupationsWithApiAsync(date, log);
             var velden = await PlannerDataAccess.GetVeldenAsync();
             var availableFields = await PlannerDataAccess.GetAvailableFieldsAsync(date);
 
@@ -1321,8 +1321,8 @@ namespace SportlinkFunction.Planner
             var matchVeld = velden.FirstOrDefault(v => match.VeldNaam != null && match.VeldNaam.StartsWith(v.VeldNaam));
             int matchVeldNummer = matchVeld?.VeldNummer ?? 0;
 
-            var occupations = await PlannerDataAccess.GetFieldOccupationsExcludingMatchAsync(
-                date, match.Wedstrijd, matchStart, matchVeldNummer);
+            var occupations = await SportlinkApiClient.GetFieldOccupationsExcludingMatchWithApiAsync(
+                date, match.Wedstrijd, matchStart, matchVeldNummer, log);
 
             // Step 5: Load team rules (empty for reschedule — we don't know the requesting team's rules)
             var teamRules = new List<TeamRegel>();

--- a/FunctionApp/Planner/SportlinkApiClient.cs
+++ b/FunctionApp/Planner/SportlinkApiClient.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace SportlinkFunction.Planner
+{
+    // Real-time veldbezetting via Sportlink /programma endpoint.
+    // Valt terug op de database als de API onbereikbaar is of UseRealtimeApi=false.
+    public static class SportlinkApiClient
+    {
+        private static readonly HttpClient _http = new() { Timeout = TimeSpan.FromSeconds(8) };
+
+        public static async Task<List<BestaandeWedstrijd>> GetFieldOccupationsWithApiAsync(
+            DateOnly date, ILogger log)
+        {
+            var useRealtime = SystemUtilities.AppSettings.GetSetting("useRealtimeApi");
+            if (useRealtime == "0" || string.Equals(useRealtime, "false", StringComparison.OrdinalIgnoreCase))
+            {
+                log.LogDebug("SportlinkApiClient: real-time API uitgeschakeld, gebruik DB.");
+                return await PlannerDataAccess.GetFieldOccupationsAsync(date);
+            }
+
+            try
+            {
+                var apiUrl    = SystemUtilities.AppSettings.GetSetting("sportlinkApiUrl")
+                                ?? throw new InvalidOperationException("sportlinkApiUrl niet ingesteld");
+                var clientId  = SystemUtilities.AppSettings.GetSetting("sportlinkClientId")
+                                ?? throw new InvalidOperationException("sportlinkClientId niet ingesteld");
+                var accommodatie = SystemUtilities.AppSettings.GetSetting("accommodatie");
+                var clubCode     = SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
+
+                // weekoffset: hoe ver ligt 'date' van vandaag (in volle weken)?
+                int weekoffset = (int)Math.Floor(
+                    (date.ToDateTime(TimeOnly.MinValue) - DateTime.Today).TotalDays / 7.0);
+
+                var url = $"{apiUrl.TrimEnd('/')}/programma" +
+                          $"?clientId={Uri.EscapeDataString(clientId)}" +
+                          $"&weekoffset={weekoffset}&aantaldagen=1&aantalregels=10000&uit=NEE";
+
+                // DB-lookups parallel laden met de API-call
+                var lookupTask     = LoadLookupsAsync(clubCode);
+                var plannerTask    = PlannerDataAccess.GetGeplandeWedstrijdenOnlyAsync(date);
+                var apiResponseTask = _http.GetStringAsync(url);
+
+                await Task.WhenAll(lookupTask, plannerTask, apiResponseTask);
+
+                var (veldenLookup, speeltijdenLookup, teamLeeftijdLookup) = await lookupTask;
+                var plannerEntries = await plannerTask;
+                var json = await apiResponseTask;
+
+                var matches = JsonConvert.DeserializeObject<List<SportlinkProgrammaMatch>>(json)
+                              ?? new List<SportlinkProgrammaMatch>();
+
+                var apiEntries = new List<BestaandeWedstrijd>();
+                foreach (var m in matches)
+                {
+                    // Alleen thuiswedstrijden op eigen accommodatie
+                    if (string.IsNullOrEmpty(m.Accommodatie)) continue;
+                    if (accommodatie != null &&
+                        !m.Accommodatie.Contains(accommodatie, StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    if (string.Equals(m.Status, "Afgelast", StringComparison.OrdinalIgnoreCase)) continue;
+                    if (string.IsNullOrEmpty(m.Aanvangstijd) || string.IsNullOrEmpty(m.Veld)) continue;
+
+                    // veld → VeldNummer via lookup (RTRIM(LEFT(veld, 6)) = VeldNaam)
+                    var veldKey = m.Veld.Length >= 6 ? m.Veld[..6].TrimEnd() : m.Veld.TrimEnd();
+                    if (!veldenLookup.TryGetValue(veldKey, out var veldNummer)) continue;
+
+                    // teamnaam → Speeltijden-sleutel
+                    var speeltijdKey = MapTeamNaamToSpeeltijdKey(m.Teamnaam, clubCode, teamLeeftijdLookup);
+                    if (speeltijdKey == null || !speeltijdenLookup.TryGetValue(speeltijdKey, out var speeltijd))
+                        continue;
+
+                    if (!TimeOnly.TryParse(m.Aanvangstijd, out var aanvang)) continue;
+
+                    var eindTijd     = aanvang.AddMinutes(speeltijd.WedstrijdTotaal);
+                    var subpositie   = m.Veld.Length > 6 ? m.Veld[6..].Trim() : null;
+
+                    apiEntries.Add(new BestaandeWedstrijd
+                    {
+                        Datum            = date,
+                        AanvangsTijd     = aanvang,
+                        EindTijd         = eindTijd,
+                        VeldNummer       = veldNummer,
+                        VeldDeelGebruik  = speeltijd.Veldafmeting,
+                        LeeftijdsCategorie = speeltijdKey,
+                        TeamNaam         = m.Teamnaam,
+                        Wedstrijd        = m.Wedstrijd,
+                        VeldSubpositie   = string.IsNullOrEmpty(subpositie) ? null : subpositie,
+                        Bron             = "API"
+                    });
+                }
+
+                // Samenvoegen: API-entries + planner-entries, dedupliceren op (VeldNummer, AanvangsTijd, Wedstrijd)
+                var combined = apiEntries
+                    .Concat(plannerEntries)
+                    .GroupBy(w => (w.VeldNummer, w.AanvangsTijd, (w.Wedstrijd ?? "").ToLowerInvariant()))
+                    .Select(g => g.OrderBy(w => w.Bron == "API" ? 0 : 1).First())
+                    .ToList();
+
+                log.LogInformation(
+                    "SportlinkApiClient: {ApiCount} API + {PlannerCount} planner → {Total} bezettingen voor {Date}",
+                    apiEntries.Count, plannerEntries.Count, combined.Count, date);
+
+                return combined;
+            }
+            catch (Exception ex)
+            {
+                log.LogWarning("SportlinkApiClient: API-fout, fallback naar DB. {Message}", ex.Message);
+                return await PlannerDataAccess.GetFieldOccupationsAsync(date);
+            }
+        }
+
+        // Identiek aan GetFieldOccupationsWithApiAsync maar filtert één wedstrijd eruit (voor herplan).
+        public static async Task<List<BestaandeWedstrijd>> GetFieldOccupationsExcludingMatchWithApiAsync(
+            DateOnly date, string wedstrijdNaam, TimeOnly aanvangsTijd, int veldNummer, ILogger log)
+        {
+            var all = await GetFieldOccupationsWithApiAsync(date, log);
+            return all.Where(o =>
+                !(o.VeldNummer == veldNummer &&
+                  o.AanvangsTijd == aanvangsTijd &&
+                  o.Wedstrijd != null &&
+                  o.Wedstrijd.Trim() == wedstrijdNaam.Trim())
+            ).ToList();
+        }
+
+        private static string? MapTeamNaamToSpeeltijdKey(
+            string? teamnaam, string clubCode,
+            Dictionary<string, string> teamLeeftijdLookup)
+        {
+            if (string.IsNullOrEmpty(teamnaam)) return null;
+
+            // G-voetbal: teamnaam = "<ClubCode> G1", "<ClubCode> G2" etc.
+            if (!string.IsNullOrEmpty(clubCode) &&
+                teamnaam.StartsWith(clubCode + " G", StringComparison.OrdinalIgnoreCase) &&
+                teamnaam.Length > clubCode.Length + 2 &&
+                char.IsDigit(teamnaam[clubCode.Length + 2]))
+                return "G";
+
+            // Opzoeken in his.teams lookup (leeftijdscategorie al gemapt naar Speeltijden-sleutel)
+            return teamLeeftijdLookup.TryGetValue(teamnaam, out var key) ? key : null;
+        }
+
+        private static async Task<(
+            Dictionary<string, int> veldenLookup,
+            Dictionary<string, Speeltijd> speeltijdenLookup,
+            Dictionary<string, string> teamLeeftijdLookup)> LoadLookupsAsync(string clubCode)
+        {
+            var veldenTask       = PlannerDataAccess.GetVeldenLookupAsync();
+            var speeltijdenTask  = PlannerDataAccess.GetSpeeltijdenLookupAsync();
+            var teamTask         = PlannerDataAccess.GetTeamLeeftijdLookupAsync(clubCode);
+
+            await Task.WhenAll(veldenTask, speeltijdenTask, teamTask);
+
+            return (await veldenTask, await speeltijdenTask, await teamTask);
+        }
+    }
+
+    // Minimale JSON-mapping voor /programma response
+    internal class SportlinkProgrammaMatch
+    {
+        [JsonProperty("teamnaam")]     public string? Teamnaam      { get; set; }
+        [JsonProperty("wedstrijd")]    public string? Wedstrijd     { get; set; }
+        [JsonProperty("aanvangstijd")] public string? Aanvangstijd  { get; set; }
+        [JsonProperty("veld")]         public string? Veld          { get; set; }
+        [JsonProperty("accommodatie")] public string? Accommodatie  { get; set; }
+        [JsonProperty("status")]       public string? Status        { get; set; }
+    }
+}

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -26,7 +26,8 @@ namespace SportlinkFunction
                                    [PlannerEmailAdres], [Accommodatie],
                                    [HerplanDeadlineDagen], [BufferMinuten],
                                    [AccommodatieLatitude], [AccommodatieLongitude], [EmailVoetnoot],
-                                   [AccommodatiePlaats]
+                                   [AccommodatiePlaats],
+                                   ISNULL([UseRealtimeApi], 1)
                             FROM [dbo].[AppSettings]";
                         using (SqlCommand command = new SqlCommand(query, connection))
                         using (SqlDataReader reader = await command.ExecuteReaderAsync())
@@ -57,6 +58,7 @@ namespace SportlinkFunction
                                 Set("accommodatieLongitude", 15);
                                 Set("emailVoetnoot", 16);
                                 Set("accommodatiePlaats", 17);
+                                settings["useRealtimeApi"] = reader.IsDBNull(18) ? "1" : (reader.GetBoolean(18) ? "1" : "0");
                             }
                         }
                     }

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -685,6 +685,10 @@ components:
           type: number
           format: double
           nullable: true
+        UseRealtimeApi:
+          type: boolean
+          description: "true = live Sportlink API raadplegen bij plannercheck; false = alleen DB"
+          default: true
         fetchScheduleLeesbaar:
           type: string
           nullable: true
@@ -704,7 +708,7 @@ components:
         Wijzig toegestane AppSettings-velden. Velden buiten de witte lijst worden genegeerd.
         Witte lijst: HerplanDeadlineDagen, BufferMinuten, PlannerAfzenderNaam, CoordinatorNaam,
         CoordinatorFunctie, PlannerEmailAdres, Accommodatie, FetchSchedule, EmailVoetnoot,
-        AccommodatiePlaats, AccommodatieLatitude, AccommodatieLongitude.
+        AccommodatiePlaats, AccommodatieLatitude, AccommodatieLongitude, UseRealtimeApi.
       properties:
         gewijzigdDoor:
           type: string

--- a/docs/v2-admin-handleiding.md
+++ b/docs/v2-admin-handleiding.md
@@ -443,3 +443,26 @@ Het veld **Totaal (incl. rust)** is de totale veldblokkeertijd die de planner di
 | `POST /api/beheer/speeltijden` | Nieuwe speeltijd toevoegen |
 | `PUT /api/beheer/speeltijden/{leeftijd}` | Speeltijd bijwerken |
 | `DELETE /api/beheer/speeltijden/{leeftijd}` | Speeltijd verwijderen |
+
+---
+
+## 12. Real-time Sportlink API voor veldbeschikbaarheid (`/instellingen`)
+
+### Wat doet deze instelling?
+
+Op de `/instellingen`-pagina staat de schakelaar **"Real-time Sportlink API raadplegen"** (standaard: aan).
+
+| Stand | Gedrag |
+|---|---|
+| **Aan** | De planner haalt bij elke beschikbaarheidscheck live wedstrijdgegevens op bij de Sportlink `/programma`-API. Dit geeft de meest actuele veldocupatie, ook als de nachtelijke sync nog niet is gelopen. |
+| **Uit** | Alleen de lokale database wordt geraadpleegd. Sneller en werkt zonder internet- of API-verbinding, maar kan achterliggen als de dagelijkse sync recent nog niet is uitgevoerd. |
+
+### Automatische fallback
+
+Bij een API-fout (time-out, netwerk, service onbeschikbaar) schakelt de planner automatisch terug naar de database. Beheerders hoeven hier niets voor te doen — de fallback is transparant.
+
+### Wanneer uitschakelen?
+
+- Testomgeving zonder geldige Sportlink API-credentials
+- Lokale ontwikkelomgeving zonder internet
+- Problematische API-respons tijdelijk omzeilen tijdens een incident


### PR DESCRIPTION
## Summary

- Nieuwe `SportlinkApiClient.cs`: raadpleegt `/programma`-API live bij plannercheck; graceful fallback naar DB bij fout (timeout 8s)
- DB lookup tables (Velden, Speeltijden, his.teams leeftijdscategorie) worden parallel met de API-call geladen
- Nieuwe kolom `UseRealtimeApi BIT DEFAULT 1` in `dbo.AppSettings` + idempotente PostDeployment-migratie
- Nieuwe schakelaar op Instellingen-pagina: "Real-time Sportlink API raadplegen"
- 4 call sites in `PlannerService.cs` + `PlannerFunction.cs` bijgewerkt naar nieuwe client

## Test plan

- [ ] `dotnet build` beide projecten: 0 errors, 0 warnings
- [ ] `Test-App.ps1`: 31 checks geslaagd
- [ ] Instellingen-pagina laadt met schakelaar zichtbaar (default: aan)
- [ ] Schakelaar opslaan → `UseRealtimeApi` in DB bijgewerkt
- [ ] Planner beschikbaarheidscheck werkt met API aan en uit

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)