### PR TITLE
fix(#359): Blazor WASM crasht bij nl-NL browser-locale

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -15,6 +15,8 @@
          Fix: schakel Blazor's pre-compression uit zodat alleen .wasm aanwezig is in de publish-
          output. SWA's eigen dynamische compressie zet vervolgens wél de juiste Content-Encoding. -->
     <CompressionEnabled>false</CompressionEnabled>
+    <!-- nl-NL browser-locale veroorzaakte crash in invariant-globalization-modus -->
+    <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
   </PropertyGroup>
 
   <!-- .NET 10: Blazor-Environment HTTP header is vervangen door WasmApplicationEnvironmentName.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- Blazor WASM crashte direct na laden ("An unhandled error has occurred") wanneer de browser ingesteld is op de Nederlandse taal (`nl-NL`). Oorzaak: `BlazorWebAssemblyLoadAllGlobalizationData` stond niet ingeschakeld, waardoor Blazor geen cultuurwijziging kon verwerken. Alle gebruikers met een Nederlandse browser-instelling konden de app niet openen.
+
 ## [2.5.0.1] — 2026-05-26
 
 ### Fixed


### PR DESCRIPTION
## Samenvatting

- Fixes #359
- Blazor WASM crashed op startup wanneer de browser ingesteld is op `nl-NL` — gebruiker zag "An unhandled error has occurred" na 100% laden
- `<BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>` toegevoegd aan `BlazorAdmin/BlazorAdmin.csproj`

## Root cause

Blazor WASM draaide in invariant-globalization-modus (default). Browser stuurt `nl-NL` als gewenste cultuur; Blazor kon die cultuurwissel niet verwerken en gooide een `AggregateException` voor App.razor renderde.

## Wijzigingen

- `BlazorAdmin/BlazorAdmin.csproj` — `BlazorWebAssemblyLoadAllGlobalizationData` op `true`
- `CHANGELOG.md` — entry toegevoegd onder `[Unreleased]`

## Test plan

- [ ] Open app in Edge InPrivate (nl-NL browser-locale)
- [ ] Geen foutbanner onderaan de pagina
- [ ] Versienummer zichtbaar in de header
- [ ] `/instellingen` laadt zonder foutmelding

## Let op — deployment

Deze PR is een **draft**. Mergen naar `main` triggert automatisch een productie-deploy.
Merge pas uitvoeren bij de volgende versie-release (versienummer bumpen + CHANGELOG afronden).

Generated with Claude Code (https://claude.com/claude-code)