### PR TITLE
feat(#358): CSV teambegeleiding importeren via Admin GUI

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.5.1.0</Version>
-    <AssemblyVersion>2.5.1.0</AssemblyVersion>
-    <FileVersion>2.5.1.0</FileVersion>
+    <Version>2.6.0.0</Version>
+    <AssemblyVersion>2.6.0.0</AssemblyVersion>
+    <FileVersion>2.6.0.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.6.0.0</Version>
-    <AssemblyVersion>2.6.0.0</AssemblyVersion>
-    <FileVersion>2.6.0.0</FileVersion>
+    <Version>2.6.0.1</Version>
+    <AssemblyVersion>2.6.0.1</AssemblyVersion>
+    <FileVersion>2.6.0.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/Layout/MainLayout.razor
+++ b/BlazorAdmin/Layout/MainLayout.razor
@@ -4,6 +4,7 @@
 @using BlazorAdmin.Services
 @inject AdminApiClient Api
 @inject ClubSelectorService ClubSelector
+@implements IDisposable
 
 <div class="page">
     <div class="sidebar">
@@ -23,6 +24,13 @@
                         }
                     </select>
                 }
+                else if (_backendBezig)
+                {
+                    <span class="text-muted small d-flex align-items-center gap-1">
+                        <span class="spinner-border spinner-border-sm" style="width:.8rem;height:.8rem;" role="status"></span>
+                        Backend start op…
+                    </span>
+                }
             </div>
             <div class="flex-fill d-flex align-items-center justify-content-end gap-2">
                 <span class="text-muted small">v@(Assembly.GetExecutingAssembly().GetName().Version?.ToString(4) ?? "?")</span>
@@ -39,23 +47,41 @@
 
 @code {
     private List<ClubDto> _clubs = new();
+    private bool _backendBezig = true;
+    private CancellationTokenSource _cts = new();
 
     protected override async Task OnInitializedAsync()
     {
         await ClubSelector.InitializeAsync();
-        var result = await Api.GetClubsAsync();
-        if (result.Success && result.Data != null)
+        await LaadClubsAsync(_cts.Token);
+    }
+
+    private async Task LaadClubsAsync(CancellationToken ct)
+    {
+        // Max 12 pogingen × 3 s = 36 s wachttijd bij koude start
+        for (var poging = 0; poging < 12 && !ct.IsCancellationRequested; poging++)
         {
-            _clubs = result.Data;
-            // Valideer dat de opgeslagen ClubCode nog bestaat; terugval op eerste club
-            if (_clubs.Count > 0 &&
-                (ClubSelector.SelectedClubCode == null ||
-                 !_clubs.Any(c => c.ClubCode == ClubSelector.SelectedClubCode)))
+            var result = await Api.GetClubsAsync();
+            if (result.Success && result.Data?.Count > 0)
             {
-                var primary = _clubs.FirstOrDefault(c => c.SyncEnabled)?.ClubCode ?? _clubs[0].ClubCode;
-                await ClubSelector.SelectClubAsync(primary);
+                _clubs = result.Data;
+                if (ClubSelector.SelectedClubCode == null ||
+                    !_clubs.Any(c => c.ClubCode == ClubSelector.SelectedClubCode))
+                {
+                    var primary = _clubs.FirstOrDefault(c => c.SyncEnabled)?.ClubCode ?? _clubs[0].ClubCode;
+                    await ClubSelector.SelectClubAsync(primary);
+                }
+                _backendBezig = false;
+                return;
+            }
+
+            if (poging < 11)
+            {
+                StateHasChanged(); // toon spinner na eerste mislukte poging
+                try { await Task.Delay(3000, ct); } catch (OperationCanceledException) { return; }
             }
         }
+        _backendBezig = false; // stop spinner na time-out
     }
 
     private async Task OnClubChanged(ChangeEventArgs e)
@@ -64,4 +90,6 @@
         if (!string.IsNullOrWhiteSpace(code))
             await ClubSelector.SelectClubAsync(code);
     }
