### PR TITLE
fix(#355,#356,#359): GETUTCDATE setup-scripts + optionele coordinatorFunctie + Blazor globalization

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.5.0.1</Version>
-    <AssemblyVersion>2.5.0.1</AssemblyVersion>
-    <FileVersion>2.5.0.1</FileVersion>
+    <Version>2.5.1.0</Version>
+    <AssemblyVersion>2.5.1.0</AssemblyVersion>
+    <FileVersion>2.5.1.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.
@@ -15,6 +15,8 @@
          Fix: schakel Blazor's pre-compression uit zodat alleen .wasm aanwezig is in de publish-
          output. SWA's eigen dynamische compressie zet vervolgens wél de juiste Content-Encoding. -->
     <CompressionEnabled>false</CompressionEnabled>
+    <!-- nl-NL browser-locale veroorzaakte Blazor WASM crash in invariant-globalization-modus (#359) -->
+    <BlazorWebAssemblyLoadAllGlobalizationData>true</BlazorWebAssemblyLoadAllGlobalizationData>
   </PropertyGroup>
 
   <!-- .NET 10: Blazor-Environment HTTP header is vervangen door WasmApplicationEnvironmentName.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- Blazor WASM crashte bij nl-NL browser-locale ("An unhandled error has occurred") door ontbrekende globalization-data in invariant-mode (#359). Alle gebruikers met een Nederlandse browser konden de app niet openen.
+- Email-handtekening gebruikte hardcoded fallback "Coördinator thuiswedstrijden" als `coordinatorFunctie` niet geconfigureerd was (#356). Veld is nu optioneel — ontbrekende instelling geeft geen tekst, geen fout.
+
+### Security
+- Setup-scripts `fix-merge-procedure.sql` en `complete-database-setup.sql` gebruikten `GETDATE()` (lokale servertijd) in gegenereerde `sp_MergeStgToHis` voor `mta_modified`/`mta_inserted`. Vervangen door `GETUTCDATE()` (#355). Productie CI-pad was niet aangetast — alleen lokale developer-setup.
+
 ## [2.5.0.1] — 2026-05-26
 
 ### Fixed

--- a/FunctionApp/Email/BerichtResponseGenerator.cs
+++ b/FunctionApp/Email/BerichtResponseGenerator.cs
@@ -638,12 +638,13 @@ public static class BerichtResponseGenerator
         var afzenderNaam = SystemUtilities.AppSettings.GetSetting("plannerAfzenderNaam")
             ?? throw new InvalidOperationException("Vereiste instelling 'plannerAfzenderNaam' ontbreekt in dbo.AppSettings");
         var coordinatorNaam = SystemUtilities.AppSettings.GetSetting("coordinatorNaam");
-        var coordinatorFunctie = SystemUtilities.AppSettings.GetSetting("coordinatorFunctie") ?? "Coördinator thuiswedstrijden";
+        var coordinatorFunctie = SystemUtilities.AppSettings.GetSetting("coordinatorFunctie");
 
         var handtekening = $"Met vriendelijke groet,\n\n{afzenderNaam}";
         if (!string.IsNullOrEmpty(coordinatorNaam))
             handtekening += $"\nGeautomatiseerd antwoord namens {coordinatorNaam}";
-        handtekening += $"\n{coordinatorFunctie}";
+        if (!string.IsNullOrEmpty(coordinatorFunctie))
+            handtekening += $"\n{coordinatorFunctie}";
 
         return handtekening;
     }

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.5.0.1</Version>
-    <AssemblyVersion>2.5.0.1</AssemblyVersion>
-    <FileVersion>2.5.0.1</FileVersion>
+    <Version>2.5.1.0</Version>
+    <AssemblyVersion>2.5.1.0</AssemblyVersion>
+    <FileVersion>2.5.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/FunctionApp/setup/complete-database-setup.sql
+++ b/FunctionApp/setup/complete-database-setup.sql
@@ -73,8 +73,8 @@ BEGIN
         [Id] INT IDENTITY(1,1) PRIMARY KEY,
         [sportlinkApiUrl] NVARCHAR(500) NOT NULL,
         [sportlinkClientId] NVARCHAR(500) NOT NULL,
-        [CreatedDate] DATETIME2 DEFAULT GETDATE(),
-        [ModifiedDate] DATETIME2 DEFAULT GETDATE()
+        [CreatedDate] DATETIME2 DEFAULT GETUTCDATE(),
+        [ModifiedDate] DATETIME2 DEFAULT GETUTCDATE()
     );
     PRINT '  ✓ AppSettings table created';
 END
@@ -117,8 +117,8 @@ BEGIN
         [target_pk] NVARCHAR(255) NULL,
         [merge_type] NVARCHAR(10) DEFAULT 'IUD',
         [is_active] BIT DEFAULT 1,
-        [created_date] DATETIME2 DEFAULT GETDATE(),
-        [modified_date] DATETIME2 DEFAULT GETDATE()
+        [created_date] DATETIME2 DEFAULT GETUTCDATE(),
+        [modified_date] DATETIME2 DEFAULT GETUTCDATE()
     );
     PRINT '  ✓ Table [mta].[source_target_mapping] created';
 END
@@ -328,7 +328,7 @@ WHEN MATCHED AND ('
 THEN
 UPDATE SET ' 
     SET @SqlString  += @SqlStringTmp  + '
-    target.mta_modified = GETDATE()'
+    target.mta_modified = GETUTCDATE()'
     SET @SqlString  += '
 WHEN NOT MATCHED BY TARGET THEN '
 
@@ -347,7 +347,7 @@ WHEN NOT MATCHED BY TARGET THEN '
 INSERT 
     (' + @TargetPk + @SqlStringTargets + ', mta_inserted,mta_modified)
 VALUES 
-    (CAST(' + @SourcePkColumns + ' AS NVARCHAR(255))' + @SqlStringValues + ', GETDATE(), GETDATE());';
+    (CAST(' + @SourcePkColumns + ' AS NVARCHAR(255))' + @SqlStringValues + ', GETUTCDATE(), GETUTCDATE());';
     
     EXEC sp_sqlexec @SqlString ;
 END;

--- a/FunctionApp/setup/fix-merge-procedure.sql
+++ b/FunctionApp/setup/fix-merge-procedure.sql
@@ -140,7 +140,7 @@ WHEN MATCHED AND ('
 THEN
 UPDATE SET ';
     SET @SqlString  += @SqlStringTmp  + '
-    target.mta_modified = GETDATE()';
+    target.mta_modified = GETUTCDATE()';
     
     SET @SqlString  += '
 WHEN NOT MATCHED BY TARGET THEN ';
@@ -161,7 +161,7 @@ WHEN NOT MATCHED BY TARGET THEN ';
 INSERT 
     (' + @TargetPk + @SqlStringTargets + ', mta_inserted, mta_modified)
 VALUES 
-    (CAST(' + @SourcePkColumns + ' AS NVARCHAR(255))' + @SqlStringValues + ', GETDATE(), GETDATE());';
+    (CAST(' + @SourcePkColumns + ' AS NVARCHAR(255))' + @SqlStringValues + ', GETUTCDATE(), GETUTCDATE());';
     
     -- Execute the dynamic SQL
     EXEC sp_executesql @SqlString;


### PR DESCRIPTION
## Wijzigingen

### Security (#355)
- `fix-merge-procedure.sql` en `complete-database-setup.sql`: `GETDATE()` → `GETUTCDATE()` zodat `mta_modified`/`mta_inserted` tijdstempels correct als UTC worden opgeslagen bij lokale developer-setup. Productie CI-pad was niet aangetast.

### Fix (#356)
- `BerichtResponseGenerator.cs`: `coordinatorFunctie` is nu optioneel — geen hardcoded fallback meer naar een vaste Nederlandse functienaam. Ontbrekende instelling in `dbo.AppSettings` geeft nu geen tekst in de handtekening (in plaats van een vaste fallback-waarde).

### Fix (#359)
- `BlazorAdmin.csproj`: `BlazorWebAssemblyLoadAllGlobalizationData=true` toegevoegd — voorkomt Blazor WASM crash bij nl-NL browser-locale in invariant-globalization-modus. Gebruikers met Nederlandse browser konden de app niet openen.

### Versie
- Bump 2.5.0.1 → 2.5.1.0 (PATCH)

## Closes
Closes #355
Closes #356
Closes #359

## Test plan
- [ ] `dotnet build FunctionApp/fa-dev-sportlink-01.csproj` → exit 0
- [ ] `dotnet build BlazorAdmin/BlazorAdmin.csproj` → exit 0
- [ ] Security Gate CI check ✅