### PR TITLE
feat(#340): Bootstrap Icons + collapsible Instellingen submenu + Opslaan rechtsboven

### DIFF
--- a/BlazorAdmin/Layout/NavMenu.razor
+++ b/BlazorAdmin/Layout/NavMenu.razor
@@ -1,5 +1,7 @@
 @inject IAuthService Auth
 @inject BlazorAdmin.Services.AdminApiClient Api
+@inject NavigationManager Navigation
+@implements IDisposable
 
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
@@ -14,53 +16,67 @@
     <nav class="nav flex-column">
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="" Match="NavLinkMatch.All">
-                <span class="bi bi-house-door-fill-nav-menu" aria-hidden="true"></span> Dashboard
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="instellingen">
-                <span class="bi bi-gear-fill-nav-menu" aria-hidden="true"></span> Instellingen
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="instellingen/thema">
-                <span class="bi bi-palette-fill-nav-menu" aria-hidden="true"></span> Thema
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="email-templates">
-                <span class="bi bi-envelope-fill-nav-menu" aria-hidden="true"></span> E-mailtemplates
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="voorkeurstijden">
-                <span class="bi bi-clock-fill-nav-menu" aria-hidden="true"></span> Voorkeurstijden
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="instellingen/speeltijden">
-                <span class="bi bi-stopwatch-fill-nav-menu" aria-hidden="true"></span> Speeltijden
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="teambegeleiding">
-                <span class="bi bi-people-fill-nav-menu" aria-hidden="true"></span> Teambegeleiding
+                <i class="bi bi-speedometer2 me-1" aria-hidden="true"></i> Dashboard
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="dagplanning">
-                <span class="bi bi-calendar2-week-fill-nav-menu" aria-hidden="true"></span> Dagplanning
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="email-tester">
-                <span class="bi bi-bug-fill-nav-menu" aria-hidden="true"></span> Email-tester
+                <i class="bi bi-calendar-week me-1" aria-hidden="true"></i> Dagplanning
             </NavLink>
         </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="leermomenten">
-                <span class="bi bi-lightbulb-fill-nav-menu" aria-hidden="true"></span> Leermomenten
+                <i class="bi bi-lightbulb me-1" aria-hidden="true"></i> Leermomenten
             </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="email-tester">
+                <i class="bi bi-envelope-check me-1" aria-hidden="true"></i> Email-tester
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="teambegeleiding">
+                <i class="bi bi-people me-1" aria-hidden="true"></i> Teambegeleiding
+            </NavLink>
+        </div>
+
+        @* Collapsible Instellingen submenu *@
+        <div class="nav-item px-3">
+            <button class="nav-link btn btn-link text-start w-100 d-flex justify-content-between align-items-center px-0 py-1"
+                    @onclick="ToggleInstellingen" @onclick:stopPropagation="true">
+                <span><i class="bi bi-gear me-1" aria-hidden="true"></i> Instellingen</span>
+                <i class="bi @(_instellingenOpen ? "bi-chevron-down" : "bi-chevron-right") ms-1 small" aria-hidden="true"></i>
+            </button>
+            @if (_instellingenOpen)
+            {
+                <div class="ps-2">
+                    <div class="nav-item">
+                        <NavLink class="nav-link py-1" href="instellingen" Match="NavLinkMatch.All">
+                            <i class="bi bi-sliders me-1" aria-hidden="true"></i> Instellingen
+                        </NavLink>
+                    </div>
+                    <div class="nav-item">
+                        <NavLink class="nav-link py-1" href="instellingen/speeltijden">
+                            <i class="bi bi-clock me-1" aria-hidden="true"></i> Speeltijden
+                        </NavLink>
+                    </div>
+                    <div class="nav-item">
+                        <NavLink class="nav-link py-1" href="voorkeurstijden">
+                            <i class="bi bi-clock-history me-1" aria-hidden="true"></i> Voorkeurstijden
+                        </NavLink>
+                    </div>
+                    <div class="nav-item">
+                        <NavLink class="nav-link py-1" href="email-templates">
+                            <i class="bi bi-file-text me-1" aria-hidden="true"></i> E-mailtemplates
+                        </NavLink>
+                    </div>
+                    <div class="nav-item">
+                        <NavLink class="nav-link py-1" href="instellingen/thema">
+                            <i class="bi bi-palette me-1" aria-hidden="true"></i> Thema
+                        </NavLink>
+                    </div>
+                </div>
+            }
         </div>
 
         @if (Auth.IsAuthenticated)
@@ -75,18 +91,37 @@
 
 @code {
     private bool collapseNavMenu = true;
+    private bool _instellingenOpen;
     private string? _clubName;
 
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 
+    private static readonly string[] InstellingenRoutes = ["/instellingen", "/voorkeurstijden", "/email-templates"];
+
     protected override async Task OnInitializedAsync()
     {
+        _instellingenOpen = IsInstellingenRoute(Navigation.Uri);
+        Navigation.LocationChanged += OnLocationChanged;
+
         var result = await Api.GetSettingsAsync();
         if (result.Success && !string.IsNullOrWhiteSpace(result.Data?.ClubName))
             _clubName = result.Data.ClubName;
     }
 
+    public void Dispose() => Navigation.LocationChanged -= OnLocationChanged;
+
+    private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
+    {
+        if (IsInstellingenRoute(e.Location))
+            _instellingenOpen = true;
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private static bool IsInstellingenRoute(string uri) =>
+        InstellingenRoutes.Any(r => uri.Contains(r, StringComparison.OrdinalIgnoreCase));
+
     private void ToggleNavMenu() => collapseNavMenu = !collapseNavMenu;
+    private void ToggleInstellingen() => _instellingenOpen = !_instellingenOpen;
 
     private async Task LogoutAsync() => await Auth.LogoutAsync();
 }

--- a/BlazorAdmin/Pages/Instellingen.razor
+++ b/BlazorAdmin/Pages/Instellingen.razor
@@ -7,7 +7,15 @@
 
 <PageTitle>Instellingen — VRC Admin</PageTitle>
 
-<h1>Instellingen</h1>
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <h1 class="mb-0">Instellingen</h1>
+    @if (settings != null && string.IsNullOrEmpty(errorMessage))
+    {
+        <button type="submit" form="settings-form" class="btn btn-primary" disabled="@saving">
+            @(saving ? "Opslaan..." : "Opslaan")
+        </button>
+    }
+</div>
 
 @if (settings == null && string.IsNullOrEmpty(errorMessage))
 {
@@ -19,7 +27,7 @@ else if (!string.IsNullOrEmpty(errorMessage))
 }
 else
 {
-    <EditForm Model="settings" OnValidSubmit="OpslaanAsync">
+    <EditForm Model="settings" OnValidSubmit="OpslaanAsync" id="settings-form">
         <div class="row">
             <div class="col-md-6 mb-3">
                 <label class="form-label">Clubnaam</label>

--- a/BlazorAdmin/Pages/Thema.razor
+++ b/BlazorAdmin/Pages/Thema.razor
@@ -8,8 +8,19 @@
 
 <PageTitle>Club-thema — Sportlink Admin</PageTitle>
 
-<h1>Club-thema</h1>
-<p class="text-muted mb-4">Pas de huidige kleuren van de beheer-interface aan op de huisstijl van de club.</p>
+<div class="d-flex justify-content-between align-items-center mb-3">
+    <div>
+        <h1 class="mb-0">Club-thema</h1>
+        <p class="text-muted mb-0">Pas de huidige kleuren van de beheer-interface aan op de huisstijl van de club.</p>
+    </div>
+    @if (!_loading && _error == null)
+    {
+        <button class="btn btn-primary" @onclick="SaveAsync" disabled="@_saving">
+            @if (_saving) { <span class="spinner-border spinner-border-sm me-1"></span> }
+            Opslaan
+        </button>
+    }
+</div>
 
 @if (_loading)
 {

--- a/BlazorAdmin/wwwroot/index.html
+++ b/BlazorAdmin/wwwroot/index.html
@@ -8,6 +8,7 @@
     <base href="/" />
     <link rel="preload" id="webassembly" />
     <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="BlazorAdmin.styles.css" rel="stylesheet" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Added
+- Navigatiemenu toont nu iconen (Bootstrap Icons) bij elk menu-item.
+- Navigatiemenu is geherstructureerd: Dagplanning, Leermomenten, Email-tester en Teambegeleiding staan bovenaan; Instellingen, Speeltijden, Voorkeurstijden, E-mailtemplates en Thema zijn samengebracht onder een inklapbaar 'Instellingen'-submenu dat automatisch openklapt zodra de beheerder een van die pagina's bezoekt.
+- Instellingen-pagina heeft nu een 'Opslaan'-knop rechtsboven naast de paginatitel, zodat opslaan toegankelijk is zonder naar het einde van het formulier te scrollen.
+- Thema-pagina heeft nu een 'Opslaan'-knop rechtsboven naast de paginatitel.
+
 ---
 
 ## [2.4.1] — 2026-05-26


### PR DESCRIPTION
## Summary
- Bootstrap Icons CDN (v1.11.3) toegevoegd aan `index.html` — iconen zijn nu zichtbaar in het menu
- `NavMenu.razor` volledig herschreven: proper `bi bi-xxx` icon classes, nieuw menu-volgorde (Dashboard > Dagplanning > Leermomenten > Email-tester > Teambegeleiding > Instellingen[collapsible])
- Inklapbaar Instellingen-submenu (Instellingen, Speeltijden, Voorkeurstijden, E-mailtemplates, Thema) dat automatisch openklapt via `LocationChanged`
- `Instellingen.razor`: Opslaan-knop rechtsboven naast paginatitel via HTML5 `form=` attribuut
- `Thema.razor`: Opslaan-knop rechtsboven naast paginatitel

Closes #340
Closes #343

## Test plan
- [ ] Menu-iconen zichtbaar in zijbalk
- [ ] Instellingen-submenu klapt in/uit bij klikken op Instellingen
- [ ] Submenu klapt automatisch open bij navigatie naar sub-pagina
- [ ] Opslaan rechtsboven werkt op Instellingen-pagina
- [ ] Opslaan rechtsboven werkt op Thema-pagina

Generated with Claude Code