### PR TITLE
feat(#339): favicon + club-logo in thema; feat(#344): Dashboard herontwerp

### DIFF
--- a/BlazorAdmin/Layout/NavMenu.razor
+++ b/BlazorAdmin/Layout/NavMenu.razor
@@ -1,11 +1,18 @@
 @inject IAuthService Auth
 @inject BlazorAdmin.Services.AdminApiClient Api
+@inject BlazorAdmin.Services.ThemeService ThemeService
 @inject NavigationManager Navigation
 @implements IDisposable
 
 <div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="">@(_clubName ?? "Admin")</a>
+        <a class="navbar-brand d-flex align-items-center gap-2" href="">
+            @if (!string.IsNullOrWhiteSpace(ThemeService.LogoUrl))
+            {
+                <img src="@ThemeService.LogoUrl" alt="Club logo" style="height:28px; width:auto; object-fit:contain;" />
+            }
+            @(_clubName ?? "Admin")
+        </a>
         <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
             <span class="navbar-toggler-icon"></span>
         </button>
@@ -102,13 +109,20 @@
     {
         _instellingenOpen = IsInstellingenRoute(Navigation.Uri);
         Navigation.LocationChanged += OnLocationChanged;
+        ThemeService.OnThemeChanged += OnThemeChanged;
 
         var result = await Api.GetSettingsAsync();
         if (result.Success && !string.IsNullOrWhiteSpace(result.Data?.ClubName))
             _clubName = result.Data.ClubName;
     }
 
-    public void Dispose() => Navigation.LocationChanged -= OnLocationChanged;
+    public void Dispose()
+    {
+        Navigation.LocationChanged -= OnLocationChanged;
+        ThemeService.OnThemeChanged -= OnThemeChanged;
+    }
+
+    private void OnThemeChanged() => _ = InvokeAsync(StateHasChanged);
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {

--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -246,7 +246,7 @@ public class LeermomentenStatsDto
     public int Rejected { get; set; }
 }
 
-// Thema (#325)
+// Thema (#325, #339)
 public class ThemeDto
 {
     public string Primary       { get; set; } = "#1b6ec2";
@@ -254,11 +254,15 @@ public class ThemeDto
     public string Accent        { get; set; } = "#0071c1";
     public string TextOnPrimary { get; set; } = "#ffffff";
     public string? ClubWebsiteUrl { get; set; }
+    public string? FaviconUrl   { get; set; }
+    public string? LogoUrl      { get; set; }
 }
 
 public class ThemeExtractResultDto
 {
-    public List<string> Colors { get; set; } = new();
+    public List<string> Colors    { get; set; } = new();
+    public string?      FaviconUrl { get; set; }
+    public string?      LogoUrl    { get; set; }
 }
 
 // Multi-club (#324)

--- a/BlazorAdmin/Pages/Home.razor
+++ b/BlazorAdmin/Pages/Home.razor
@@ -1,180 +1,74 @@
 @page "/"
-@inject AdminApiClient Api
-@inject ClubSelectorService ClubSelector
+@inject ThemeService ThemeService
 @using BlazorAdmin.Services
 @implements IDisposable
 
-<PageTitle>Dashboard — VRC Admin</PageTitle>
+<PageTitle>Dashboard — Sportlink Admin</PageTitle>
+
+@if (!string.IsNullOrWhiteSpace(ThemeService.LogoUrl))
+{
+    <div class="mb-4 text-center">
+        <img src="@ThemeService.LogoUrl" alt="Club logo" style="max-height:80px; max-width:240px; object-fit:contain;" />
+    </div>
+}
 
 <h1>Dashboard</h1>
+<p class="text-muted mb-4">Welkom in de beheeromgeving. Kies een functie om te beginnen.</p>
 
-<div class="row mt-4">
-    <div class="col-md-6">
-        <div class="card shadow-sm">
-            <div class="card-body">
-                <h5 class="card-title">Synchronisatie</h5>
-                @if (loading)
-                {
-                    <p class="text-muted">Laden...</p>
-                }
-                else if (status == null)
-                {
-                    <p class="text-danger">Kon synchronisatiestatus niet ophalen.</p>
-                }
-                else
-                {
-                    <p>
-                        <strong>Laatste sync:</strong>
-                        @(status.LastSyncTimestamp.HasValue
-                              ? status.LastSyncTimestamp.Value.ToLocalTime().ToString("dd-MM-yyyy HH:mm")
-                              : "nog niet uitgevoerd")
-                    </p>
-                    <p>
-                        <strong>Synchronisatieschema:</strong> @CronNaarNederlands(status.FetchSchedule)
-                        <small class="text-muted ms-1">(<code>@status.FetchSchedule</code>)</small>
-                    </p>
-                    <p>
-                        <strong>Status:</strong>
-                        <span class="badge @(status.Status == "ok" ? "bg-success" : "bg-warning")">
-                            @status.Status
-                        </span>
-                    </p>
-                }
-
-                <button class="btn btn-primary" @onclick="TriggerSyncAsync" disabled="@(syncing)">
-                    @(syncing ? "Synchroniseren..." : "Nu synchroniseren")
-                </button>
-                @if (!string.IsNullOrEmpty(syncResult))
-                {
-                    <div class="alert alert-info mt-3">@syncResult</div>
-                }
+<div class="row g-3 mt-2">
+    <div class="col-sm-6 col-xl-3">
+        <a href="dagplanning" class="text-decoration-none">
+            <div class="card h-100 shadow-sm border-0 dashboard-card">
+                <div class="card-body d-flex flex-column align-items-center text-center p-4">
+                    <i class="bi bi-calendar-week dashboard-card-icon mb-3" aria-hidden="true"></i>
+                    <h5 class="card-title mb-1">Dagplanning</h5>
+                    <p class="card-text text-muted small mb-0">Plan wedstrijden in en beheer de veldindeling voor een speeldag.</p>
+                </div>
             </div>
-        </div>
+        </a>
     </div>
-
-    <div class="col-md-6">
-        <div class="card shadow-sm">
-            <div class="card-body">
-                <h5 class="card-title">Email verwerking (laatste 24u)</h5>
-                @if (emailLog == null)
-                {
-                    <p class="text-muted">Laden...</p>
-                }
-                else
-                {
-                    <p><strong>Verwerkt:</strong> @verwerkt</p>
-                    <p><strong>Fouten:</strong> @fouten</p>
-                    <p><strong>Buiten scope:</strong> @buitenScope</p>
-                }
+    <div class="col-sm-6 col-xl-3">
+        <a href="leermomenten" class="text-decoration-none">
+            <div class="card h-100 shadow-sm border-0 dashboard-card">
+                <div class="card-body d-flex flex-column align-items-center text-center p-4">
+                    <i class="bi bi-lightbulb dashboard-card-icon mb-3" aria-hidden="true"></i>
+                    <h5 class="card-title mb-1">Leermomenten</h5>
+                    <p class="card-text text-muted small mb-0">Valideer AI-classificatiecorrecties om het systeem te verbeteren.</p>
+                </div>
             </div>
-        </div>
+        </a>
+    </div>
+    <div class="col-sm-6 col-xl-3">
+        <a href="email-tester" class="text-decoration-none">
+            <div class="card h-100 shadow-sm border-0 dashboard-card">
+                <div class="card-body d-flex flex-column align-items-center text-center p-4">
+                    <i class="bi bi-envelope-check dashboard-card-icon mb-3" aria-hidden="true"></i>
+                    <h5 class="card-title mb-1">Email-tester</h5>
+                    <p class="card-text text-muted small mb-0">Test de e-mailverwerking en verstuur testberichten vanuit de beheeromgeving.</p>
+                </div>
+            </div>
+        </a>
+    </div>
+    <div class="col-sm-6 col-xl-3">
+        <a href="teambegeleiding" class="text-decoration-none">
+            <div class="card h-100 shadow-sm border-0 dashboard-card">
+                <div class="card-body d-flex flex-column align-items-center text-center p-4">
+                    <i class="bi bi-people dashboard-card-icon mb-3" aria-hidden="true"></i>
+                    <h5 class="card-title mb-1">Teambegeleiding</h5>
+                    <p class="card-text text-muted small mb-0">Bekijk en beheer de contactgegevens van teambegeleid&shy;ers.</p>
+                </div>
+            </div>
+        </a>
     </div>
 </div>
 
 @code {
-    private SyncStatusDto? status;
-    private EmailLogResponse? emailLog;
-    private bool loading = true;
-    private bool syncing;
-    private string? syncResult;
-    private int verwerkt, fouten, buitenScope;
-
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
-        ClubSelector.OnChange += OnClubChanged;
-        await LoadAsync();
+        ThemeService.OnThemeChanged += OnThemeChanged;
     }
 
-    private void OnClubChanged() => _ = InvokeAsync(async () => { await LoadAsync(); StateHasChanged(); });
-    public void Dispose() => ClubSelector.OnChange -= OnClubChanged;
+    public void Dispose() => ThemeService.OnThemeChanged -= OnThemeChanged;
 
-    private async Task LoadAsync()
-    {
-        loading = true;
-        var statusResult = await Api.GetSyncStatusAsync();
-        if (statusResult.Success) status = statusResult.Data;
-
-        var vanaf = DateTime.Today.AddDays(-1);
-        var logResult = await Api.GetEmailLogAsync(vanaf: vanaf, limit: 200);
-        if (logResult.Success)
-        {
-            emailLog = logResult.Data;
-            if (emailLog?.Items != null)
-            {
-                verwerkt = emailLog.Items.Count(i => i.Status == "AntwoordVerstuurd");
-                fouten = emailLog.Items.Count(i => i.Status == "Fout");
-                buitenScope = emailLog.Items.Count(i => i.Status == "BuitenScope");
-            }
-        }
-        loading = false;
-    }
-
-    private async Task TriggerSyncAsync()
-    {
-        syncing = true;
-        syncResult = null;
-
-        var timestampVoor = status?.LastSyncTimestamp;
-
-        var r = await Api.TriggerSyncAsync();
-        if (!r.Success)
-        {
-            syncResult = $"Sync starten mislukt: {r.ErrorMessage}";
-            syncing = false;
-            return;
-        }
-
-        // 202 Accepted: sync draait op achtergrond — poll tot LastSyncTimestamp wijzigt
-        syncResult = "Synchronisatie gestart, even geduld…";
-        StateHasChanged();
-
-        var deadline = DateTime.UtcNow.AddMinutes(10);
-        while (DateTime.UtcNow < deadline)
-        {
-            await Task.Delay(5000);
-            var statusResult = await Api.GetSyncStatusAsync();
-            if (statusResult.Success && statusResult.Data?.LastSyncTimestamp != timestampVoor)
-            {
-                status = statusResult.Data;
-                syncResult = "Synchronisatie voltooid.";
-                syncing = false;
-                StateHasChanged();
-                return;
-            }
-        }
-
-        // Na 10 min nog geen wijziging — sync loopt waarschijnlijk nog door
-        syncResult = "Synchronisatie loopt op de achtergrond. Herlaad de pagina later voor de actuele status.";
-        syncing = false;
-        await LoadAsync();
-    }
-
-    // Azure Functions cron: {seconde} {minuut} {uur} {dag} {maand} {weekdag}
-    private static string CronNaarNederlands(string? cron)
-    {
-        if (string.IsNullOrWhiteSpace(cron)) return "Onbekend schema";
-        var p = cron.Trim().Split(' ');
-        if (p.Length != 6) return cron;
-
-        var (sec, min, hour, day, month, weekday) = (p[0], p[1], p[2], p[3], p[4], p[5]);
-
-        if (sec == "0" && day == "*" && month == "*" && weekday == "*")
-        {
-            if (int.TryParse(hour, out var h) && int.TryParse(min, out var m))
-                return m == 0 ? $"Elke dag om {h:D2}:00" : $"Elke dag om {h:D2}:{m:D2}";
-        }
-
-        if (sec == "0" && min == "0" && hour == "*" && day == "*" && month == "*" && weekday == "*")
-            return "Elk uur";
-
-        string[] dagNamen = { "", "maandag", "dinsdag", "woensdag", "donderdag", "vrijdag", "zaterdag", "zondag" };
-        if (sec == "0" && min == "0" && day == "*" && month == "*"
-            && int.TryParse(hour, out var h2) && int.TryParse(weekday, out var wd) && wd >= 0 && wd <= 7)
-        {
-            var dag = wd == 0 ? dagNamen[7] : wd < dagNamen.Length ? dagNamen[wd] : $"dag {wd}";
-            return $"Elke {dag} om {h2:D2}:00";
-        }
-
-        return cron;
-    }
+    private void OnThemeChanged() => _ = InvokeAsync(StateHasChanged);
 }