+
+    public void Dispose() => _cts.Cancel();
 }

--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -145,6 +145,20 @@ public class TeamRegelDto
 
 // ── Teambegeleiding ──
 
+public class TeambegeldingImportRequest
+{
+    public string CsvContent { get; set; } = "";
+    public string? Bestandsnaam { get; set; }
+}
+
+public class TeambegeldingImportResultaat
+{
+    public int Rijen { get; set; }
+    public List<string> Herkend { get; set; } = [];
+    public List<string> Ontbreekt { get; set; } = [];
+    public List<string> Waarschuwingen { get; set; } = [];
+}
+
 public class TeambegeleidingItem
 {
     public string Naam { get; set; } = "";

--- a/BlazorAdmin/Pages/Teambegeleiding.razor
+++ b/BlazorAdmin/Pages/Teambegeleiding.razor
@@ -4,6 +4,7 @@
 @inject ClubSelectorService ClubSelector
 @using BlazorAdmin.Models
 @using BlazorAdmin.Services
+@using Microsoft.AspNetCore.Components.Forms
 @implements IDisposable
 
 <PageTitle>Teambegeleiding — Admin</PageTitle>
@@ -130,6 +131,86 @@ else if (_selectedTeam != null && !_loadingBegeleiders)
     <div class="alert alert-info">Geen begeleiding gevonden voor @_selectedTeam.</div>
 }
 
