### PR TITLE
fix(#342,#341): club wisselen propageert nu naar alle pagina's + correcte standaard club

### DIFF
--- a/BlazorAdmin/Layout/MainLayout.razor
+++ b/BlazorAdmin/Layout/MainLayout.razor
@@ -14,9 +14,8 @@
         <div class="top-row px-4 d-flex align-items-center justify-content-end">
             @if (_clubs.Count > 1)
             {
-                <div class="me-3 d-flex align-items-center gap-2">
-                    <span class="text-muted small">Club:</span>
-                    <select class="form-select form-select-sm club-selector" @onchange="OnClubChanged" value="@ClubSelector.SelectedClubCode">
+                <div class="me-3">
+                    <select class="form-select form-select-sm club-selector" style="min-width:200px" @onchange="OnClubChanged" value="@ClubSelector.SelectedClubCode">
                         @foreach (var club in _clubs)
                         {
                             <option value="@club.ClubCode">@club.ClubName</option>
@@ -50,7 +49,8 @@
                 (ClubSelector.SelectedClubCode == null ||
                  !_clubs.Any(c => c.ClubCode == ClubSelector.SelectedClubCode)))
             {
-                await ClubSelector.SelectClubAsync(_clubs[0].ClubCode);
+                var primary = _clubs.FirstOrDefault(c => c.SyncEnabled)?.ClubCode ?? _clubs[0].ClubCode;
+                await ClubSelector.SelectClubAsync(primary);
             }
         }
     }

--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -266,4 +266,5 @@ public class ClubDto
 {
     public string ClubCode { get; set; } = "";
     public string ClubName { get; set; } = "";
+    public bool SyncEnabled { get; set; }
 }

--- a/BlazorAdmin/Pages/EmailTemplates.razor
+++ b/BlazorAdmin/Pages/EmailTemplates.razor
@@ -1,6 +1,9 @@
 @page "/email-templates"
 @inject AdminApiClient Api
 @inject IAuthService Auth
+@inject ClubSelectorService ClubSelector
+@using BlazorAdmin.Services
+@implements IDisposable
 
 <PageTitle>E-mailtemplates — VRC Admin</PageTitle>
 
@@ -153,6 +156,16 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        ClubSelector.OnChange += OnClubChanged;
+        await LoadAsync();
+    }
+
+    private void OnClubChanged() => _ = InvokeAsync(async () => { await LoadAsync(); StateHasChanged(); });
+    public void Dispose() => ClubSelector.OnChange -= OnClubChanged;
+
+    private async Task LoadAsync()
+    {
+        loading = true;
         await Task.WhenAll(LoadTemplatesAsync(), LoadVoetnootAsync());
         loading = false;
     }

--- a/BlazorAdmin/Pages/Home.razor
+++ b/BlazorAdmin/Pages/Home.razor
@@ -1,5 +1,8 @@
 @page "/"
 @inject AdminApiClient Api
+@inject ClubSelectorService ClubSelector
+@using BlazorAdmin.Services
+@implements IDisposable
 
 <PageTitle>Dashboard — VRC Admin</PageTitle>
 
@@ -78,8 +81,12 @@
 
     protected override async Task OnInitializedAsync()
     {
+        ClubSelector.OnChange += OnClubChanged;
         await LoadAsync();
     }
+
+    private void OnClubChanged() => _ = InvokeAsync(async () => { await LoadAsync(); StateHasChanged(); });
+    public void Dispose() => ClubSelector.OnChange -= OnClubChanged;
 
     private async Task LoadAsync()
     {

--- a/BlazorAdmin/Pages/Instellingen.razor
+++ b/BlazorAdmin/Pages/Instellingen.razor
@@ -1,6 +1,9 @@
 @page "/instellingen"
 @inject AdminApiClient Api
 @inject IAuthService Auth
+@inject ClubSelectorService ClubSelector
+@using BlazorAdmin.Services
+@implements IDisposable
 
 <PageTitle>Instellingen — VRC Admin</PageTitle>
 
@@ -240,10 +243,19 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        ClubSelector.OnChange += OnClubChanged;
+        await LoadAsync();
+    }
+
+    private void OnClubChanged() => _ = InvokeAsync(async () => { await LoadAsync(); StateHasChanged(); });
+    public void Dispose() => ClubSelector.OnChange -= OnClubChanged;
+
+    private async Task LoadAsync()
+    {
+        errorMessage = null;
         var r = await Api.GetSettingsAsync();
         if (r.Success) settings = r.Data;
         else errorMessage = r.ErrorMessage;
-
         await LaadUitgeslotenEmailsAsync();
     }
 

