### PR TITLE
hotfix(#316): UseRealtimeApi dynamisch laden — backward-compatible

### DIFF
--- a/FunctionApp/Admin/AdminSettingsFunction.cs
+++ b/FunctionApp/Admin/AdminSettingsFunction.cs
@@ -79,8 +79,7 @@ public static class AdminSettingsFunction
                     [LastSyncTimestamp], [FetchSchedule], [PlannerAfzenderNaam], [CoordinatorNaam],
                     [CoordinatorFunctie], [PlannerEmailAdres], [HerplanDeadlineDagen],
                     [BufferMinuten], [EmailVoetnoot], [AccommodatiePlaats],
-                    [AccommodatieLatitude], [AccommodatieLongitude],
-                    ISNULL([UseRealtimeApi], 1) AS [UseRealtimeApi]
+                    [AccommodatieLatitude], [AccommodatieLongitude]
                 FROM [dbo].[AppSettings]", connection);
 
             using var reader = await command.ExecuteReaderAsync();
@@ -94,6 +93,20 @@ public static class AdminSettingsFunction
                 var raw = reader.IsDBNull(i) ? null : reader.GetValue(i);
                 result[name] = raw is DateTime dt ? DateTime.SpecifyKind(dt, DateTimeKind.Utc) : raw;
             }
+            reader.Close();
+
+            // UseRealtimeApi: dynamisch laden — kolom bestaat pas na DB-migratie
+            using var rtaCmd = new SqlCommand(@"
+                DECLARE @v BIT = 1;
+                DECLARE @sql NVARCHAR(200) = CASE
+                    WHEN COL_LENGTH('[dbo].[AppSettings]', 'UseRealtimeApi') IS NOT NULL
+                    THEN N'SELECT TOP 1 @v = [UseRealtimeApi] FROM [dbo].[AppSettings]'
+                    ELSE N'SELECT @v = CAST(1 AS BIT)'
+                END;
+                EXEC sp_executesql @sql, N'@v BIT OUTPUT', @v = @v OUTPUT;
+                SELECT @v;", connection);
+            var rtaScalar = await rtaCmd.ExecuteScalarAsync();
+            result["UseRealtimeApi"] = rtaScalar is bool rtaBool ? rtaBool : true;
 
             // Voeg CRON-preview toe als FetchSchedule aanwezig is
             if (result.TryGetValue("FetchSchedule", out var sched) && sched is string schedStr && !string.IsNullOrWhiteSpace(schedStr))

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -26,8 +26,7 @@ namespace SportlinkFunction
                                    [PlannerEmailAdres], [Accommodatie],
                                    [HerplanDeadlineDagen], [BufferMinuten],
                                    [AccommodatieLatitude], [AccommodatieLongitude], [EmailVoetnoot],
-                                   [AccommodatiePlaats],
-                                   ISNULL([UseRealtimeApi], 1)
+                                   [AccommodatiePlaats]
                             FROM [dbo].[AppSettings]";
                         using (SqlCommand command = new SqlCommand(query, connection))
                         using (SqlDataReader reader = await command.ExecuteReaderAsync())
@@ -58,9 +57,22 @@ namespace SportlinkFunction
                                 Set("accommodatieLongitude", 15);
                                 Set("emailVoetnoot", 16);
                                 Set("accommodatiePlaats", 17);
-                                settings["useRealtimeApi"] = reader.IsDBNull(18) ? "1" : (reader.GetBoolean(18) ? "1" : "0");
                             }
                         }
+
+                        // UseRealtimeApi: kolom bestaat pas na DB-migratie — dynamisch laden zodat
+                        // de Function App ook opstart als de kolom nog niet aangemaakt is.
+                        using var rtaCmd = new SqlCommand(@"
+                            DECLARE @v BIT = 1;
+                            DECLARE @sql NVARCHAR(200) = CASE
+                                WHEN COL_LENGTH('[dbo].[AppSettings]', 'UseRealtimeApi') IS NOT NULL
+                                THEN N'SELECT TOP 1 @v = [UseRealtimeApi] FROM [dbo].[AppSettings]'
+                                ELSE N'SELECT @v = CAST(1 AS BIT)'
+                            END;
+                            EXEC sp_executesql @sql, N'@v BIT OUTPUT', @v = @v OUTPUT;
+                            SELECT @v;", connection);
+                        var rtaResult = await rtaCmd.ExecuteScalarAsync();
+                        settings["useRealtimeApi"] = (rtaResult is bool b && !b) ? "0" : "1";
                     }
                     log.LogInformation("App settings loaded successfully.");
                 }


### PR DESCRIPTION
## Summary

Kritieke productiefix voor regressie geïntroduceerd in PR #315.

- `LoadSettingsAsync` en `AdminSettingsFunction GET` refereerden direct aan `[UseRealtimeApi]` via `ISNULL([UseRealtimeApi], 1)`. Op productie bestaat deze kolom nog niet (DB-migratie pending, free DB-limiet bereikt). SQL Server faalt het hele query bij compile-time op "Invalid column name" → Function App start niet op → alle endpoints 503.
- Fix: dynamische SQL via `sp_executesql` + `COL_LENGTH`-check. Kolom aanwezig → waarde lezen. Kolom ontbreekt → default 1 (realtime aan). Volledig backward-compatible.

## Test plan

- [ ] `dotnet build`: 0 errors
- [ ] `Test-App.ps1`: 31 checks
- [ ] Productie start op zonder `UseRealtimeApi`-kolom in DB

Fixes regressie uit #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)