+@* ── Teambegeleiding importeren ─────────────────────────────────────────────── *@
+<hr class="mt-4" />
+<h4>Teambegeleiding importeren</h4>
+<p class="text-muted small">
+    Download de CSV via club.sportlink.com → Leden → Exporteer tabel.<br />
+    De CSV wordt in de browser ingelezen en verwerkt — er worden geen bestanden opgeslagen op de server.
+</p>
+
+<div class="mb-3" style="max-width: 480px;">
+    <InputFile OnChange="BestandGeselecteerdAsync" accept=".csv" class="form-control"
+               disabled="@_importBezig" />
+</div>
+
+@if (_importLeesError != null)
+{
+    <div class="alert alert-danger">@_importLeesError</div>
+}
+
+@if (_csvPreview != null && _importResultaat == null)
+{
+    <div class="card border-info mb-3">
+        <div class="card-header bg-info bg-opacity-10">
+            Voorbeeldweergave — eerste @_csvPreview.VoorbeeldRijen.Count van @_csvPreview.TotaalRijen rijen
+        </div>
+        <div class="card-body p-0 table-responsive">
+            <table class="table table-sm table-bordered mb-0">
+                <thead class="table-light">
+                    <tr>
+                        @foreach (var h in _csvPreview.Headers)
+                        {
+                            <th class="small">@h</th>
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var rij in _csvPreview.VoorbeeldRijen)
+                    {
+                        <tr>
+                            @foreach (var cel in rij)
+                            {
+                                <td class="small text-nowrap">@cel</td>
+                            }
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    @if (_importError != null)
+    {
+        <div class="alert alert-danger">@_importError</div>
+    }
+
+    <button class="btn btn-warning" @onclick="ImporteerAsync" disabled="@_importBezig">
+        @if (_importBezig)
+        {
+            <span class="spinner-border spinner-border-sm me-1" role="status"></span>
+        }
+        Importeer @_csvPreview.TotaalRijen begeleider@(_csvPreview.TotaalRijen == 1 ? "" : "s")
+    </button>
+    <button class="btn btn-link text-muted ms-2" @onclick="ResetImport">Annuleer</button>
+}
+
+@if (_importResultaat != null)
+{
+    <div class="alert alert-success">
+        <strong>Geïmporteerd:</strong> @_importResultaat.Rijen begeleider@(_importResultaat.Rijen == 1 ? "" : "s") succesvol geladen.
+        @if (_importResultaat.Waarschuwingen.Count > 0)
+        {
+            <ul class="mt-2 mb-0 small">
+                @foreach (var w in _importResultaat.Waarschuwingen)
+                {
+                    <li>@w</li>
+                }
+            </ul>
+        }
+    </div>
+}
+
 @code {
     private List<string> _teams = new();
     private List<TeambegeleidingItem> _begeleiders = new();
@@ -143,6 +224,15 @@ else if (_selectedTeam != null && !_loadingBegeleiders)
     private string? _doorsturenError;
     private string? _doorsturenSuccess;
     private bool _gekopieerd;
+
+    // Import
+    private CsvPreviewModel? _csvPreview;
+    private string? _csvContent;
+    private string? _bestandsnaam;
+    private bool _importBezig;
+    private string? _importError;
+    private string? _importLeesError;
+    private TeambegeldingImportResultaat? _importResultaat;
 
     private string OutlookRegel => string.Join("; ", _begeleiders
         .Where(b => !string.IsNullOrWhiteSpace(b.Emailadres))
@@ -239,4 +329,96 @@ else if (_selectedTeam != null && !_loadingBegeleiders)
             _doorsturenError = result.ErrorMessage ?? "Doorsturen mislukt. Probeer opnieuw.";
         }
     }
+
+    // ── Import ────────────────────────────────────────────────────────────────
+
+    private async Task BestandGeselecteerdAsync(InputFileChangeEventArgs e)
+    {
+        _csvPreview = null;
+        _csvContent = null;
+        _importError = null;
+        _importLeesError = null;
+        _importResultaat = null;
+
+        var file = e.File;
+        if (!file.Name.EndsWith(".csv", StringComparison.OrdinalIgnoreCase))
+        {
+            _importLeesError = "Alleen CSV-bestanden (.csv) zijn toegestaan.";
+            return;
+        }
+
+        _bestandsnaam = file.Name;
+
+        try
+        {
+            using var stream = file.OpenReadStream(maxAllowedSize: 5 * 1024 * 1024);
+            using var reader = new System.IO.StreamReader(stream, System.Text.Encoding.UTF8);
+            _csvContent = await reader.ReadToEndAsync();
+        }
+        catch (Exception)
+        {
+            _importLeesError = "Bestand kon niet worden ingelezen. Controleer of het een geldig CSV-bestand is (max. 5 MB).";
+            return;
+        }
+
+        _csvPreview = MaakCsvPreview(_csvContent);
+        if (_csvPreview.TotaalRijen == 0)
+            _importLeesError = "CSV bevat geen gegevensrijen.";
+    }
+
+    private static CsvPreviewModel MaakCsvPreview(string csv)
+    {
+        var regels = csv
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(r => r.TrimEnd('\r'))
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .ToList();
+
+        if (regels.Count == 0)
+            return new CsvPreviewModel([], [], 0);
+
+        var headers = regels[0].Split(';').Select(h => h.Trim('"').Trim()).ToList();
+        var voorbeeldRijen = regels.Skip(1).Take(5)
+            .Select(r => r.Split(';').Select(v => v.Trim('"').Trim()).ToList())
+            .ToList();
+
+        return new CsvPreviewModel(headers, voorbeeldRijen, regels.Count - 1);
+    }
+
+    private async Task ImporteerAsync()
+    {
+        if (_csvContent == null) return;
+
+        _importBezig = true;
+        _importError = null;
+
+        var result = await Api.ImporteerTeambegeleidingAsync(_csvContent, _bestandsnaam);
+        _importBezig = false;
+
+        if (result.Success)
+        {
+            _importResultaat = result.Data;
+            _csvPreview = null;
+            _csvContent = null;
+            await LoadAsync();
+        }
+        else
+        {
+            _importError = result.ErrorMessage ?? "Import mislukt. Controleer het CSV-bestand en probeer opnieuw.";
+        }
+    }
+
+    private void ResetImport()
+    {
+        _csvPreview = null;
+        _csvContent = null;
+        _importError = null;
+        _importLeesError = null;
+        _importResultaat = null;
+    }
+
+    private record CsvPreviewModel(
+        List<string> Headers,
+        List<List<string>> VoorbeeldRijen,
+        int TotaalRijen);
 }