--- a/BlazorAdmin/Pages/Instellingen.razor
+++ b/BlazorAdmin/Pages/Instellingen.razor
@@ -17,6 +17,70 @@
     }
 </div>
 
+@* ── Synchronisatie (verplaatst van Dashboard #344) ── *@
+<div class="row mb-4">
+    <div class="col-md-6">
+        <div class="card shadow-sm h-100">
+            <div class="card-body">
+                <h5 class="card-title">Synchronisatie</h5>
+                @if (_syncLoading)
+                {
+                    <p class="text-muted">Laden...</p>
+                }
+                else if (_status == null)
+                {
+                    <p class="text-danger">Kon synchronisatiestatus niet ophalen.</p>
+                }
+                else
+                {
+                    <p>
+                        <strong>Laatste sync:</strong>
+                        @(_status.LastSyncTimestamp.HasValue
+                              ? _status.LastSyncTimestamp.Value.ToLocalTime().ToString("dd-MM-yyyy HH:mm")
+                              : "nog niet uitgevoerd")
+                    </p>
+                    <p>
+                        <strong>Schema:</strong> @CronNaarNederlands(_status.FetchSchedule)
+                        <small class="text-muted ms-1">(<code>@_status.FetchSchedule</code>)</small>
+                    </p>
+                    <p>
+                        <strong>Status:</strong>
+                        <span class="badge @(_status.Status == "ok" ? "bg-success" : "bg-warning")">
+                            @_status.Status
+                        </span>
+                    </p>
+                }
+                <button class="btn btn-primary btn-sm" @onclick="TriggerSyncAsync" disabled="@(_syncing)">
+                    @(_syncing ? "Synchroniseren..." : "Nu synchroniseren")
+                </button>
+                @if (!string.IsNullOrEmpty(_syncResult))
+                {
+                    <div class="alert alert-info mt-3">@_syncResult</div>
+                }
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="card shadow-sm h-100">
+            <div class="card-body">
+                <h5 class="card-title">Email verwerking (laatste 24u)</h5>
+                @if (_emailLog == null && !_syncLoading)
+                {
+                    <p class="text-muted">Niet beschikbaar.</p>
+                }
+                else if (_emailLog != null)
+                {
+                    <p><strong>Verwerkt:</strong> @_emailVerwerkt</p>
+                    <p><strong>Fouten:</strong> @_emailFouten</p>
+                    <p><strong>Buiten scope:</strong> @_emailBuitenScope</p>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+<hr class="mb-4" />
+
 @if (settings == null && string.IsNullOrEmpty(errorMessage))
 {
     <p class="text-muted">Laden...</p>
@@ -249,6 +313,14 @@ else
     private UitgeslotenEmailAdresDto? nieuwAdres;
     private string? uitgeslotenMessage;
 
+    // Sync + email log (verplaatst van Dashboard #344)
+    private SyncStatusDto? _status;
+    private EmailLogResponse? _emailLog;
+    private bool _syncLoading = true;
+    private bool _syncing;
+    private string? _syncResult;
+    private int _emailVerwerkt, _emailFouten, _emailBuitenScope;
+
     protected override async Task OnInitializedAsync()
     {
         ClubSelector.OnChange += OnClubChanged;
@@ -261,10 +333,91 @@ else
     private async Task LoadAsync()
     {
         errorMessage = null;
-        var r = await Api.GetSettingsAsync();
+        _syncLoading = true;
+
+        var settingsTask = Api.GetSettingsAsync();
+        var syncTask    = Api.GetSyncStatusAsync();
+        var emailTask   = Api.GetEmailLogAsync(vanaf: DateTime.Today.AddDays(-1), limit: 200);
+
+        await Task.WhenAll(settingsTask, syncTask, emailTask);
+
+        var r = await settingsTask;
         if (r.Success) settings = r.Data;
         else errorMessage = r.ErrorMessage;
+
+        var syncResult = await syncTask;
+        if (syncResult.Success) _status = syncResult.Data;
+
+        var emailResult = await emailTask;
+        if (emailResult.Success)
+        {
+            _emailLog = emailResult.Data;
+            if (_emailLog?.Items != null)
+            {
+                _emailVerwerkt    = _emailLog.Items.Count(i => i.Status == "AntwoordVerstuurd");
+                _emailFouten      = _emailLog.Items.Count(i => i.Status == "Fout");
+                _emailBuitenScope = _emailLog.Items.Count(i => i.Status == "BuitenScope");
+            }
+        }
+
+        _syncLoading = false;
         await LaadUitgeslotenEmailsAsync();
+    }
+
+    private async Task TriggerSyncAsync()
+    {
+        _syncing = true;
+        _syncResult = null;
+        var timestampVoor = _status?.LastSyncTimestamp;
+        var r = await Api.TriggerSyncAsync();
+        if (!r.Success)
+        {
+            _syncResult = $"Sync starten mislukt: {r.ErrorMessage}";
+            _syncing = false;
+            return;
+        }
+        _syncResult = "Synchronisatie gestart, even geduld…";
+        StateHasChanged();
+        var deadline = DateTime.UtcNow.AddMinutes(10);
+        while (DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(5000);
+            var statusResult = await Api.GetSyncStatusAsync();
+            if (statusResult.Success && statusResult.Data?.LastSyncTimestamp != timestampVoor)
+            {
+                _status = statusResult.Data;
+                _syncResult = "Synchronisatie voltooid.";
+                _syncing = false;
+                StateHasChanged();
+                return;
+            }
+        }
+        _syncResult = "Synchronisatie loopt op de achtergrond. Herlaad de pagina later voor de actuele status.";
+        _syncing = false;
+        await LoadAsync();
+    }
+
+    private static string CronNaarNederlands(string? cron)
+    {
+        if (string.IsNullOrWhiteSpace(cron)) return "Onbekend schema";
+        var p = cron.Trim().Split(' ');
+        if (p.Length != 6) return cron;
+        var (sec, min, hour, day, month, weekday) = (p[0], p[1], p[2], p[3], p[4], p[5]);
+        if (sec == "0" && day == "*" && month == "*" && weekday == "*")
+        {
+            if (int.TryParse(hour, out var h) && int.TryParse(min, out var m))
+                return m == 0 ? $"Elke dag om {h:D2}:00" : $"Elke dag om {h:D2}:{m:D2}";
+        }
+        if (sec == "0" && min == "0" && hour == "*" && day == "*" && month == "*" && weekday == "*")
+            return "Elk uur";
+        string[] dagNamen = { "", "maandag", "dinsdag", "woensdag", "donderdag", "vrijdag", "zaterdag", "zondag" };
+        if (sec == "0" && min == "0" && day == "*" && month == "*"
+            && int.TryParse(hour, out var h2) && int.TryParse(weekday, out var wd) && wd >= 0 && wd <= 7)
+        {
+            var dag = wd == 0 ? dagNamen[7] : wd < dagNamen.Length ? dagNamen[wd] : $"dag {wd}";
+            return $"Elke {dag} om {h2:D2}:00";
+        }
+        return cron;
     }
 
     private async Task LaadUitgeslotenEmailsAsync()

--- a/BlazorAdmin/Pages/Thema.razor
+++ b/BlazorAdmin/Pages/Thema.razor
@@ -93,10 +93,10 @@ else
                         <div class="input-group">
                             <input type="url" class="form-control" placeholder="https://www.mijnclub.nl"
                                    @bind="_theme.ClubWebsiteUrl" @bind:event="oninput" />
-                            <button class="btn btn-outline-secondary" type="button" @onclick="ExtractColorsAsync"
+                            <button class="btn btn-outline-secondary" type="button" @onclick="ExtractFromWebsiteAsync"
                                     disabled="@(_extracting || string.IsNullOrWhiteSpace(_theme.ClubWebsiteUrl))">
                                 @if (_extracting) { <span class="spinner-border spinner-border-sm me-1"></span> }
-                                Kleuren ophalen
+                                Ophalen
                             </button>
                         </div>
                         @if (_extractError != null)
@@ -123,6 +123,40 @@ else
                         }
                     </div>
 
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Favicon URL</label>
+                        <input type="url" class="form-control" placeholder="https://www.mijnclub.nl/favicon.ico"
+                               @bind="_theme.FaviconUrl" @bind:event="oninput" />
+                        @if (!string.IsNullOrWhiteSpace(_extractedFaviconUrl))
+                        {
+                            <div class="mt-2 d-flex align-items-center gap-2">
+                                <img src="@_extractedFaviconUrl" alt="Favicon" style="width:24px;height:24px;object-fit:contain;" />
+                                <small class="text-muted">Gevonden favicon</small>
+                                <button class="btn btn-sm btn-outline-primary" type="button"
+                                        @onclick="() => { _theme.FaviconUrl = _extractedFaviconUrl; StateHasChanged(); }">
+                                    Gebruiken
+                                </button>
+                            </div>
+                        }
+                    </div>
+
+                    <div class="mb-3">
+                        <label class="form-label fw-semibold">Club-logo URL</label>
+                        <input type="url" class="form-control" placeholder="https://www.mijnclub.nl/logo.png"
+                               @bind="_theme.LogoUrl" @bind:event="oninput" />
+                        @if (!string.IsNullOrWhiteSpace(_extractedLogoUrl))
+                        {
+                            <div class="mt-2 d-flex align-items-center gap-2">
+                                <img src="@_extractedLogoUrl" alt="Logo" style="max-height:40px;max-width:80px;object-fit:contain;" />
+                                <small class="text-muted">Gevonden logo (OG-afbeelding)</small>
+                                <button class="btn btn-sm btn-outline-primary" type="button"
+                                        @onclick="() => { _theme.LogoUrl = _extractedLogoUrl; StateHasChanged(); }">
+                                    Gebruiken
+                                </button>
+                            </div>
+                        }
+                    </div>
+
                     <hr class="my-3" />
 
                     <div class="d-flex gap-2 align-items-center">
@@ -145,7 +179,11 @@ else
             <div class="card mb-4">
                 <div class="card-header">Live preview</div>
                 <div class="card-body p-0">
-                    <div style="background-color: @_theme.Primary; padding: 1rem;">
+                    <div style="background-color: @_theme.Primary; padding: 1rem; display:flex; align-items:center; gap:0.5rem;">
+                        @if (!string.IsNullOrWhiteSpace(_theme.LogoUrl))
+                        {
+                            <img src="@_theme.LogoUrl" alt="Logo" style="height:28px;width:auto;object-fit:contain;" />
+                        }
                         <span style="color: @_theme.TextOnPrimary; font-weight: bold;">Zijbalk achtergrond</span>
                     </div>
                     <div style="padding: 1rem;">
@@ -174,6 +212,8 @@ else
     private bool _saveSuccess;
     private string? _extractError;
     private List<string> _extractedColors = new();
+    private string? _extractedFaviconUrl;
+    private string? _extractedLogoUrl;
 
     protected override async Task OnInitializedAsync()
     {
@@ -227,22 +267,31 @@ else
 
     private async Task ResetToDefaultAsync()
     {
-        _theme = new ThemeDto();
+        _theme = new ThemeDto { FaviconUrl = null, LogoUrl = null };
         await ThemeService.ApplyAsync(_theme);
+        StateHasChanged();
     }
 
-    private async Task ExtractColorsAsync()
+    private async Task ExtractFromWebsiteAsync()
     {
         _extracting = true;
         _extractError = null;
         _extractedColors = new();
+        _extractedFaviconUrl = null;
+        _extractedLogoUrl = null;
         StateHasChanged();
 
         var result = await Api.ExtractThemeColorsAsync(_theme.ClubWebsiteUrl ?? "");
         if (result.Success && result.Data != null)
+        {
             _extractedColors = result.Data.Colors;
+            _extractedFaviconUrl = result.Data.FaviconUrl;
+            _extractedLogoUrl = result.Data.LogoUrl;
+        }
         else
-            _extractError = result.ErrorMessage ?? "Kleuren konden niet worden opgehaald.";
+        {
+            _extractError = result.ErrorMessage ?? "Ophalen mislukt.";
+        }
 
         _extracting = false;
     }

--- a/BlazorAdmin/Services/ThemeService.cs
+++ b/BlazorAdmin/Services/ThemeService.cs
@@ -4,12 +4,17 @@ using Microsoft.JSInterop;
 namespace BlazorAdmin.Services;
 
 /// <summary>
-/// Laadt het club-thema vanuit de API en past CSS-variabelen toe via JSInterop. v2 — #325.
+/// Laadt het club-thema vanuit de API en past CSS-variabelen + favicon toe via JSInterop. v2 — #325/#339.
 /// </summary>
 public class ThemeService
 {
     private readonly AdminApiClient _api;
     private readonly IJSRuntime _js;
+
+    public string? LogoUrl    { get; private set; }
+    public string? FaviconUrl { get; private set; }
+
+    public event Action? OnThemeChanged;
 
     public ThemeService(AdminApiClient api, IJSRuntime js)
     {
@@ -26,6 +31,9 @@ public class ThemeService
 
     public async Task ApplyAsync(ThemeDto theme)
     {
+        LogoUrl    = theme.LogoUrl;
+        FaviconUrl = theme.FaviconUrl;
+
         try
         {
             await _js.InvokeVoidAsync("themeHelper.apply",
@@ -33,10 +41,15 @@ public class ThemeService
                 theme.Secondary,
                 theme.Accent,
                 theme.TextOnPrimary);
+
+            if (!string.IsNullOrWhiteSpace(theme.FaviconUrl))
+                await _js.InvokeVoidAsync("themeHelper.setFavicon", theme.FaviconUrl);
         }
         catch
         {
             // JSInterop kan falen als WASM nog niet volledig geladen is — stilzwijgend negeren
         }
+
+        OnThemeChanged?.Invoke();
     }
 }

--- a/BlazorAdmin/wwwroot/css/app.css
+++ b/BlazorAdmin/wwwroot/css/app.css
@@ -176,6 +176,25 @@ code {
     to { transform: rotate(360deg); }
 }
 
+/* ── Dashboard quick-access cards (#344) ─────────────────────── */
+
+.dashboard-card {
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+    cursor: pointer;
+    color: inherit;
+}
+
+.dashboard-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, .12) !important;
+    color: var(--theme-primary);
+}
+
+.dashboard-card-icon {
+    font-size: 2.5rem;
+    color: var(--theme-primary);
+}
+
 /* Green checkmark */
 .startup-check {
     width: 3.5rem;

--- a/BlazorAdmin/wwwroot/js/theme.js
+++ b/BlazorAdmin/wwwroot/js/theme.js
@@ -5,5 +5,14 @@ window.themeHelper = {
         root.style.setProperty('--theme-secondary',       secondary);
         root.style.setProperty('--theme-accent',          accent);
         root.style.setProperty('--theme-text-on-primary', textOnPrimary);
+    },
+    setFavicon: function (url) {
+        var link = document.querySelector("link[rel='icon']");
+        if (!link) {
+            link = document.createElement('link');
+            link.rel = 'icon';
+            document.head.appendChild(link);
+        }
+        link.href = url;
     }
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Navigatiemenu is geherstructureerd: Dagplanning, Leermomenten, Email-tester en Teambegeleiding staan bovenaan; Instellingen, Speeltijden, Voorkeurstijden, E-mailtemplates en Thema zijn samengebracht onder een inklapbaar 'Instellingen'-submenu dat automatisch openklapt zodra de beheerder een van die pagina's bezoekt.
 - Instellingen-pagina heeft nu een 'Opslaan'-knop rechtsboven naast de paginatitel, zodat opslaan toegankelijk is zonder naar het einde van het formulier te scrollen.
 - Thema-pagina heeft nu een 'Opslaan'-knop rechtsboven naast de paginatitel.
+- Themabeheer uitgebreid: beheerders kunnen nu een favicon en club-logo opslaan via de Thema-pagina. De knop 'Ophalen' haalt kleuren, favicon én OG-afbeelding tegelijk op uit de club-website. Het favicon wordt direct in het browsertabblad toegepast; het logo verschijnt linksboven in de navigatiebalk naast de clubnaam. Nieuwe DB-velden `FaviconUrl` en `LogoUrl` op `dbo.AppSettings`.
+- Dashboard herontworpen: toont nu vier grote klikbare kaarten (Dagplanning, Leermomenten, Email-tester, Teambegeleiding) als snelkoppelingen, met optioneel club-logo bovenaan.
+- Synchronisatiestatus en emailverwerkingslog zijn verplaatst van het Dashboard naar de Instellingen-pagina (bovenaan, boven de configuratievelden).
 
 ---
 

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -116,6 +116,25 @@ BEGIN
 END
 GO
 
+-- AppSettings: FaviconUrl en LogoUrl toevoegen voor club-thema (#339, idempotent)
+IF NOT EXISTS (
+    SELECT 1 FROM [sys].[columns]
+    WHERE [object_id] = OBJECT_ID('[dbo].[AppSettings]') AND [name] = 'FaviconUrl'
+)
+BEGIN
+    ALTER TABLE [dbo].[AppSettings] ADD [FaviconUrl] NVARCHAR(2048) NULL
+END
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM [sys].[columns]
+    WHERE [object_id] = OBJECT_ID('[dbo].[AppSettings]') AND [name] = 'LogoUrl'
+)
+BEGIN
+    ALTER TABLE [dbo].[AppSettings] ADD [LogoUrl] NVARCHAR(2048) NULL
+END
+GO
+
 -- AppSettings: email-integratie velden vullen
 IF EXISTS (SELECT 1 FROM [dbo].[AppSettings] WHERE [PlannerAfzenderNaam] IS NULL)
 BEGIN

--- a/FunctionApp/Admin/AdminThemeFunction.cs
+++ b/FunctionApp/Admin/AdminThemeFunction.cs
@@ -19,8 +19,13 @@ namespace SportlinkFunction.Admin;
 public static class AdminThemeFunction
 {
     private static readonly HttpClient _httpClient;
-    private static readonly Regex _hexColorRegex = new(@"#([0-9a-fA-F]{6})\b", RegexOptions.Compiled);
+    private static readonly Regex _hexColorRegex    = new(@"#([0-9a-fA-F]{6})\b", RegexOptions.Compiled);
     private static readonly Regex _hexColorValidRegex = new(@"^#[0-9a-fA-F]{6}$", RegexOptions.Compiled);
+    private static readonly Regex _faviconRegex     = new(@"<link[^>]*rel=[""'](?:shortcut icon|icon)[""'][^>]*href=[""']([^""']+)[""']", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex _faviconAltRegex  = new(@"<link[^>]*href=[""']([^""']+)[""'][^>]*rel=[""'](?:shortcut icon|icon)[""']", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex _ogImageRegex     = new(@"<meta[^>]*property=[""']og:image[""'][^>]*content=[""']([^""']+)[""']", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex _ogImageAltRegex  = new(@"<meta[^>]*content=[""']([^""']+)[""'][^>]*property=[""']og:image[""']", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex _appleTouchRegex  = new(@"<link[^>]*rel=[""']apple-touch-icon[""'][^>]*href=[""']([^""']+)[""']", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     static AdminThemeFunction()
     {
@@ -44,7 +49,8 @@ public static class AdminThemeFunction
             await connection.OpenAsync();
             using var command = new SqlCommand(@"
                 SELECT [ThemeColorPrimary], [ThemeColorSecondary], [ThemeColorAccent],
-                       [ThemeColorTextOnPrimary], [ThemeClubWebsiteUrl]
+                       [ThemeColorTextOnPrimary], [ThemeClubWebsiteUrl],
+                       [FaviconUrl], [LogoUrl]
                 FROM [dbo].[AppSettings]
                 WHERE [ClubCode] = @ClubCode", connection);
             command.Parameters.AddWithValue("@ClubCode", clubCode);
@@ -58,7 +64,9 @@ public static class AdminThemeFunction
                 secondary      = reader.IsDBNull(1) ? "#6c757d" : reader.GetString(1),
                 accent         = reader.IsDBNull(2) ? "#0071c1" : reader.GetString(2),
                 textOnPrimary  = reader.IsDBNull(3) ? "#ffffff" : reader.GetString(3),
-                clubWebsiteUrl = reader.IsDBNull(4) ? ""        : reader.GetString(4)
+                clubWebsiteUrl = reader.IsDBNull(4) ? ""        : reader.GetString(4),
+                faviconUrl     = reader.IsDBNull(5) ? null      : reader.GetString(5),
+                logoUrl        = reader.IsDBNull(6) ? null      : reader.GetString(6)
             });
         }
         catch (Exception ex)
@@ -112,13 +120,17 @@ public static class AdminThemeFunction
                     [ThemeColorSecondary]      = @Secondary,
                     [ThemeColorAccent]         = @Accent,
                     [ThemeColorTextOnPrimary]  = @TextOnPrimary,
-                    [ThemeClubWebsiteUrl]      = @WebsiteUrl
+                    [ThemeClubWebsiteUrl]      = @WebsiteUrl,
+                    [FaviconUrl]               = @FaviconUrl,
+                    [LogoUrl]                  = @LogoUrl
                 WHERE [ClubCode]              = @ClubCode", connection);
             command.Parameters.AddWithValue("@Primary",        dto.Primary       ?? "#1b6ec2");
             command.Parameters.AddWithValue("@Secondary",      dto.Secondary     ?? "#6c757d");
             command.Parameters.AddWithValue("@Accent",         dto.Accent        ?? "#0071c1");
             command.Parameters.AddWithValue("@TextOnPrimary",  dto.TextOnPrimary ?? "#ffffff");
             command.Parameters.AddWithValue("@WebsiteUrl",     (object?)dto.ClubWebsiteUrl ?? DBNull.Value);
+            command.Parameters.AddWithValue("@FaviconUrl",     (object?)dto.FaviconUrl     ?? DBNull.Value);
+            command.Parameters.AddWithValue("@LogoUrl",        (object?)dto.LogoUrl        ?? DBNull.Value);
             command.Parameters.AddWithValue("@ClubCode",       clubCode);
             await command.ExecuteNonQueryAsync();
 
@@ -157,8 +169,11 @@ public static class AdminThemeFunction
         {
             var html = await _httpClient.GetStringAsync(parsedUri);
             var colors = ExtractColors(html);
-            log.LogInformation("Kleuren geëxtraheerd uit {Host}: {Count} gevonden", parsedUri.Host, colors.Count);
-            return new OkObjectResult(new { colors });
+            var faviconUrl = ExtractFaviconUrl(html, parsedUri);
+            var logoUrl = ExtractLogoUrl(html, parsedUri);
+            log.LogInformation("Assets geëxtraheerd uit {Host}: {Count} kleuren, favicon={Fav}, logo={Logo}",
+                parsedUri.Host, colors.Count, faviconUrl != null, logoUrl != null);
+            return new OkObjectResult(new { colors, faviconUrl, logoUrl });
         }
         catch (Exception ex)
         {
@@ -223,21 +238,52 @@ public static class AdminThemeFunction
         return _hexColorValidRegex.IsMatch(value);
     }
 
+    private static string? ExtractFaviconUrl(string html, Uri baseUri)
+    {
+        var m = _faviconRegex.Match(html);
+        if (!m.Success) m = _faviconAltRegex.Match(html);
+        var href = m.Success ? m.Groups[1].Value : "/favicon.ico";
+        return ResolveUrl(href, baseUri);
+    }
+
+    private static string? ExtractLogoUrl(string html, Uri baseUri)
+    {
+        var m = _ogImageRegex.Match(html);
+        if (!m.Success) m = _ogImageAltRegex.Match(html);
+        if (!m.Success) m = _appleTouchRegex.Match(html);
+        if (!m.Success) return null;
+        return ResolveUrl(m.Groups[1].Value, baseUri);
+    }
+
+    private static string? ResolveUrl(string url, Uri baseUri)
+    {
+        if (string.IsNullOrWhiteSpace(url)) return null;
+        if (Uri.TryCreate(url, UriKind.Absolute, out var abs))
+            return abs.Scheme == "http" || abs.Scheme == "https" ? abs.ToString() : null;
+        if (Uri.TryCreate(baseUri, url, out var rel))
+            return rel.Scheme == "http" || rel.Scheme == "https" ? rel.ToString() : null;
+        return null;
+    }
+
     private static object DefaultTheme() => new
     {
         primary        = "#1b6ec2",
         secondary      = "#6c757d",
         accent         = "#0071c1",
         textOnPrimary  = "#ffffff",
-        clubWebsiteUrl = ""
+        clubWebsiteUrl = "",
+        faviconUrl     = (string?)null,
+        logoUrl        = (string?)null
     };
 }
 
 internal sealed class ThemeUpdateRequest
 {
-    public string? Primary       { get; set; }
-    public string? Secondary     { get; set; }
-    public string? Accent        { get; set; }
-    public string? TextOnPrimary { get; set; }
+    public string? Primary        { get; set; }
+    public string? Secondary      { get; set; }
+    public string? Accent         { get; set; }
+    public string? TextOnPrimary  { get; set; }
     public string? ClubWebsiteUrl { get; set; }
+    public string? FaviconUrl     { get; set; }
+    public string? LogoUrl        { get; set; }
 }

--- a/scripts/migrations/003-add-favicon-logo-to-appsettings.sql
+++ b/scripts/migrations/003-add-favicon-logo-to-appsettings.sql
@@ -1,0 +1,27 @@
+-- Migratie 003: FaviconUrl en LogoUrl toevoegen aan dbo.AppSettings
+-- Idempotent: veilig meerdere keren uit te voeren.
+-- Van toepassing op alle rijen (alle clubs).
+
+IF NOT EXISTS (
+    SELECT 1 FROM [sys].[columns]
+    WHERE [object_id] = OBJECT_ID('[dbo].[AppSettings]') AND [name] = 'FaviconUrl'
+)
+BEGIN
+    ALTER TABLE [dbo].[AppSettings] ADD [FaviconUrl] NVARCHAR(2048) NULL;
+    PRINT 'Kolom FaviconUrl toegevoegd aan dbo.AppSettings';
+END
+ELSE
+    PRINT 'Kolom FaviconUrl bestaat al — overgeslagen';
+GO
+
+IF NOT EXISTS (
+    SELECT 1 FROM [sys].[columns]
+    WHERE [object_id] = OBJECT_ID('[dbo].[AppSettings]') AND [name] = 'LogoUrl'
+)
+BEGIN
+    ALTER TABLE [dbo].[AppSettings] ADD [LogoUrl] NVARCHAR(2048) NULL;
+    PRINT 'Kolom LogoUrl toegevoegd aan dbo.AppSettings';
+END
+ELSE
+    PRINT 'Kolom LogoUrl bestaat al — overgeslagen';
+GO


### PR DESCRIPTION
## Summary
- Favicon en club-logo opslaan en tonen (#339): nieuwe Favicon URL + Logo URL velden op de Thema-pagina; knop "Ophalen" haalt kleuren + favicon + logo in één keer op; logo verschijnt linksboven in navigatiebalk; favicon wordt in browsertabblad toegepast
- DB: nieuwe kolommen FaviconUrl/LogoUrl op dbo.AppSettings (migratie 003 + PostDeployment1)
- Dashboard herontworpen (#344): vier grote klikbare kaarten als snelkoppelingen naar Dagplanning, Leermomenten, Email-tester, Teambegeleiding; optioneel club-logo als hero bovenaan
- Synchronisatiestatus + emailverwerkingslog verplaatst van Dashboard naar Instellingen-pagina

Closes #339
Closes #344

## Test plan
- [ ] Thema-pagina: website-URL invullen en "Ophalen" klikken — kleuren + favicon + logo worden getoond
- [ ] "Gebruiken" knop voor favicon/logo toepassen en opslaan
- [ ] Na opslaan: favicon zichtbaar in browsertabblad; logo linksboven in zijbalk
- [ ] Dashboard toont 4 kaarten + hover-effect; logo-hero als logo ingesteld is
- [ ] Instellingen-pagina toont synchronisatiestatus en emaillog bovenaan
- [ ] "Nu synchroniseren" werkt op Instellingen-pagina

Generated with Claude Code