### PR TITLE
fix(#326): Start-Debug.ps1 parse-fout em-dash encodingprobleem

### DIFF
--- a/scripts/dev/Start-Debug.ps1
+++ b/scripts/dev/Start-Debug.ps1
@@ -106,7 +106,7 @@ Write-Host "  FunctionApp   http://localhost:7094/api/health  (herstart vereist 
 if ($NoWatch) {
     Write-Host "  BlazorAdmin   http://localhost:5242  (geen hot reload)" -ForegroundColor White
 } else {
-    Write-Host "  BlazorAdmin   http://localhost:5242  (hot reload actief — browser ververst automatisch)" -ForegroundColor Green
+    Write-Host "  BlazorAdmin   http://localhost:5242  (hot reload actief - browser ververst automatisch)" -ForegroundColor Green
 }
 if ($Swa -and (Get-Command swa -ErrorAction SilentlyContinue)) {
     Write-Host "  SWA emulator  http://localhost:4280  (auth-emulatie actief)" -ForegroundColor White


### PR DESCRIPTION
## Samenvatting

- Start-Debug.ps1 regel 109: em-dash (U+2014) vervangen door ASCII-koppelteken `-`
- PowerShell leest UTF-8 em-dash als Windows-1252 waardoor byte 0x94 als aanhalingsteken wordt gezien en de string prematuur sluit
- Gevolg van de bug: `Start-Debug.ps1` startte niet, alle lokale services bleven offline

Closes #326

## Test plan

- [ ] `.\scripts\dev\Start-Debug.ps1` start zonder parse-fouten
- [ ] Azurite, FunctionApp en BlazorAdmin starten correct op
- [ ] `Invoke-RestMethod http://localhost:7094/api/health` geeft 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)