--- a/BlazorAdmin/Services/AdminApiClient.cs
+++ b/BlazorAdmin/Services/AdminApiClient.cs
@@ -146,6 +146,11 @@ public class AdminApiClient
     public async Task<ApiResult<object>> StuurTeambegeleidingBerichtAsync(DoorsturenRequest request)
         => await PostAsync<object>("api/beheer/teambegeleiding/doorsturen", request);
 
+    public async Task<ApiResult<TeambegeldingImportResultaat>> ImporteerTeambegeleidingAsync(
+        string csvContent, string? bestandsnaam)
+        => await PostAsync<TeambegeldingImportResultaat>("api/beheer/teambegeleiding/import",
+            new TeambegeldingImportRequest { CsvContent = csvContent, Bestandsnaam = bestandsnaam });
+
     // ── Speeltijden ──
 
     public async Task<ApiResult<List<SpeeltijdDto>>> GetSpeeltijdenAsync()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,15 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+## [2.6.0.1] — 2026-05-26
+
 ### Added
 - Teambegeleiding importeren via de Admin GUI (#358): beheerders kunnen nu een CSV-bestand van club.sportlink.com direct uploaden op de Teambegeleiding-pagina. De CSV wordt in de browser ingelezen (geen serveropslag — AVG), een voorbeeldtabel toont de eerste vijf rijen ter controle, en na bevestiging worden de begeleiders geïmporteerd met dezelfde kolomdetectie als het handmatige PowerShell-script. Handmatig script blijft bestaan als fallback.
 - `avg.ImportLog` uitgebreid met `ClubCode`-kolom voor multi-club isolatie van importlogs.
+- Koude-start indicator in de topbalk: zolang de backend nog opwarmt (koude start tot ±36 seconden) verschijnt een kleine spinner met "Backend start op…". Na succesvol laden verdwijnt de spinner en verschijnt automatisch de club-selector.
+
+### Fixed
+- CSV-import via de GUI gaf altijd "Import mislukt" door ontbrekende `ClubCode`-kolom in `avg.ImportLog`. Import werkt nu correct.
 
 ## [2.5.1.0] — 2026-05-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Added
+- Teambegeleiding importeren via de Admin GUI (#358): beheerders kunnen nu een CSV-bestand van club.sportlink.com direct uploaden op de Teambegeleiding-pagina. De CSV wordt in de browser ingelezen (geen serveropslag — AVG), een voorbeeldtabel toont de eerste vijf rijen ter controle, en na bevestiging worden de begeleiders geïmporteerd met dezelfde kolomdetectie als het handmatige PowerShell-script. Handmatig script blijft bestaan als fallback.
+- `avg.ImportLog` uitgebreid met `ClubCode`-kolom voor multi-club isolatie van importlogs.
+
 ## [2.5.1.0] — 2026-05-26
 
 ### Fixed

--- a/Database/avg/Tables/ImportLog.sql
+++ b/Database/avg/Tables/ImportLog.sql
@@ -5,5 +5,6 @@ CREATE TABLE [avg].[ImportLog] (
     [CsvBestand]       NVARCHAR (500) NULL,
     [ImporterendeDoor] NVARCHAR (200) NULL,
     [Duur_ms]          INT            NULL,
+    [ClubCode]         NVARCHAR (20)  NOT NULL CONSTRAINT [DF_avg_ImportLog_ClubCode] DEFAULT '',
     CONSTRAINT [PK_avg_ImportLog] PRIMARY KEY CLUSTERED ([Id] ASC)
 );

--- a/FunctionApp/Admin/AdminTeambegeleidingFunction.cs
+++ b/FunctionApp/Admin/AdminTeambegeleidingFunction.cs
@@ -210,5 +210,237 @@ public static class AdminTeambegeleidingFunction
         }
     }
 
