### PR TITLE
fix(#352): multi-club data-isolatie — alle admin-schermen zien nu correct data van geselecteerde club

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.5.0</Version>
-    <AssemblyVersion>2.5.0.0</AssemblyVersion>
-    <FileVersion>2.5.0.0</FileVersion>
+    <Version>2.5.0.1</Version>
+    <AssemblyVersion>2.5.0.1</AssemblyVersion>
+    <FileVersion>2.5.0.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/Layout/MainLayout.razor
+++ b/BlazorAdmin/Layout/MainLayout.razor
@@ -11,21 +11,24 @@
     </div>
 
     <main>
-        <div class="top-row px-4 d-flex align-items-center justify-content-end">
-            @if (_clubs.Count > 1)
-            {
-                <div class="me-3">
+        <div class="top-row px-4 d-flex align-items-center">
+            <div class="flex-fill"></div>
+            <div class="d-flex justify-content-center">
+                @if (_clubs.Count > 1)
+                {
                     <select class="form-select form-select-sm club-selector" style="min-width:200px" @onchange="OnClubChanged" value="@ClubSelector.SelectedClubCode">
                         @foreach (var club in _clubs)
                         {
                             <option value="@club.ClubCode">@club.ClubName</option>
                         }
                     </select>
-                </div>
-            }
-            <span class="text-muted small me-3">v@(Assembly.GetExecutingAssembly().GetName().Version?.ToString(4) ?? "?")</span>
-            <FeedbackWidget />
-            <a href="https://github.com/Jaapbeus/Sportlink-wedstrijdzaken" target="_blank">About</a>
+                }
+            </div>
+            <div class="flex-fill d-flex align-items-center justify-content-end gap-2">
+                <span class="text-muted small">v@(Assembly.GetExecutingAssembly().GetName().Version?.ToString(4) ?? "?")</span>
+                <FeedbackWidget />
+                <a href="https://github.com/Jaapbeus/Sportlink-wedstrijdzaken" target="_blank">About</a>
+            </div>
         </div>
 
         <article class="content px-4">

--- a/BlazorAdmin/Layout/NavMenu.razor.css
+++ b/BlazorAdmin/Layout/NavMenu.razor.css
@@ -63,12 +63,30 @@
         line-height: 3rem;
     }
 
+    .nav-item ::deep button.nav-link {
+        color: #d7d7d7;
+        background: none;
+        border: none;
+        border-radius: 4px;
+        height: 3rem;
+        display: flex;
+        align-items: center;
+        padding-left: 1rem;
+        width: 100%;
+        text-align: start;
+    }
+
 .nav-item ::deep a.active {
     background-color: rgba(255,255,255,0.37);
     color: white;
 }
 
 .nav-item ::deep a:hover {
+    background-color: rgba(255,255,255,0.1);
+    color: white;
+}
+
+.nav-item ::deep button.nav-link:hover {
     background-color: rgba(255,255,255,0.1);
     color: white;
 }

