### PR TITLE
fix(#324): seed-migratie 002 gecorrigeerd — kolomnamen en PK-conflict Velden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- Migratie 002 (AllStars FC seed) werkt nu correct: kolomnamen in `avg.Teambegeleiding` gecorrigeerd en VeldNummer-reeks aangepast naar 101-103 om PK-conflict met de primaire club te vermijden.
+
 ---
 
 ## [2.4.0] — 2026-05-26

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -467,9 +467,14 @@ BEGIN
         [Emailadres]             NVARCHAR (200) NULL,
         [Telefoonnummer]         NVARCHAR (50)  NULL,
         [mta_imported]           DATETIME       CONSTRAINT [DF_avg_Teambegeleiding_mta_imported] DEFAULT (GETUTCDATE()) NOT NULL,
+        [ClubCode]               NVARCHAR (20)  NOT NULL CONSTRAINT [DF_avg_Teambegeleiding_ClubCode] DEFAULT '',
         CONSTRAINT [PK_avg_Teambegeleiding] PRIMARY KEY CLUSTERED ([Id] ASC)
     );
 END
+GO
+-- ClubCode toevoegen aan bestaande avg.Teambegeleiding installaties (idempotent)
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('avg.Teambegeleiding') AND name = 'ClubCode')
+    ALTER TABLE [avg].[Teambegeleiding] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_avg_Teambegeleiding_ClubCode] DEFAULT '';
 GO
 
 -- #238: avg.sp_CleanupTeambegeleiding — AVG-vangnet: verwijder rijen ouder dan 1 jaar

--- a/Database/avg/Tables/Teambegeleiding.sql
+++ b/Database/avg/Tables/Teambegeleiding.sql
@@ -11,5 +11,6 @@ CREATE TABLE [avg].[Teambegeleiding] (
     [Emailadres]             NVARCHAR (200) NULL,
     [Telefoonnummer]         NVARCHAR (50)  NULL,
     [mta_imported]           DATETIME       CONSTRAINT [DF_avg_Teambegeleiding_mta_imported] DEFAULT (GETUTCDATE()) NOT NULL,
+    [ClubCode]               NVARCHAR (20)  NOT NULL CONSTRAINT [DF_avg_Teambegeleiding_ClubCode] DEFAULT '',
     CONSTRAINT [PK_avg_Teambegeleiding] PRIMARY KEY CLUSTERED ([Id] ASC)
 );

--- a/scripts/migrations/002-seed-allstars-fc.sql
+++ b/scripts/migrations/002-seed-allstars-fc.sql
@@ -24,13 +24,14 @@ END
 GO
 
 -- ─── Velden ────────────────────────────────────────────────
+-- VeldNummer 101-103: vermijdt PK-conflict met primaire club (PK_Velden is op VeldNummer alleen)
 IF NOT EXISTS (SELECT 1 FROM [dbo].[Velden] WHERE [ClubCode] = 'ALLSTARS')
 BEGIN
     INSERT INTO [dbo].[Velden] ([VeldNummer], [VeldNaam], [VeldType], [HeeftKunstlicht], [Actief], [ClubCode])
     VALUES
-        (1, 'Kunstgras 1', 'kunstgras',   1, 1, 'ALLSTARS'),
-        (2, 'Kunstgras 2', 'kunstgras',   1, 1, 'ALLSTARS'),
-        (3, 'Gras',        'natuurgras',  0, 1, 'ALLSTARS');
+        (101, 'Kunstgras 1', 'kunstgras',   1, 1, 'ALLSTARS'),
+        (102, 'Kunstgras 2', 'kunstgras',   1, 1, 'ALLSTARS'),
+        (103, 'Gras',        'natuurgras',  0, 1, 'ALLSTARS');
 END
 GO
 
@@ -38,7 +39,7 @@ GO
 IF NOT EXISTS (SELECT 1 FROM [avg].[Teambegeleiding] WHERE [ClubCode] = 'ALLSTARS')
 BEGIN
     INSERT INTO [avg].[Teambegeleiding]
-        ([TeamNaam], [Naam], [EmailAdres], [Rol], [ClubCode])
+        ([Team], [Naam], [Emailadres], [Teamrol], [ClubCode])
     VALUES
         ('AllStars JO8 1',   'Frenkie',  'frenkie@allstars-fc.test',  'Trainer', 'ALLSTARS'),
         ('AllStars JO8 2',   'John',     'john@allstars-fc.test',     'Trainer', 'ALLSTARS'),


### PR DESCRIPTION
## Samenvatting

Twee bugs gecorrigeerd in de AllStars FC seed-migratie die werden ontdekt bij lokaal testen van v2.4.0.

### Bug 1: Kolomnamen avg.Teambegeleiding onjuist

De seed gebruikte kolomnamen die niet overeenkwamen met de werkelijke tabelstructuur:
- `TeamNaam` → `Team`
- `EmailAdres` → `Emailadres`
- `Rol` → `Teamrol`

Bovendien ontbrak de `ClubCode` kolom in `avg.Teambegeleiding`. Toegevoegd via idempotente `ALTER TABLE` in `Script.PostDeployment1.sql` en in de tabeldef.

### Bug 2: PK-conflict dbo.Velden

`PK_Velden` is op `VeldNummer` alleen (niet composite met `ClubCode`). De primaire club gebruikt VeldNummer 1-6. De AllStars FC seed probeerde ook VeldNummer 1, 2, 3 te inserten → PK-schending.

Fix: VeldNummer 101, 102, 103 voor AllStars FC.

## Geteste migratie

Na fix (lokaal):
- 1 AppSettings ALLSTARS
- 3 Velden ALLSTARS (101-103)
- 37 Teambegeleiders ALLSTARS
- 37 teams ALLSTARS
- 24 wedstrijden ALLSTARS

`.\scripts\dev\Test-App.ps1` → 31/31 geslaagd, exit 0.

Closes #324 (bugfix op gemerged issue)