+    /// <summary>
+    /// POST /api/beheer/teambegeleiding/import — verwerkt een CSV en importeert de begeleiders.
+    /// CSV-inhoud wordt in-memory verwerkt en nooit opgeslagen (AVG).
+    /// Audit log schrijft alleen metadata (rijen, bestandsnaam, duur) — geen PII.
+    /// </summary>
+    [Function("AdminTeambegeleidingImport")]
+    public static async Task<IActionResult> Import(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "beheer/teambegeleiding/import")] HttpRequest req,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("AdminTeambegeleidingImport");
+        var correlationId = EasyAuthHelper.ExtractOrCreateCorrelationId(req);
+        var authResult = EasyAuthHelper.RequireAdmin(req);
+        if (authResult != null) return authResult;
+        using var traceScope = log.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = correlationId });
+        try
+        {
+            await SystemUtilities.WaitForDatabaseAsync(log);
+
+            using var bodyReader = new StreamReader(req.Body);
+            var body = await bodyReader.ReadToEndAsync();
+            var dto = JsonConvert.DeserializeObject<TeambegeleidingImportRequest>(body);
+            if (dto == null || string.IsNullOrWhiteSpace(dto.CsvContent))
+                return new BadRequestObjectResult(new { error = "csvContent is vereist" });
+
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+
+            var parseResult = ParseCsv(dto.CsvContent);
+            if (!parseResult.IsValid)
+                return new BadRequestObjectResult(new
+                {
+                    error = parseResult.Error,
+                    ontbreekt = parseResult.Ontbreekt
+                });
+
+            using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+            await connection.OpenAsync();
+
+            using (var deleteCmd = new SqlCommand(
+                "DELETE FROM [avg].[Teambegeleiding] WHERE [ClubCode] = @ClubCode", connection))
+            {
+                deleteCmd.Parameters.AddWithValue("@ClubCode", clubCode);
+                await deleteCmd.ExecuteNonQueryAsync();
+            }
+
+            using (var tx = connection.BeginTransaction())
+            {
+                foreach (var row in parseResult.Rows)
+                {
+                    using var ins = new SqlCommand(@"
+                        INSERT INTO [avg].[Teambegeleiding]
+                            (Team, LeeftijdscategorieTeam, Teamrol, Naam, Emailadres, Telefoonnummer, ClubCode)
+                        VALUES
+                            (@Team, @Leeftijd, @Teamrol, @Naam, @Email, @Telefoon, @ClubCode)",
+                        connection, tx);
+                    ins.Parameters.AddWithValue("@Team",     (object?)row.Team ?? DBNull.Value);
+                    ins.Parameters.AddWithValue("@Leeftijd", (object?)row.LeeftijdscategorieTeam ?? DBNull.Value);
+                    ins.Parameters.AddWithValue("@Teamrol",  (object?)row.Teamrol ?? DBNull.Value);
+                    ins.Parameters.AddWithValue("@Naam",     (object?)row.Naam ?? DBNull.Value);
+                    ins.Parameters.AddWithValue("@Email",    (object?)row.Emailadres ?? DBNull.Value);
+                    ins.Parameters.AddWithValue("@Telefoon", (object?)row.Telefoonnummer ?? DBNull.Value);
+                    ins.Parameters.AddWithValue("@ClubCode", clubCode);
+                    await ins.ExecuteNonQueryAsync();
+                }
+                tx.Commit();
+            }
+
+            sw.Stop();
+
+            var importeerder = EasyAuthHelper.GetCallerName(req) ?? "admin";
+            using (var logCmd = new SqlCommand(@"
+                INSERT INTO [avg].[ImportLog] (AantalRijen, CsvBestand, ImporterendeDoor, Duur_ms, ClubCode)
+                VALUES (@rijen, @csv, @door, @duur, @club)", connection))
+            {
+                logCmd.Parameters.AddWithValue("@rijen", parseResult.Rows.Count);
+                logCmd.Parameters.AddWithValue("@csv",   (object?)dto.Bestandsnaam ?? DBNull.Value);
+                logCmd.Parameters.AddWithValue("@door",  importeerder);
+                logCmd.Parameters.AddWithValue("@duur",  (int)sw.ElapsedMilliseconds);
+                logCmd.Parameters.AddWithValue("@club",  clubCode);
+                await logCmd.ExecuteNonQueryAsync();
+            }
+
+            log.LogInformation("Teambegeleiding import geslaagd: {Rijen} rijen (geen PII gelogd — AVG)", parseResult.Rows.Count);
+
+            return new OkObjectResult(new
+            {
+                rijen         = parseResult.Rows.Count,
+                herkend       = parseResult.Herkend,
+                ontbreekt     = new List<string>(),
+                waarschuwingen = parseResult.Waarschuwingen
+            });
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij importeren teambegeleiding (geen PII gelogd — AVG)");
+            return new ObjectResult(new { error = "Import mislukt" }) { StatusCode = 500 };
+        }
+    }
+
+    // ── CSV parsing helpers ───────────────────────────────────────────────────
+
+    private static readonly Dictionary<string, string[]> _kolomAliassen = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Team"]                   = ["Team", "Teamnaam", "Team naam"],
+        ["Teamrol"]                = ["Teamrol", "Rol", "Rol in team", "Rol team"],
+        ["Roepnaam"]               = ["Roepnaam", "Voornaam", "First name"],
+        ["Achternaam"]             = ["Achternaam", "Familienaam", "Last name"],
+        ["Emailadres"]             = ["E-mailadres", "Email", "E-mail", "Emailadres", "Mailadres"],
+        ["LeeftijdscategorieTeam"] = ["Leeftijdscategorie team", "Leeftijdscategorie", "Age category"],
+        ["Tussenvoegsel"]          = ["Tussenvoegsel(s)", "Tussenvoegsel", "Infix", "Tussenv."],
+        ["MobielNummer"]           = ["Mobiel nummer", "Mobiel", "Mobiele telefoon", "Mobile"],
+        ["TelefoonnummerKolom"]    = ["Telefoonnummer", "Telefoon", "Vaste telefoon", "Phone"],
+    };
+
+    private static readonly string[] _vereistKolommen = ["Team", "Teamrol", "Roepnaam", "Achternaam", "Emailadres"];
+
+    private record ImportRij(
+        string? Team, string? LeeftijdscategorieTeam, string? Teamrol,
+        string? Naam, string? Emailadres, string? Telefoonnummer);
+
+    private class CsvParseResult
+    {
+        public bool IsValid { get; set; }
+        public string? Error { get; set; }
+        public List<string> Ontbreekt { get; set; } = [];
+        public List<string> Herkend { get; set; } = [];
+        public List<string> Waarschuwingen { get; set; } = [];
+        public List<ImportRij> Rows { get; set; } = [];
+    }
+
+    private static CsvParseResult ParseCsv(string csvContent)
+    {
+        var result = new CsvParseResult();
+        var lines = csvContent
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => l.TrimEnd('\r'))
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .ToList();
+
+        if (lines.Count < 2)
+        {
+            result.Error = "CSV bevat geen gegevensrijen.";
+            return result;
+        }
+
+        var headers = SplitCsvLine(lines[0]);
+
+        var mapping = new Dictionary<string, int>();
+        foreach (var (canonical, aliases) in _kolomAliassen)
+        {
+            for (int i = 0; i < headers.Length; i++)
+            {
+                if (aliases.Any(a => string.Equals(a, headers[i], StringComparison.OrdinalIgnoreCase)))
+                {
+                    mapping[canonical] = i;
+                    break;
+                }
+            }
+        }
+
+        var ontbreekt = _vereistKolommen.Where(v => !mapping.ContainsKey(v)).ToList();
+        if (ontbreekt.Count > 0)
+        {
+            result.IsValid = false;
+            result.Ontbreekt = ontbreekt;
+            result.Error = $"Vereiste kolommen niet gevonden: {string.Join(", ", ontbreekt)}";
+            return result;
+        }
+
+        result.Herkend = [.. mapping.Keys];
+
+        if (!mapping.ContainsKey("MobielNummer") && !mapping.ContainsKey("TelefoonnummerKolom"))
+            result.Waarschuwingen.Add("Geen telefoonnummer-kolom gevonden — Telefoonnummer wordt leeg.");
+        if (!mapping.ContainsKey("LeeftijdscategorieTeam"))
+            result.Waarschuwingen.Add("Kolom 'Leeftijdscategorie team' niet gevonden — wordt leeg.");
+
+        for (int i = 1; i < lines.Count; i++)
+        {
+            var fields = SplitCsvLine(lines[i]);
+
+            string? GetVeld(string key)
+            {
+                if (!mapping.TryGetValue(key, out var idx) || idx >= fields.Length) return null;
+                var v = fields[idx];
+                return string.IsNullOrWhiteSpace(v) ? null : v;
+            }
+
+            var naamDelen = new[] { GetVeld("Roepnaam"), GetVeld("Tussenvoegsel"), GetVeld("Achternaam") }
+                .Where(p => p != null).ToArray();
+            var naam = naamDelen.Length > 0 ? string.Join(" ", naamDelen) : null;
+
+            var telefoon = GetVeld("MobielNummer") ?? GetVeld("TelefoonnummerKolom");
+
+            result.Rows.Add(new ImportRij(
+                GetVeld("Team"),
+                GetVeld("LeeftijdscategorieTeam"),
+                GetVeld("Teamrol"),
+                naam,
+                GetVeld("Emailadres"),
+                telefoon));
+        }
+
+        result.IsValid = true;
+        return result;
+    }
+
+    private static string[] SplitCsvLine(string line)
+    {
+        var fields = new List<string>();
+        var current = new System.Text.StringBuilder();
+        bool inQuote = false;
+        for (int i = 0; i < line.Length; i++)
+        {
+            char c = line[i];
+            if (c == '"')
+            {
+                if (inQuote && i + 1 < line.Length && line[i + 1] == '"')
+                { current.Append('"'); i++; }
+                else
+                { inQuote = !inQuote; }
+            }
+            else if (c == ';' && !inQuote)
+            { fields.Add(current.ToString().Trim()); current.Clear(); }
+            else
+            { current.Append(c); }
+        }
+        fields.Add(current.ToString().Trim());
+        return [.. fields];
+    }
+
     private record DoorsturenRequest(string TeamNaam, string? Onderwerp, string Bericht);