--- a/BlazorAdmin/Layout/NavMenu.razor.css
+++ b/BlazorAdmin/Layout/NavMenu.razor.css
@@ -13,12 +13,8 @@
 
 .bi {
     display: inline-block;
-    position: relative;
     width: 1.25rem;
-    height: 1.25rem;
-    margin-right: 0.75rem;
-    top: -1px;
-    background-size: cover;
+    text-align: center;
 }
 
 .bi-house-door-fill-nav-menu {

--- a/BlazorAdmin/Pages/Dagplanning.razor
+++ b/BlazorAdmin/Pages/Dagplanning.razor
@@ -2,6 +2,9 @@
 @inject AdminApiClient Api
 @inject IAuthService Auth
 @inject IJSRuntime JS
+@inject ClubSelectorService ClubSelector
+@using BlazorAdmin.Services
+@implements IDisposable
 
 <PageTitle>Dagplanning — Admin</PageTitle>
 
@@ -120,7 +123,18 @@
     protected override void OnInitialized()
     {
         _datumDt = VolgendZaterdag().ToDateTime(TimeOnly.MinValue);
+        ClubSelector.OnChange += OnClubChanged;
     }
+
+    private void OnClubChanged() => InvokeAsync(() =>
+    {
+        _resultaat = null;
+        _errorMessage = null;
+        _kopieerStatus = null;
+        StateHasChanged();
+    });
+
+    public void Dispose() => ClubSelector.OnChange -= OnClubChanged;
 
     private static DateOnly VolgendZaterdag()
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,19 +9,24 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 > zie [docs/VERSIONING.md](docs/VERSIONING.md).
 
 > **Conventie voor versies:**
-> - `MAJOR` (x.0.0) -- grote nieuwe laag of breaking change (bijv. Admin GUI, nieuwe auth-laag)
-> - `MINOR` (2.x.0) -- nieuwe feature, backwards compatible (nieuw endpoint, nieuw scherm, nieuwe instelling)
-> - `PATCH` (2.0.x) -- bugfix, beveiligingspatch, documentatie zonder gedragswijziging
+> - `MAJOR` (x.0.0.0) -- grote nieuwe laag of breaking change (bijv. Admin GUI, nieuwe auth-laag)
+> - `MINOR` (2.x.0.0) -- nieuwe feature, backwards compatible (nieuw endpoint, nieuw scherm, nieuwe instelling)
+> - `PATCH` (2.0.x.0) -- bugfix of beveiligingspatch
+> - `REVISION` (2.0.0.x) -- kleine fix, CSS/UX-verbetering of aanpassing met zichtbaar effect; elke commit die de beheerder merkt
 
 ---
 
 ## [Unreleased]
+
+## [2.5.0.1] — 2026-05-26
 
 ### Fixed
 - Multi-club data-isolatie volledig gerepareerd (#352): alle admin-schermen (Instellingen, Sync-status, Templates, Speeltijden, Voorkeurstijden, Veldenbeschikbaarheid, Email-log, Leermomenten, Uitgesloten-emails, Teambegeleiding) tonen nu uitsluitend data van de actief geselecteerde club. Voordien negeerden alle API-endpoints de `X-Club-Code`-header van de Blazor-frontend en laadden altijd de primaire/eerste club uit de startup-cache.
 - Club-switch in de topbalk staat nu gecentreerd in de navigatiebalk in plaats van rechtsuitgelijnd.
 - Instellingen-submenu in de navigatiebalk is nu zichtbaar (knop had Bootstrap `.btn-link`-kleur die onzichtbaar was op de donkere achtergrond).
 - Import-script teambegeleiding: `TRUNCATE TABLE` vervangen door `DELETE WHERE ClubCode = @cc` zodat data van andere clubs niet wordt gewist bij een import.
+- Navigatiemenu-iconen staan nu gelijk uitgelijnd met de menutekst (was licht omhoog verschoven door een verouderde CSS-regel voor het oude SVG-icon-systeem).
+- Dagplanning-pagina wordt nu automatisch leeggemaakt bij het wisselen van club in de topbalk, zodat er geen verwarring ontstaat met data van de vorige club.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Alle noemenswaardige wijzigingen in dit project worden bijgehouden in dit bestand.
 
 De indeling volgt [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).  
-Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie [docs/VERSIONING.md](docs/VERSIONING.md).
 
 > **Definities en beslisregels** -- wat is een bug, wat is een feature, wat hoort hier wel/niet in:  
 > zie [docs/VERSIONING.md](docs/VERSIONING.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Versienummering volgt [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Fixed
+- Multi-club data-isolatie volledig gerepareerd (#352): alle admin-schermen (Instellingen, Sync-status, Templates, Speeltijden, Voorkeurstijden, Veldenbeschikbaarheid, Email-log, Leermomenten, Uitgesloten-emails, Teambegeleiding) tonen nu uitsluitend data van de actief geselecteerde club. Voordien negeerden alle API-endpoints de `X-Club-Code`-header van de Blazor-frontend en laadden altijd de primaire/eerste club uit de startup-cache.
+- Club-switch in de topbalk staat nu gecentreerd in de navigatiebalk in plaats van rechtsuitgelijnd.
+- Instellingen-submenu in de navigatiebalk is nu zichtbaar (knop had Bootstrap `.btn-link`-kleur die onzichtbaar was op de donkere achtergrond).
+- Import-script teambegeleiding: `TRUNCATE TABLE` vervangen door `DELETE WHERE ClubCode = @cc` zodat data van andere clubs niet wordt gewist bij een import.
+
 ---
 
 ## [2.5.0] — 2026-05-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Alle noemenswaardige wijzigingen in dit project worden bijgehouden in dit bestand.
 
-De indeling volgt [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).  
+De indeling volgt [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie [docs/VERSIONING.md](docs/VERSIONING.md).
 
 > **Definities en beslisregels** -- wat is een bug, wat is een feature, wat hoort hier wel/niet in:  

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,27 +147,35 @@ if ($branch -eq 'main' -or [string]::IsNullOrEmpty($branch)) {
 
 ### Stap 2 — Verificatielus (herhaal tot exit 0, max 3 iteraties)
 
+> **KRITIEKE REGEL — Blazor fingerprint-veiligheid:**
+> Roep **NOOIT** `dotnet build BlazorAdmin` aan terwijl de Blazor dev server al draait of ná het starten.
+> BlazorAdmin genereert content-hash fingerprints per compilatie. Twee compilatiepassen = twee sets fingerprints
+> = 404 op framework-JS = "An unhandled error has occurred. Reload" in de browser.
+> Stap `b` is uitsluitend voor build-fout-detectie; de services worden daarna gestopt + gecleand + herstart.
+
 ```
 ITERATIE:
   a. dotnet build FunctionApp/fa-dev-sportlink-01.csproj -c Debug
      → fouten? Fix, ga terug naar a.
 
-  b. dotnet build BlazorAdmin/BlazorAdmin.csproj  (als Blazor bestaat)
+  b. dotnet build BlazorAdmin/BlazorAdmin.csproj  (build-fout-detectie — NIET terwijl server draait)
      → fouten? Fix, ga terug naar a.
 
   c. .\scripts\dev\Test-App.ps1 -Fix
      → exit 1 zonder -Fix te herstellen? Fix code, ga terug naar a.
 
-  d. Start services via Start-Debug.ps1 (aanbevolen — regelt hot reload automatisch):
+  d. Stop services + clean BlazorAdmin + herstart:
+       Stop-Process -Name "func","dotnet","node" -ErrorAction SilentlyContinue
+       Start-Sleep -Seconds 2
+       dotnet clean BlazorAdmin/BlazorAdmin.csproj | Out-Null   # verwijdert stale fingerprints
        .\scripts\dev\Start-Debug.ps1
-       Start-Sleep -Seconds 15
+       Start-Sleep -Seconds 20
 
        # Hot reload gedrag (vastgelegd in Start-Debug.ps1):
        # - BlazorAdmin :5242 → HOT RELOAD via 'dotnet watch'. Wijzigingen in .razor/.cs/.css
        #   worden automatisch doorgevoerd; browser ververst zonder herstart.
        # - FunctionApp :7094 → GEEN hot reload. Azure Functions isolated worker ondersteunt
        #   dit niet. Na elke C#-wijziging in FunctionApp: services stoppen en herstart uitvoeren.
-       #   Zie: scripts/dev/Start-Debug.ps1 (commentaarblok bovenaan voor details)
 
        # Alternatief (handmatig, als Start-Debug.ps1 niet beschikbaar):
        # 1. Azurite
@@ -184,27 +192,46 @@ ITERATIE:
        if (Test-Path "BlazorAdmin/BlazorAdmin.csproj") {
            Start-Process powershell -ArgumentList "-NoExit -Command Set-Location BlazorAdmin; dotnet watch run --launch-profile http"
        }
-       Start-Sleep -Seconds 15
+       Start-Sleep -Seconds 20
 
-  e. Controleer FunctionApp health:
-       Invoke-RestMethod http://localhost:7094/api/health
+  e. Controleer FunctionApp health + versienummer:
+       $health = Invoke-RestMethod http://localhost:7094/api/health
+       Write-Host "Versie: $($health.version)"
        → niet 200? Fix, kill services, ga terug naar a.
 
-  f. .\scripts\dev\Test-App.ps1 (met live services — secties 4+5+6 worden nu uitgevoerd)
+  f. Blazor fingerprint consistency check (VERPLICHT — detecteert root cause van "An unhandled error"):
+       # .NET 10 Blazor WASM: importmap key is './_framework/dotnet.js' (niet 'dotnet')
+       $html = (Invoke-WebRequest "http://localhost:5242/" -UseBasicParsing -ErrorAction SilentlyContinue).Content
+       $importmapMatch = [regex]::Match($html, '<script type="importmap"[^>]*>(.*?)</script>',
+           [System.Text.RegularExpressions.RegexOptions]::Singleline)
+       if ($importmapMatch.Success) {
+           $dotnetEntry = ($importmapMatch.Groups[1].Value | ConvertFrom-Json).imports."./_framework/dotnet.js" -replace '^\.\/', ''
+           $check = Invoke-WebRequest "http://localhost:5242/$dotnetEntry" -UseBasicParsing -ErrorAction SilentlyContinue
+           if ($check.StatusCode -ne 200) {
+               Write-Host "FINGERPRINT MISMATCH: $dotnetEntry → $($check.StatusCode)" -ForegroundColor Red
+           }
+       }
+       → mismatch of importmap leeg? Stop services → dotnet clean BlazorAdmin → terug naar d.
+
+  g. .\scripts\dev\Test-App.ps1 (met live services — secties 4+5+6 worden nu uitgevoerd)
      → exit 1? Fix, kill services, ga terug naar a.
 
-  g. Controleer Blazor-pagina's:
-       Invoke-WebRequest http://localhost:5242/ -UseBasicParsing
-       Invoke-WebRequest http://localhost:5242/instellingen -UseBasicParsing
-       (herhaal voor elke gewijzigde route)
-       → fout of HTML bevat "An unhandled error"? Fix, kill services, ga terug naar a.
+  h. Browser render check — VERPLICHT (HTTP 200 ≠ Blazor rendert):
+     In Blazor WASM retourneert elke route dezelfde index.html (HTTP 200). Client-side rendering
+     kan alsnog crashen. Instrueer de gebruiker of verifieer handmatig:
+       Open http://localhost:5242 → Ctrl+Shift+F5 (hard refresh)
+       Minimale verificatie:
+         - Geen "An unhandled error has occurred" banner onderaan de pagina
+         - Versienummer zichtbaar in de header (bijv. v2.5.0)
+         - http://localhost:5242/instellingen laadt zonder foutmelding
+     → fout? F12 → Console → foutmelding rapporteren
 
-  h. Kill services:
+  i. Kill services:
        Stop-Process -Name "func" -ErrorAction SilentlyContinue
        Stop-Process -Name "dotnet" -ErrorAction SilentlyContinue
        Stop-Process -Name "node" -ErrorAction SilentlyContinue  # SWA CLI
 
-GESLAAGD als: alle stappen exit 0 of 2xx, geen foutindicatoren
+GESLAAGD als: alle stappen exit 0 of 2xx, fingerprint consistent ✅, browser toont geen foutbanner
 ```
 
 **SWA emulator (optioneel — voor auth-flow testen):**
@@ -590,12 +617,26 @@ Versienummering volgt `MAJOR.MINOR.PATCH`:
 
 ### Conventional Commits → versie-bump
 
-Commit-type bepaalt de minimum versie-bump:
-- `feat:` → MINOR bump
-- `fix:` → PATCH bump
-- `security:` → PATCH bump
-- `BREAKING CHANGE:` in commit-body → MAJOR bump
-- `chore:`, `docs:`, `refactor:` → geen versie-bump (tenzij er ook een `fix:`/`feat:` bij zit)
+Het versienummer heeft vier cijfers: `MAJOR.MINOR.PATCH.REVISION`
+
+| Commit-type | Versie-impact | Voorbeeld |
+|---|---|---|
+| `feat:` | MINOR bump — Patch en Revision resetten naar 0 | `2.5.0.3 → 2.6.0.0` |
+| `fix:` of `security:` | PATCH bump — Revision reset naar 0 | `2.5.0.3 → 2.5.1.0` |
+| `BREAKING CHANGE:` in commit-body | MAJOR bump | `2.5.x.x → 3.0.0.0` |
+| Kleine fix, CSS, UX, chore **met zichtbaar effect** | REVISION bump | `2.5.0.0 → 2.5.0.1` |
+| Puur intern (refactor zonder effect, docs, CLAUDE.md) | Geen bump | — |
+
+> **Reden voor Revision:** de beheerder ziet het versienummer in de header. Na een deployment
+> kan de beheerder bevestigen dat de juiste versie actief is. Zonder Revision-bump is elke
+> kleine fix onzichtbaar in de UI.
+
+Zet alle drie velden synchroon in **beide** csproj's:
+```xml
+<Version>2.5.0.1</Version>
+<AssemblyVersion>2.5.0.1</AssemblyVersion>
+<FileVersion>2.5.0.1</FileVersion>
+```
 
 ### CHANGELOG.md bijhouden
 

--- a/FunctionApp/Admin/AdminEmailLogFunction.cs
+++ b/FunctionApp/Admin/AdminEmailLogFunction.cs
@@ -32,8 +32,7 @@ public static class AdminEmailLogFunction
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
 
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             DateTime? vanaf = null, tot = null;
             if (DateTime.TryParse(req.Query["vanaf"].ToString(), out var vd)) vanaf = vd.Date;

--- a/FunctionApp/Admin/AdminLeermomentenFunction.cs
+++ b/FunctionApp/Admin/AdminLeermomentenFunction.cs
@@ -32,8 +32,7 @@ public static class AdminLeermomentenFunction
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
 
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             var statusFilter = req.Query["status"].ToString();
             int limit = DefaultLimit;
@@ -100,8 +99,7 @@ public static class AdminLeermomentenFunction
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
 
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -145,8 +143,7 @@ public static class AdminLeermomentenFunction
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
 
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             string body;
             using (var sr = new System.IO.StreamReader(req.Body))

--- a/FunctionApp/Admin/AdminSettingsFunction.cs
+++ b/FunctionApp/Admin/AdminSettingsFunction.cs
@@ -72,6 +72,7 @@ public static class AdminSettingsFunction
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
 
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
             // Geen SportlinkClientId, geen geheimen
             using var command = new SqlCommand(@"
                 SELECT TOP 1
@@ -80,7 +81,9 @@ public static class AdminSettingsFunction
                     [CoordinatorFunctie], [PlannerEmailAdres], [HerplanDeadlineDagen],
                     [BufferMinuten], [EmailVoetnoot], [AccommodatiePlaats],
                     [AccommodatieLatitude], [AccommodatieLongitude]
-                FROM [dbo].[AppSettings]", connection);
+                FROM [dbo].[AppSettings]
+                WHERE [ClubCode] = @ClubCode", connection);
+            command.Parameters.AddWithValue("@ClubCode", clubCode);
 
             using var reader = await command.ExecuteReaderAsync();
             if (!await reader.ReadAsync())
@@ -98,13 +101,14 @@ public static class AdminSettingsFunction
             // UseRealtimeApi: dynamisch laden — kolom bestaat pas na DB-migratie
             using var rtaCmd = new SqlCommand(@"
                 DECLARE @v BIT = 1;
-                DECLARE @sql NVARCHAR(200) = CASE
+                DECLARE @sql NVARCHAR(300) = CASE
                     WHEN COL_LENGTH('[dbo].[AppSettings]', 'UseRealtimeApi') IS NOT NULL
-                    THEN N'SELECT TOP 1 @v = [UseRealtimeApi] FROM [dbo].[AppSettings]'
+                    THEN N'SELECT TOP 1 @v = [UseRealtimeApi] FROM [dbo].[AppSettings] WHERE [ClubCode] = @cc'
                     ELSE N'SELECT @v = CAST(1 AS BIT)'
                 END;
-                EXEC sp_executesql @sql, N'@v BIT OUTPUT', @v = @v OUTPUT;
+                EXEC sp_executesql @sql, N'@v BIT OUTPUT, @cc NVARCHAR(20)', @v = @v OUTPUT, @cc = @ClubCode;
                 SELECT @v;", connection);
+            rtaCmd.Parameters.AddWithValue("@ClubCode", clubCode);
             var rtaScalar = await rtaCmd.ExecuteScalarAsync();
             result["UseRealtimeApi"] = rtaScalar is bool rtaBool ? rtaBool : true;
 
@@ -148,6 +152,7 @@ public static class AdminSettingsFunction
             var gewijzigdDoor = updateRequest.GewijzigdDoor ?? req.Query["gewijzigdDoor"].ToString();
             if (string.IsNullOrWhiteSpace(gewijzigdDoor)) gewijzigdDoor = "onbekend";
 
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
             // Pluk alleen de toegestane velden — alles erbuiten wordt genegeerd
             var changes = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
             if (updateRequest.Velden != null)
@@ -179,14 +184,15 @@ public static class AdminSettingsFunction
 
             try
             {
-                var currentValues = await ReadCurrentValuesAsync(connection, (SqlTransaction)transaction, changes.Keys);
+                var currentValues = await ReadCurrentValuesAsync(connection, (SqlTransaction)transaction, changes.Keys, clubCode);
 
                 foreach (var (veld, nieuweWaarde) in changes)
                 {
                     var updateCmd = new SqlCommand(
-                        $"UPDATE [dbo].[AppSettings] SET [{veld}] = @Waarde",
+                        $"UPDATE [dbo].[AppSettings] SET [{veld}] = @Waarde WHERE [ClubCode] = @ClubCode",
                         connection, (SqlTransaction)transaction);
                     updateCmd.Parameters.AddWithValue("@Waarde", (object?)nieuweWaarde ?? DBNull.Value);
+                    updateCmd.Parameters.AddWithValue("@ClubCode", clubCode);
                     await updateCmd.ExecuteNonQueryAsync();
 
                     currentValues.TryGetValue(veld, out var oud);
@@ -199,9 +205,7 @@ public static class AdminSettingsFunction
                     auditCmd.Parameters.AddWithValue("@Veld", veld);
                     auditCmd.Parameters.AddWithValue("@OudeWaarde", (object?)oud ?? DBNull.Value);
                     auditCmd.Parameters.AddWithValue("@NieuweWaarde", (object?)nieuweWaarde ?? DBNull.Value);
-                    auditCmd.Parameters.AddWithValue("@ClubCode",
-                        SystemUtilities.AppSettings.GetSetting("clubCode")
-                            ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings"));
+                    auditCmd.Parameters.AddWithValue("@ClubCode", clubCode);
                     await auditCmd.ExecuteNonQueryAsync();
                 }
 
@@ -438,7 +442,7 @@ public static class AdminSettingsFunction
     }
 
     private static async Task<Dictionary<string, string?>> ReadCurrentValuesAsync(
-        SqlConnection connection, SqlTransaction transaction, IEnumerable<string> velden)
+        SqlConnection connection, SqlTransaction transaction, IEnumerable<string> velden, string clubCode)
     {
         var safe = velden.Where(v => AllowedFields.Contains(v, StringComparer.OrdinalIgnoreCase))
                          .Select(v => $"[{v}]")
@@ -446,8 +450,9 @@ public static class AdminSettingsFunction
         var result = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
         if (safe.Count == 0) return result;
 
-        var sql = $"SELECT TOP 1 {string.Join(", ", safe)} FROM [dbo].[AppSettings]";
+        var sql = $"SELECT TOP 1 {string.Join(", ", safe)} FROM [dbo].[AppSettings] WHERE [ClubCode] = @ClubCode";
         using var cmd = new SqlCommand(sql, connection, transaction);
+        cmd.Parameters.AddWithValue("@ClubCode", clubCode);
         using var reader = await cmd.ExecuteReaderAsync();
         if (await reader.ReadAsync())
         {

--- a/FunctionApp/Admin/AdminSpeeltijdenFunction.cs
+++ b/FunctionApp/Admin/AdminSpeeltijdenFunction.cs
@@ -26,8 +26,7 @@ public static class AdminSpeeltijdenFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -84,8 +83,7 @@ public static class AdminSpeeltijdenFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var bodyReader = new StreamReader(req.Body);
             var body = await bodyReader.ReadToEndAsync();
@@ -136,8 +134,7 @@ public static class AdminSpeeltijdenFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var bodyReader = new StreamReader(req.Body);
             var body = await bodyReader.ReadToEndAsync();
@@ -189,8 +186,7 @@ public static class AdminSpeeltijdenFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();

--- a/FunctionApp/Admin/AdminSyncFunction.cs
+++ b/FunctionApp/Admin/AdminSyncFunction.cs
@@ -31,9 +31,11 @@ public static class AdminSyncFunction
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
 
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
             using var command = new SqlCommand(
-                "SELECT TOP 1 [LastSyncTimestamp], [FetchSchedule] FROM [dbo].[AppSettings]",
+                "SELECT TOP 1 [LastSyncTimestamp], [FetchSchedule] FROM [dbo].[AppSettings] WHERE [ClubCode] = @ClubCode",
                 connection);
+            command.Parameters.AddWithValue("@ClubCode", clubCode);
             using var reader = await command.ExecuteReaderAsync();
             if (!await reader.ReadAsync())
                 return new NotFoundObjectResult(new { error = "Geen AppSettings rij" });

--- a/FunctionApp/Admin/AdminTeambegeleidingFunction.cs
+++ b/FunctionApp/Admin/AdminTeambegeleidingFunction.cs
@@ -36,9 +36,11 @@ public static class AdminTeambegeleidingFunction
             await SystemUtilities.WaitForDatabaseAsync(log);
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
             using var command = new SqlCommand(
-                "SELECT DISTINCT [Team] FROM [avg].[Teambegeleiding] WHERE [Team] IS NOT NULL ORDER BY [Team]",
+                "SELECT DISTINCT [Team] FROM [avg].[Teambegeleiding] WHERE [Team] IS NOT NULL AND [ClubCode] = @ClubCode ORDER BY [Team]",
                 connection);
+            command.Parameters.AddWithValue("@ClubCode", clubCode);
             using var reader = await command.ExecuteReaderAsync();
             var teams = new List<string>();
             while (await reader.ReadAsync())
@@ -72,10 +74,12 @@ public static class AdminTeambegeleidingFunction
             await SystemUtilities.WaitForDatabaseAsync(log);
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
             using var command = new SqlCommand(@"
                 SELECT [Naam], [Teamrol], [Emailadres], [Telefoonnummer]
                 FROM [avg].[Teambegeleiding]
                 WHERE [Team] = @team
+                  AND [ClubCode] = @ClubCode
                 ORDER BY
                     CASE WHEN [Teamrol] LIKE '%Trainer%' THEN 1
                          WHEN [Teamrol] LIKE '%Coach%' THEN 2
@@ -84,6 +88,7 @@ public static class AdminTeambegeleidingFunction
                     [Naam]
             ", connection);
             command.Parameters.AddWithValue("@team", team);
+            command.Parameters.AddWithValue("@ClubCode", clubCode);
             using var reader = await command.ExecuteReaderAsync();
             var list = new List<object>();
             while (await reader.ReadAsync())
@@ -140,11 +145,13 @@ public static class AdminTeambegeleidingFunction
             using (var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString))
             {
                 await connection.OpenAsync();
+                var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
                 using var cmd = new SqlCommand(@"
                     SELECT TOP 1 [Emailadres]
                     FROM [avg].[Teambegeleiding]
                     WHERE [Team] = @team
                       AND [Emailadres] IS NOT NULL
+                      AND [ClubCode] = @ClubCode
                     ORDER BY
                         CASE WHEN [Teamrol] LIKE '%Trainer%' THEN 1
                              WHEN [Teamrol] LIKE '%Coach%' THEN 2
@@ -152,6 +159,7 @@ public static class AdminTeambegeleidingFunction
                              ELSE 4 END
                 ", connection);
                 cmd.Parameters.AddWithValue("@team", dto.TeamNaam);
+                cmd.Parameters.AddWithValue("@ClubCode", clubCode);
                 var result = await cmd.ExecuteScalarAsync();
                 coachEmail = result as string;
             }

--- a/FunctionApp/Admin/AdminTemplatesFunction.cs
+++ b/FunctionApp/Admin/AdminTemplatesFunction.cs
@@ -30,8 +30,7 @@ public static class AdminTemplatesFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -88,8 +87,7 @@ public static class AdminTemplatesFunction
                 return new BadRequestObjectResult(new { error = "Onderwerp en BodyTemplate verplicht" });
 
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -152,8 +150,7 @@ public static class AdminTemplatesFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();

--- a/FunctionApp/Admin/AdminUitgeslotenEmailFunction.cs
+++ b/FunctionApp/Admin/AdminUitgeslotenEmailFunction.cs
@@ -25,8 +25,7 @@ public static class AdminUitgeslotenEmailFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -79,8 +78,7 @@ public static class AdminUitgeslotenEmailFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
             var body = await new System.IO.StreamReader(req.Body).ReadToEndAsync();
             var dto = JsonConvert.DeserializeObject<UitgeslotenEmailRequest>(body);
             if (dto == null || string.IsNullOrWhiteSpace(dto.EmailAdres))
@@ -128,8 +126,7 @@ public static class AdminUitgeslotenEmailFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();

--- a/FunctionApp/Admin/AdminVeldBeschikbaarheidFunction.cs
+++ b/FunctionApp/Admin/AdminVeldBeschikbaarheidFunction.cs
@@ -25,8 +25,7 @@ public static class AdminVeldBeschikbaarheidFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -79,8 +78,7 @@ public static class AdminVeldBeschikbaarheidFunction
             if (validatie != null) return validatie;
 
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -122,8 +120,7 @@ public static class AdminVeldBeschikbaarheidFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -166,8 +163,7 @@ public static class AdminVeldBeschikbaarheidFunction
             if (tijdenValidatie != null) return tijdenValidatie;
 
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -221,8 +217,7 @@ public static class AdminVeldBeschikbaarheidFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();

--- a/FunctionApp/Admin/AdminVoorkeurTijdenFunction.cs
+++ b/FunctionApp/Admin/AdminVoorkeurTijdenFunction.cs
@@ -25,8 +25,7 @@ public static class AdminVoorkeurTijdenFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
             string? team = req.Query["team"].ToString();
             if (string.IsNullOrWhiteSpace(team)) team = null;
 
@@ -83,8 +82,7 @@ public static class AdminVoorkeurTijdenFunction
             if (validatie != null) return validatie;
 
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -129,8 +127,7 @@ public static class AdminVoorkeurTijdenFunction
             if (validatie != null) return validatie;
 
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -174,8 +171,7 @@ public static class AdminVoorkeurTijdenFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -212,8 +208,7 @@ public static class AdminVoorkeurTijdenFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -267,8 +262,7 @@ public static class AdminVoorkeurTijdenFunction
             if (validatie != null) return validatie;
 
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -320,8 +314,7 @@ public static class AdminVoorkeurTijdenFunction
             if (validatie != null) return validatie;
 
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
@@ -369,8 +362,7 @@ public static class AdminVoorkeurTijdenFunction
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
 
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.5.0</Version>
-    <AssemblyVersion>2.5.0.0</AssemblyVersion>
-    <FileVersion>2.5.0.0</FileVersion>
+    <Version>2.5.0.1</Version>
+    <AssemblyVersion>2.5.0.1</AssemblyVersion>
+    <FileVersion>2.5.0.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -232,24 +232,51 @@ Voorbeelden:
 
 ## 6. Versie-bump beslisboom
 
+Het versienummer heeft **vier** cijfers: `MAJOR.MINOR.PATCH.REVISION`
+
+| Getal | Wanneer omhoog | Reset bij |
+|---|---|---|
+| **MAJOR** | Breaking change voor de gebruiker | — |
+| **MINOR** | Nieuwe feature | MAJOR-bump → 0 |
+| **PATCH** | Bugfix of security-patch | MINOR-bump → 0 |
+| **REVISION** | **Elke commit die gebruikerszichtbare bestanden raakt** (.razor, .cs, .css, .sql, .json in wwwroot) | PATCH-bump → 0 |
+
+> **Waarom Revision?** De beheerder ziet het versienummer in de header (bijv. `v2.5.0.1`).
+> Na een deployment kan de beheerder bevestigen dat de juiste versie actief is door het getal te checken.
+> Zonder Revision ziet elke kleine fix er hetzelfde uit — geen bevestiging mogelijk.
+
 ```
 Wat is er gewijzigd?
 │
 ├── Verwijdert of breekt bestaande functionaliteit voor een gebruiker?
-│   └── JA → MAJOR (x.0.0)
+│   └── JA → MAJOR (x.0.0.0)
 │
 ├── Voegt nieuwe gebruikersfunctionaliteit toe?
-│   └── JA → MINOR (2.x.0)
+│   └── JA → MINOR (2.x.0.0)
 │
 ├── Repareert iets wat verkeerd werkte voor een gebruiker?
-│   └── JA → PATCH (2.0.x)
+│   └── JA → PATCH (2.0.x.0)
 │
 ├── Beveiligingspatch?
-│   └── JA → PATCH (2.0.x) — tenzij breaking → MAJOR
+│   └── JA → PATCH (2.0.x.0) — tenzij breaking → MAJOR
 │
-└── Alleen intern (refactor, docs, tooling)?
+├── Kleine fix, CSS, UX-verbetering of chore met zichtbaar effect?
+│   └── JA → REVISION (2.0.0.x)
+│
+└── Alleen intern (refactor zonder effect, docs, tooling, CLAUDE.md)?
     └── Geen versie-bump
 ```
+
+### In de csproj
+
+Zet alle drie velden synchroon op het volledige 4-cijferige nummer:
+```xml
+<Version>2.5.0.1</Version>
+<AssemblyVersion>2.5.0.1</AssemblyVersion>
+<FileVersion>2.5.0.1</FileVersion>
+```
+
+Dit getal wordt via `Assembly.GetExecutingAssembly().GetName().Version?.ToString(4)` getoond in de header.
 
 ### Twijfelgevallen
 

--- a/exports/import-teambegeleiding-to-sql.ps1
+++ b/exports/import-teambegeleiding-to-sql.ps1
@@ -19,7 +19,8 @@
 
 param (
     [string] $CsvPath              = "",
-    [bool]   $DeleteCsvAfterImport = $false
+    [bool]   $DeleteCsvAfterImport = $false,
+    [string] $ClubCode             = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -86,6 +87,22 @@ if (-not $connectionStr) {
 }
 
 Write-Host "  Verbindingsstring gevonden." -ForegroundColor Green
+
+# ── ClubCode bepalen ──────────────────────────────────────────────────────────
+if (-not $ClubCode) {
+    $connTemp = New-Object System.Data.SqlClient.SqlConnection($connectionStr)
+    $connTemp.Open()
+    try {
+        $cmdTemp             = $connTemp.CreateCommand()
+        $cmdTemp.CommandText = "SELECT TOP 1 [ClubCode] FROM [dbo].[AppSettings]"
+        $ClubCode            = $cmdTemp.ExecuteScalar()
+    } finally { $connTemp.Close() }
+}
+if (-not $ClubCode) {
+    Write-Host "  FOUT: ClubCode niet gevonden. Geef -ClubCode mee of voeg een rij toe aan dbo.AppSettings." -ForegroundColor Red
+    exit 1
+}
+Write-Host "  ClubCode: $ClubCode" -ForegroundColor Green
 
 # ── Stap 3: CSV inlezen en kolomdetectie ──────────────────────────────────────
 Write-Host "`n[3/5] CSV inlezen en kolomdetectie..." -ForegroundColor Yellow
@@ -154,6 +171,7 @@ $null  = $table.Columns.Add("Teamrol",                [object])
 $null  = $table.Columns.Add("Naam",                   [object])
 $null  = $table.Columns.Add("Emailadres",             [object])
 $null  = $table.Columns.Add("Telefoonnummer",         [object])
+$null  = $table.Columns.Add("ClubCode",               [object])
 
 function Get-CsvValue([object]$row, [string]$col) {
     if (-not $col) { return [DBNull]::Value }
@@ -189,6 +207,7 @@ foreach ($row in $csvRows) {
     $r["Naam"]                   = $naam
     $r["Emailadres"]             = Get-CsvValue $row $resolved["Emailadres"]
     $r["Telefoonnummer"]         = $telefoon
+    $r["ClubCode"]               = $ClubCode
     $table.Rows.Add($r)
 }
 
@@ -202,9 +221,10 @@ $conn.Open()
 
 try {
     $cmd             = $conn.CreateCommand()
-    $cmd.CommandText = "TRUNCATE TABLE [avg].[Teambegeleiding]"
+    $cmd.CommandText = "DELETE FROM [avg].[Teambegeleiding] WHERE [ClubCode] = @cc"
+    $null = $cmd.Parameters.AddWithValue("@cc", $ClubCode)
     $cmd.ExecuteNonQuery() | Out-Null
-    Write-Host "  avg.Teambegeleiding leeggemaakt (TRUNCATE)." -ForegroundColor Gray
+    Write-Host "  avg.Teambegeleiding leeggemaakt voor ClubCode '$ClubCode' (DELETE WHERE)." -ForegroundColor Gray
 
     $bulk                      = New-Object System.Data.SqlClient.SqlBulkCopy($conn)
     $bulk.DestinationTableName = "[avg].[Teambegeleiding]"


### PR DESCRIPTION
## Probleem

Alle admin API-endpoints gebruikten `SystemUtilities.AppSettings.GetSetting("clubCode")` — een **statische startup-cache** die altijd de eerste/primaire club teruggeeft. De `X-Club-Code`-header die Blazor bij elk verzoek meegestuurd (via `ClubCodeHeaderHandler`) werd volledig genegeerd.

Gevolg: Teambegeleiding toonde teams van alle clubs door elkaar, Instellingen laadde altijd de eerste club, etc.

## Oplossing

### FunctionApp (backend)
Vervangen in alle 10 Admin-functions (28 plaatsen):
```csharp
// Fout — altijd eerste club
var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode") ?? throw ...;

// Correct — leest X-Club-Code header
var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
```

SQL WHERE ClubCode toegevoegd waar die ontbrak:
- `AdminSettingsFunction.cs`: GET query + UseRealtimeApi dynamisch SQL + PUT UPDATE + `ReadCurrentValuesAsync`
- `AdminSyncFunction.cs`: Status query
- `AdminTeambegeleidingFunction.cs`: GetTeams, GetBegeleiders, Doorsturen (3 queries)

### BlazorAdmin (frontend)
- `NavMenu.razor.css`: `button.nav-link` krijgt nu expliciete kleur (#d7d7d7) — Bootstrap `.btn-link` overschreef de linkkleur blauw, onzichtbaar op donkere sidebar
- `MainLayout.razor`: Club-switch gecentreerd via 3-koloms flex-layout (flex-fill links, selector midden, versie/feedback/about rechts)

### Import-script
`exports/import-teambegeleiding-to-sql.ps1`: `TRUNCATE TABLE` → `DELETE WHERE [ClubCode] = @cc`; ClubCode wordt automatisch gelezen uit `dbo.AppSettings` of via `-ClubCode` parameter.

## Test

Selecteer in de GUI club A → alle pagina's tonen data van A.  
Selecteer club B → alle pagina's tonen data van B.  
Instellingen-submenu in de sidebar is nu zichtbaar en klikbaar.

Closes #352