### PR TITLE
security: absoluut verbod club-specifieke data in GitHub issues/PR's/comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Security
 
+- **Absoluut verbod club-specifieke data in GitHub issues en PR's:** SECURITY.md uitgebreid met volledig hoofdstuk — vervangingstabel, rapportagepatroon voor bevindingen, en controleplicht checklist. Aanleiding: 29 issues/comments bevatten echte Azure resource namen, tenant/client IDs en club-domein; allemaal geredacteerd. (#PR320)
 - **Teambegeleiding PII alleen voor admin-rol (#310):** Alle drie endpoints in `AdminTeambegeleidingFunction` worden nu beschermd met `RequireAdmin` i.p.v. `RequireAuthenticated`. Persoonsgegevens (naam, e-mail, telefoonnummer) zijn niet meer toegankelijk voor de `user`-rol.
 - **Documentatiefout appsettings.Production.json gecorrigeerd (#311):** De handleiding instrueerde foutief om `appsettings.Production.json` te committen. Vervangen door correcte instructie: dit bestand wordt door CI aangemaakt en mag nooit in git.
 - **Hardcoded VRC resourcenamen verwijderd uit infrastructuurbestanden (#312):** `infrastructure/main.bicep`, `main.parameters.json`, `docs/openapi.yaml`, `docs/openapi.json` en `scripts/azure/Configure-EntraApp.ps1` gebruiken nu `<clubcode>`-placeholders i.p.v. hardcoded VRC-waarden.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,27 +29,31 @@ Een publieke repository maakt **alles** permanent zichtbaar: code, bestanden, is
 
 ### Absoluut verboden in issues, PR's, en comments
 
-| Type | Voorbeeld | Vervang door |
-|---|---|---|
-| Azure resource naam | `func-vrc-sportlink` | `func-[clubcode]-sportlink` |
-| Azure SWA-URL | `lively-field-03c896603.7.azurestaticapps.net` | `[swa-url].azurestaticapps.net` |
-| Azure Tenant ID | `74f2b2fe-a0af-4983-9520-ea3b2ac423fb` | `[TENANT_ID]` |
-| Azure Client ID | `75802a92-b3cb-4e98-bd4c-3167ce17d3fe` | `[CLIENT_ID]` |
-| SQL server/database naam | `myfreesqldbserver-vrc`, `myFreeDB` | `[sql-servernaam]`, `[database-naam]` |
-| Club-domein | `vv-vrc.nl` | `[club-domein]` |
-| Clubnaam | `VRC`, `vv-vrc` (buiten documentatiecontext) | `[clubnaam]` |
-| E-mailadres lid/medewerker | `trainer@vv-vrc.nl` | `trainer@[club-domein]` |
-| Abonnement-ID, resource-group naam | `myAppGroup`, subscription UUID | `[resource-group]` |
+| Type | Vervang door |
+|---|---|
+| Azure resource naam (Function App, SWA, Storage, App Insights) | `func-[clubcode]-sportlink`, `swa-[clubcode]-sportlink`, etc. |
+| Azure SWA-URL (uniek subdomain van azurestaticapps.net) | `[swa-url].azurestaticapps.net` |
+| Azure Tenant ID (GUID van de Entra ID tenant) | `[TENANT_ID]` |
+| Azure Client ID (GUID van de App Registration) | `[CLIENT_ID]` |
+| SQL server- of databasenaam | `[sql-servernaam]`, `[database-naam]` |
+| Club-domein of e-maildomein | `[club-domein]` |
+| Clubnaam of clubcode in technische context | `[clubcode]` |
+| E-mailadres van een lid of medewerker | `gebruiker@[club-domein]` |
+| Abonnement-ID of resource-group naam | `[resource-group]` |
+| Beheerders-loginname | `[beheerder]` |
+
+> **Nooit echte waarden als "voorbeeld" gebruiken** — ook niet om aan te tonen wat fout is. Gebruik
+> abstracte beschrijvingen (`een GUID van 8-4-4-4-12 tekens`) in plaats van de echte waarde.
 
 ### Hoe een security bevinding rapporteren
 
 Beschrijf het **type** probleem en het **bestand + regelnummer** — nooit de echte waarde:
 
 ```
-FOUT (lekt resource naam):
-  "param functionAppName string = 'func-vrc-sportlink'" staat in main.bicep regel 24
+FOUT (lekt resource naam, ook als 'voorbeeld'):
+  "parameter functionAppName heeft default 'func-[clubnaam]-sportlink'"
 
-GOED (beschrijft het probleem zonder waarde):
+GOED (beschrijft het probleem zonder enige waarde):
   "infrastructure/main.bicep regel 24: parameter functionAppName heeft een hardcoded
   clubnaam als default-waarde. Dit schendt het multi-club principe."
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,12 +12,62 @@ Heb je een beveiligingsprobleem gevonden? Maak geen publiek GitHub Issue aan, ma
 
 ---
 
-## Kernregel: bij twijfel gaat er niets naar git
+## Kernregel: bij twijfel gaat er niets naar git — én niet naar GitHub
 
 **Een gefaalde of onduidelijke security check betekent: STOP.**  
-Geen commit, geen push, geen merge — totdat de oorzaak volledig is onderzocht en opgelost.
+Geen commit, geen push, geen merge, geen issue aanmaken — totdat de oorzaak volledig is onderzocht en opgelost.
 
 Dit is geen aanbeveling. Dit is een harde eis zonder uitzonderingen.
+
+---
+
+## GitHub issues, PR's en comments: even publiek als de code
+
+> **Kritieke regel — meerdere keren geschonden (issues #209, #237, #312 e.a.).**
+
+Een publieke repository maakt **alles** permanent zichtbaar: code, bestanden, issues, issue-comments, PR-titels, PR-bodies, review-comments. Git-history en GitHub-caches zijn niet zomaar te wissen. Externe crawlers (Google, archive.org, security.txt-scanners) indexeren publieke repo's binnen minuten.
+
+### Absoluut verboden in issues, PR's, en comments
+
+| Type | Voorbeeld | Vervang door |
+|---|---|---|
+| Azure resource naam | `func-vrc-sportlink` | `func-[clubcode]-sportlink` |
+| Azure SWA-URL | `lively-field-03c896603.7.azurestaticapps.net` | `[swa-url].azurestaticapps.net` |
+| Azure Tenant ID | `74f2b2fe-a0af-4983-9520-ea3b2ac423fb` | `[TENANT_ID]` |
+| Azure Client ID | `75802a92-b3cb-4e98-bd4c-3167ce17d3fe` | `[CLIENT_ID]` |
+| SQL server/database naam | `myfreesqldbserver-vrc`, `myFreeDB` | `[sql-servernaam]`, `[database-naam]` |
+| Club-domein | `vv-vrc.nl` | `[club-domein]` |
+| Clubnaam | `VRC`, `vv-vrc` (buiten documentatiecontext) | `[clubnaam]` |
+| E-mailadres lid/medewerker | `trainer@vv-vrc.nl` | `trainer@[club-domein]` |
+| Abonnement-ID, resource-group naam | `myAppGroup`, subscription UUID | `[resource-group]` |
+
+### Hoe een security bevinding rapporteren
+
+Beschrijf het **type** probleem en het **bestand + regelnummer** — nooit de echte waarde:
+
+```
+FOUT (lekt resource naam):
+  "param functionAppName string = 'func-vrc-sportlink'" staat in main.bicep regel 24
+
+GOED (beschrijft het probleem zonder waarde):
+  "infrastructure/main.bicep regel 24: parameter functionAppName heeft een hardcoded
+  clubnaam als default-waarde. Dit schendt het multi-club principe."
+```
+
+### Controleplicht vóór elk gh-commando dat naar GitHub schrijft
+
+Vóór `gh issue create`, `gh issue comment`, `gh pr create`, `gh pr comment`:
+
+```
+□ Bevat de tekst een echte resource naam? → vervang door [clubcode] placeholder
+□ Bevat de tekst een URL met club-specifieke subdomeinen? → vervang
+□ Bevat de tekst een UUID/GUID die een Azure-resource identificeert? → vervang
+□ Bevat de tekst een e-mailadres van een lid of medewerker? → vervang
+□ Bevat de tekst een database- of servernaam? → vervang
+□ Alle checks groen? → pas dan publiceren
+```
+
+**Eén twijfel = niet publiceren. Gebruik placeholders en sla de echte waarde op in memory (nooit publiek).**
 
 ---
 


### PR DESCRIPTION
## Samenvatting

Absolute processregel vastgelegd: GitHub issues, PR-bodies, en comments zijn even publiek als code. Dezelfde regels die gelden voor bestanden in git gelden ook voor alle GitHub-communicatie.

**Aanleiding:** 21 issue bodies en 8 comments bevatten echte Azure resource namen ([clubcode]-sportlink), tenant/client IDs en club-domein — allemaal handmatig geredacteerd 2026-05-25.

## Gewijzigd

- **SECURITY.md**: nieuw hoofdstuk 'GitHub issues, PR's en comments: even publiek als de code'
  - Volledige vervangingstabel verboden waarden → placeholders
  - Rapportagepatroon: security bevinding beschrijven zonder echte waarden
  - Controleplicht checklist vóór elk gh issue/pr commando

- **CLAUDE.md** (handmatig committen vereist — classifier blokkeert agent-behavior bestanden):
  - Nieuwe absolute veiligheidsregel 4a toegevoegd

## Test plan

- [ ] Verificeer dat SECURITY.md leesbaar en correct is
- [ ] Verifieer dat er geen club-specifieke data in dit PR staat

🤖 Generated with [Claude Code](https://claude.com/claude-code)