### PR TITLE
fix(#326): UTF-8 BOM toevoegen Start-Debug.ps1 + CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+
+- **Start-Debug.ps1 parse-fout door em-dash encodingprobleem (#326):** Regel 109 bevatte een em-dash (U+2014) die PowerShell als Windows-1252 decodeerde. Byte 0x94 werd daardoor als aanhalingsteken gelezen, waardoor de string vroegtijdig sloot en het script niet kon starten. Vervangen door ASCII-koppelteken. Gevolg van de bug: alle lokale services (Azurite, FunctionApp, BlazorAdmin) startten niet via `Start-Debug.ps1`.
+
 ### Security
 
 - **Preventie-infrastructuur club-specifieke data (#321):** Drie onafhankelijke lagen voorkomen nu dat Azure-resourcenamen of infrastructuuridentifiers naar GitHub gaan: (1) 7 nieuwe gitleaks-regels op structurele naampatronen, (2) nieuw CI-job `infra-patterns` in security-scan.yml met ondersteuning voor `CLUB_EXTRA_PATTERNS` GitHub Secret, (3) pre-push hook bugfix voor nieuwe branches. Script `scripts/security/Clean-GitHistory.ps1` voor historische git-history cleanup toegevoegd.

--- a/scripts/dev/Start-Debug.ps1
+++ b/scripts/dev/Start-Debug.ps1
@@ -1,4 +1,4 @@
-# Start-Debug.ps1
+﻿# Start-Debug.ps1
 # Start alle lokale services voor v2 ontwikkelen en testen.
 # Vereisten: .NET 10 SDK, Azure Functions Core Tools v4, Azurite, SQL Server met SportlinkSqlDb.
 #


### PR DESCRIPTION
## Samenvatting

- **UTF-8 BOM toegevoegd** aan `scripts/dev/Start-Debug.ps1`: zonder BOM leest PowerShell het UTF-8-bestand als Windows-1252, waardoor em-dashes (byte 0x94) als aanhalingstekens worden gezien en strings vroegtijdig sluiten. BOM instrueert PowerShell expliciet UTF-8 te gebruiken.
- **CHANGELOG bijgewerkt** met entry voor #326 fix (vergeten in vorige commit).

De eerder gemergede ASCII-vervangingsfix in PR #327 is vervangen door deze structurele oplossing.

Closes #326

## Test plan

- [ ] `.\scripts\dev\Start-Debug.ps1` start zonder parse-fouten
- [ ] Alle drie de services (Azurite, FunctionApp, BlazorAdmin) starten correct op
- [ ] `Invoke-RestMethod http://localhost:7094/api/health` geeft 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)