--- a/BlazorAdmin/Pages/Leermomenten.razor
+++ b/BlazorAdmin/Pages/Leermomenten.razor
@@ -1,5 +1,8 @@
 @page "/leermomenten"
 @inject AdminApiClient Api
+@inject ClubSelectorService ClubSelector
+@using BlazorAdmin.Services
+@implements IDisposable
 
 <PageTitle>Leermomenten — Admin</PageTitle>
 
@@ -143,7 +146,14 @@ else
     private string? _fout;
     private readonly HashSet<int> _actieBezigId = new();
 
-    protected override async Task OnInitializedAsync() => await LaadAsync("pending");
+    protected override async Task OnInitializedAsync()
+    {
+        ClubSelector.OnChange += OnClubChanged;
+        await LaadAsync("pending");
+    }
+
+    private void OnClubChanged() => _ = InvokeAsync(async () => { await LaadAsync(_filterStatus ?? "pending"); StateHasChanged(); });
+    public void Dispose() => ClubSelector.OnChange -= OnClubChanged;
 
     private async Task LaadAsync(string status)
     {

--- a/BlazorAdmin/Pages/Speeltijden.razor
+++ b/BlazorAdmin/Pages/Speeltijden.razor
@@ -1,6 +1,9 @@
 @page "/instellingen/speeltijden"
 @inject AdminApiClient Api
+@inject ClubSelectorService ClubSelector
 @using BlazorAdmin.Models
+@using BlazorAdmin.Services
+@implements IDisposable
 
 <PageTitle>Speeltijden — Admin</PageTitle>
 
@@ -108,7 +111,14 @@ else
     private string? _error;
     private string? _saveError;
 
-    protected override async Task OnInitializedAsync() => await LaadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        ClubSelector.OnChange += OnClubChanged;
+        await LaadAsync();
+    }
+
+    private void OnClubChanged() => _ = InvokeAsync(async () => { await LaadAsync(); StateHasChanged(); });
+    public void Dispose() => ClubSelector.OnChange -= OnClubChanged;
 
     private async Task LaadAsync()
     {

--- a/BlazorAdmin/Pages/Teambegeleiding.razor
+++ b/BlazorAdmin/Pages/Teambegeleiding.razor
@@ -1,7 +1,10 @@
 @page "/teambegeleiding"
 @inject AdminApiClient Api
 @inject IJSRuntime JS
+@inject ClubSelectorService ClubSelector
 @using BlazorAdmin.Models
+@using BlazorAdmin.Services
+@implements IDisposable
 
 <PageTitle>Teambegeleiding — Admin</PageTitle>
 
@@ -147,6 +150,19 @@ else if (_selectedTeam != null && !_loadingBegeleiders)
 
     protected override async Task OnInitializedAsync()
     {
+        ClubSelector.OnChange += OnClubChanged;
+        await LoadAsync();
+    }
+
+    private void OnClubChanged() => _ = InvokeAsync(async () => { await LoadAsync(); StateHasChanged(); });
+    public void Dispose() => ClubSelector.OnChange -= OnClubChanged;
+
+    private async Task LoadAsync()
+    {
+        _loadingTeams = true;
+        _teamsError = null;
+        _selectedTeam = null;
+        _begeleiders.Clear();
         var result = await Api.GetTeambegeleidingTeamsAsync();
         if (result.Success)
             _teams = result.Data ?? new();

--- a/BlazorAdmin/Pages/Thema.razor
+++ b/BlazorAdmin/Pages/Thema.razor
@@ -3,6 +3,8 @@
 @using BlazorAdmin.Services
 @inject AdminApiClient Api
 @inject ThemeService ThemeService
+@inject ClubSelectorService ClubSelector
+@implements IDisposable
 
 <PageTitle>Club-thema — Sportlink Admin</PageTitle>
 
@@ -172,6 +174,17 @@ else
 
     protected override async Task OnInitializedAsync()
     {
+        ClubSelector.OnChange += OnClubChanged;
+        await LoadAsync();
+    }
+
+    private void OnClubChanged() => _ = InvokeAsync(async () => { await LoadAsync(); StateHasChanged(); });
+    public void Dispose() => ClubSelector.OnChange -= OnClubChanged;
+
+    private async Task LoadAsync()
+    {
+        _loading = true;
+        _error = null;
         var result = await Api.GetThemeAsync();
         if (result.Success && result.Data != null)
             _theme = result.Data;

--- a/BlazorAdmin/Pages/Voorkeurstijden.razor
+++ b/BlazorAdmin/Pages/Voorkeurstijden.razor
@@ -1,6 +1,9 @@
 @page "/voorkeurstijden"
 @inject AdminApiClient Api
+@inject ClubSelectorService ClubSelector
 @using BlazorAdmin.Models
+@using BlazorAdmin.Services
+@implements IDisposable
 
 <PageTitle>Voorkeurstijden — VRC Admin</PageTitle>
 
@@ -254,7 +257,14 @@ else
     // #288: alleen actieve teamregels tonen in de tabel
     private List<TeamRegelDto> ActieveTeamRegels => teamRegels.Where(r => r.Actief).ToList();
 
-    protected override async Task OnInitializedAsync() => await LoadAsync();
+    protected override async Task OnInitializedAsync()
+    {
+        ClubSelector.OnChange += OnClubChanged;
+        await LoadAsync();
+    }
+
+    private void OnClubChanged() => _ = InvokeAsync(async () => { await LoadAsync(); StateHasChanged(); });
+    public void Dispose() => ClubSelector.OnChange -= OnClubChanged;
 
     private async Task LoadAsync()
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 - Migratie 002 (AllStars FC seed) werkt nu correct: kolomnamen in `avg.Teambegeleiding` gecorrigeerd en VeldNummer-reeks aangepast naar 101-103 om PK-conflict met de primaire club te vermijden.
+- Club-selector in de topbalk selecteert nu automatisch de juiste primaire club (op basis van `SyncEnabled=1`) in plaats van altijd de eerste club in de lijst. Brede selector, het "Club:"-voorvoegsel is verwijderd.
+- Wisselen van club in de topbalk werkt nu correct: alle pagina's (Dashboard, Instellingen, Thema, Voorkeurstijden, Speeltijden, E-mailtemplates, Teambegeleiding, Leermomenten) laden hun data automatisch opnieuw zodra de beheerder van club wisselt.
 
 ---
 

--- a/FunctionApp/Admin/AdminClubsFunction.cs
+++ b/FunctionApp/Admin/AdminClubsFunction.cs
@@ -30,7 +30,7 @@ public static class AdminClubsFunction
             await connection.OpenAsync();
 
             using var command = new SqlCommand(@"
-                SELECT [ClubCode], [ClubName]
+                SELECT [ClubCode], [ClubName], [SyncEnabled]
                 FROM [dbo].[AppSettings]
                 ORDER BY [SyncEnabled] DESC, [ClubName]",
                 connection);
@@ -42,7 +42,8 @@ public static class AdminClubsFunction
                 clubs.Add(new
                 {
                     clubCode = reader.GetString(0),
-                    clubName = reader.GetString(1)
+                    clubName = reader.GetString(1),
+                    syncEnabled = !reader.IsDBNull(2) && reader.GetBoolean(2)
                 });
             }
 


### PR DESCRIPTION
## Samenvatting

Sluit #342 en #341.

**#342 — Club wisselen propageert niet naar pagina's:**
Alle datapagina's (Home, Instellingen, Thema, Speeltijden, Voorkeurstijden, EmailTemplates, Teambegeleiding, Leermomenten) abonneren nu op `ClubSelector.OnChange` via `IDisposable`. Bij clubwissel laden ze hun data automatisch opnieuw.

**#341 — Club-selector selecteert verkeerde standaard club:**
`GET /api/beheer/clubs` retourneert nu ook `SyncEnabled`. `MainLayout` kiest de club met `SyncEnabled=1` als standaard in plaats van altijd `_clubs[0]`. Het "Club:"-label is verwijderd en de selector is verbreed naar 200px.

## Test plan

- [ ] Debug omgeving starten met twee clubs (primaire + AllStars FC)
- [ ] Controleer dat na laden de primaire club (SyncEnabled=1) geselecteerd is
- [ ] Schakel naar AllStars FC — controleer dat Dashboard data herlaadt
- [ ] Navigeer naar Instellingen, Thema, Voorkeurstijden — elk laadt data van AllStars FC
- [ ] Schakel terug naar primaire club — data toont primaire club
- [ ] CI groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)