+    private record TeambegeleidingImportRequest(string CsvContent, string? Bestandsnaam);
 }

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.5.1.0</Version>
-    <AssemblyVersion>2.5.1.0</AssemblyVersion>
-    <FileVersion>2.5.1.0</FileVersion>
+    <Version>2.6.0.0</Version>
+    <AssemblyVersion>2.6.0.0</AssemblyVersion>
+    <FileVersion>2.6.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.6.0.0</Version>
-    <AssemblyVersion>2.6.0.0</AssemblyVersion>
-    <FileVersion>2.6.0.0</FileVersion>
+    <Version>2.6.0.1</Version>
+    <AssemblyVersion>2.6.0.1</AssemblyVersion>
+    <FileVersion>2.6.0.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/exports/import-teambegeleiding-to-sql.ps1
+++ b/exports/import-teambegeleiding-to-sql.ps1
@@ -239,12 +239,13 @@ try {
     $stopwatch.Stop()
     $cmdLog             = $conn.CreateCommand()
     $cmdLog.CommandText = @"
-INSERT INTO [avg].[ImportLog] (AantalRijen, CsvBestand, ImporterendeDoor, Duur_ms)
-VALUES (@rijen, @csv, SYSTEM_USER, @duur)
+INSERT INTO [avg].[ImportLog] (AantalRijen, CsvBestand, ImporterendeDoor, Duur_ms, ClubCode)
+VALUES (@rijen, @csv, SYSTEM_USER, @duur, @club)
 "@
     $null = $cmdLog.Parameters.AddWithValue("@rijen", $table.Rows.Count)
     $null = $cmdLog.Parameters.AddWithValue("@csv",   $CsvPath)
     $null = $cmdLog.Parameters.AddWithValue("@duur",  [int]$stopwatch.ElapsedMilliseconds)
+    $null = $cmdLog.Parameters.AddWithValue("@club",  $ClubCode)
     $cmdLog.ExecuteNonQuery() | Out-Null
     Write-Host "  Importlog weggeschreven (avg.ImportLog)." -ForegroundColor Gray
 }


