### PR TITLE
fix(#338): thema-pagina UX — 4 knelpunten opgelost

### DIFF
--- a/BlazorAdmin/Pages/Thema.razor
+++ b/BlazorAdmin/Pages/Thema.razor
@@ -79,10 +79,40 @@ else
 
                     <div class="mb-3">
                         <label class="form-label fw-semibold">Club-website URL</label>
-                        <input type="url" class="form-control" placeholder="https://www.mijnclub.nl"
-                               @bind="_theme.ClubWebsiteUrl" @bind:event="oninput" />
-                        <small class="text-muted">Voor kleurextractie hieronder</small>
+                        <div class="input-group">
+                            <input type="url" class="form-control" placeholder="https://www.mijnclub.nl"
+                                   @bind="_theme.ClubWebsiteUrl" @bind:event="oninput" />
+                            <button class="btn btn-outline-secondary" type="button" @onclick="ExtractColorsAsync"
+                                    disabled="@(_extracting || string.IsNullOrWhiteSpace(_theme.ClubWebsiteUrl))">
+                                @if (_extracting) { <span class="spinner-border spinner-border-sm me-1"></span> }
+                                Kleuren ophalen
+                            </button>
+                        </div>
+                        @if (_extractError != null)
+                        {
+                            <div class="alert alert-warning mt-2">@_extractError</div>
+                        }
+                        @if (_extractedColors.Count > 0)
+                        {
+                            <div class="mt-2">
+                                <p class="small mb-1">Klik op een kleur om deze als primaire kleur in te stellen:</p>
+                                <div class="d-flex flex-wrap gap-2">
+                                    @foreach (var color in _extractedColors)
+                                    {
+                                        var capturedColor = color;
+                                        <div class="d-flex flex-column align-items-center">
+                                            <div style="width:40px; height:40px; background-color:@capturedColor; border:1px solid #dee2e6; border-radius:4px; cursor:pointer;"
+                                                 title="@capturedColor"
+                                                 @onclick='() => OnColorChange("primary", capturedColor)'></div>
+                                            <small style="font-size:0.65rem;">@capturedColor</small>
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                        }
                     </div>
+
+                    <hr class="my-3" />
 
                     <div class="d-flex gap-2 align-items-center">
                         <button class="btn btn-primary" @onclick="SaveAsync" disabled="@_saving">
@@ -111,7 +141,7 @@ else
                         <button class="btn btn-primary me-2" style="background-color: @_theme.Primary; border-color: @_theme.Primary; color: @_theme.TextOnPrimary;">
                             Primaire knop
                         </button>
-                        <button class="btn btn-outline-secondary me-2">Secundaire knop</button>
+                        <button class="btn btn-outline-secondary me-2" style="color: @_theme.Secondary; border-color: @_theme.Secondary;">Secundaire knop</button>
                         <a href="#" style="color: @_theme.Accent;">Link</a>
                     </div>
                     <div style="padding: 0.5rem 1rem; background: #f8f9fa;">
@@ -119,44 +149,6 @@ else
                     </div>
                 </div>
             </div>
-
-            @if (!string.IsNullOrWhiteSpace(_theme.ClubWebsiteUrl))
-            {
-                <div class="card mb-4">
-                    <div class="card-header">Kleuren extraheren uit club-website</div>
-                    <div class="card-body">
-                        <p class="text-muted small">Haal kleuraccenten op uit de HTML van de club-website.</p>
-                        <button class="btn btn-outline-primary" @onclick="ExtractColorsAsync" disabled="@_extracting">
-                            @if (_extracting) { <span class="spinner-border spinner-border-sm me-1"></span> }
-                            Kleuren ophalen
-                        </button>
-
-                        @if (_extractError != null)
-                        {
-                            <div class="alert alert-warning mt-2">@_extractError</div>
-                        }
-
-                        @if (_extractedColors.Count > 0)
-                        {
-                            <div class="mt-3">
-                                <p class="small mb-2">Klik op een kleur om deze als primaire kleur in te stellen:</p>
-                                <div class="d-flex flex-wrap gap-2">
-                                    @foreach (var color in _extractedColors)
-                                    {
-                                        var capturedColor = color;
-                                        <div class="d-flex flex-column align-items-center">
-                                            <div style="width:40px; height:40px; background-color:@capturedColor; border:1px solid #dee2e6; border-radius:4px; cursor:pointer;"
-                                                 title="@capturedColor"
-                                                 @onclick='() => OnColorChange("primary", capturedColor)'></div>
-                                            <small style="font-size:0.65rem;">@capturedColor</small>
-                                        </div>
-                                    }
-                                </div>
-                            </div>
-                        }
-                    </div>
-                </div>
-            }
         </div>
     </div>
 }
@@ -196,6 +188,9 @@ else
     private void OnColorChange(string property, string? value)
     {
         if (string.IsNullOrWhiteSpace(value)) return;
+        // Auto-prepend # for bare 6-digit hex strings (e.g. "1b6ec2" → "#1b6ec2")
+        if (value.Length == 6 && System.Text.RegularExpressions.Regex.IsMatch(value, "^[0-9a-fA-F]{6}$"))
+            value = "#" + value;
         switch (property)
         {
             case "primary":       _theme.Primary = value; break;
@@ -204,6 +199,7 @@ else
             case "textOnPrimary": _theme.TextOnPrimary = value; break;
         }
         _ = ThemeService.ApplyAsync(_theme);
+        StateHasChanged();
     }
 
     private async Task SaveAsync()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Migratie 002 (AllStars FC seed) werkt nu correct: kolomnamen in `avg.Teambegeleiding` gecorrigeerd en VeldNummer-reeks aangepast naar 101-103 om PK-conflict met de primaire club te vermijden.
 - Club-selector in de topbalk selecteert nu automatisch de juiste primaire club (op basis van `SyncEnabled=1`) in plaats van altijd de eerste club in de lijst. Brede selector, het "Club:"-voorvoegsel is verwijderd.
 - Wisselen van club in de topbalk werkt nu correct: alle pagina's (Dashboard, Instellingen, Thema, Voorkeurstijden, Speeltijden, E-mailtemplates, Teambegeleiding, Leermomenten) laden hun data automatisch opnieuw zodra de beheerder van club wisselt.
+- Thema-pagina UX (#338): 'Kleuren ophalen' staat nu naast het URL-veld als input-groep; 'Opslaan' is duidelijk los van de URL-sectie geplaatst met een scheidingslijn; secundaire kleur-preview werkt nu correct real-time; HEX-waarde zonder `#`-prefix (bijv. `1b6ec2`) wordt automatisch aangevuld.
 
 ---
 


### PR DESCRIPTION
## Samenvatting

Sluit #338.

**4 UX-knelpunten opgelost:**
1. **Kleuren ophalen** staat nu als input-group naast het URL-veld — niet meer in een aparte kaart
2. **Opslaan**-knop gescheiden van URL-sectie via `<hr>` — duidelijk als globale actie
3. **Secundaire kleur preview** reflecteert nu live de gekozen kleur (`style="color:@_theme.Secondary; border-color:@_theme.Secondary;"`) + `StateHasChanged()` forceer herrender
4. **HEX zonder `#`**: `1b6ec2` wordt automatisch `#1b6ec2` via regex in `OnColorChange`

## Test plan

- [ ] URL-veld + Kleuren ophalen naast elkaar zichtbaar
- [ ] Secundaire kleur aanpassen → preview-knop update direct
- [ ] Plakken van `1b6ec2` (zonder #) → veld wordt `#1b6ec2`
- [ ] Opslaan-knop duidelijk los van URL-sectie
- [ ] CI groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)