### PR DESCRIPTION
## Samenvatting

- Beheerders kunnen nu een CSV-bestand van club.sportlink.com direct uploaden op de Teambegeleiding-pagina, zonder het handmatige PowerShell-script te hoeven draaien
- CSV wordt in de browser ingelezen en als platte tekst via JSON verstuurd — geen serveropslag (AVG-compliant)
- Voorbeeldtabel toont eerste 5 rijen en kolomnamen ter controle vóór de definitieve import; verdwijnt na succesvolle import
- Dezelfde kolomdetectie en naamsamenstelling als het bestaande PowerShell-script (9 kolomaliassen, case-insensitief)
- Handmatig script blijft bestaan als fallback

## Gewijzigde bestanden

| Bestand | Wijziging |
|---|---|
| `FunctionApp/Admin/AdminTeambegeleidingFunction.cs` | Nieuw endpoint `POST /api/beheer/teambegeleiding/import` + CSV-parser |
| `BlazorAdmin/Models/AdminModels.cs` | `TeambegeldingImportRequest` + `TeambegeldingImportResultaat` DTOs |
| `BlazorAdmin/Services/AdminApiClient.cs` | `ImporteerTeambegeleidingAsync` methode |
| `BlazorAdmin/Pages/Teambegeleiding.razor` | Upload-sectie met preview + resultaat |
| `Database/avg/Tables/ImportLog.sql` | `ClubCode`-kolom toegevoegd |
| `exports/import-teambegeleiding-to-sql.ps1` | ClubCode meesturen in audit log INSERT |

## AVG/Security

- CSV-inhoud wordt uitsluitend in-memory verwerkt en nooit opgeslagen op de server
- `avg.ImportLog` logt alleen metadata (rijen, bestandsnaam, duur, ClubCode) — geen PII
- Endpoint vereist `EasyAuthHelper.RequireAdmin()` — zelfde auth als alle andere admin-endpoints
- Multi-club isolatie: DELETE en INSERT filteren altijd op ClubCode van de ingelogde beheerder

## Testplan

- [ ] CSV van club.sportlink.com selecteren → voorbeeldtabel verschijnt met eerste 5 rijen
- [ ] Importeer-knop → succesmelding met aantal rijen, preview verdwijnt
- [ ] Teambegeleiding-dropdown toont nieuwe teams direct na import
- [ ] CSV met ontbrekende verplichte kolom → foutmelding, geen import
- [ ] avg.ImportLog bevat nieuwe rij met ClubCode
- [ ] Handmatig PowerShell-script werkt nog steeds (backwards compatible)

> **Let op:** feature nog niet voor productie — CI mag groen zijn maar niet mergen zonder expliciete goedkeuring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)