### PR TITLE
fix(#364): veldplanner multi-club isolatie en VeldType-gebaseerde grasveld-logica

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.6.0.1</Version>
-    <AssemblyVersion>2.6.0.1</AssemblyVersion>
-    <FileVersion>2.6.0.1</FileVersion>
+    <Version>2.6.1.0</Version>
+    <AssemblyVersion>2.6.1.0</AssemblyVersion>
+    <FileVersion>2.6.1.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -201,7 +201,7 @@ public class OptimaliseerResponseDto
     public string HuidigeEindtijd { get; set; } = "";
     public string? GeschatteNieuweEindtijd { get; set; }
     public int AantalVerplaatsingen { get; set; }
-    public int AantalVanVeld5Verplaatst { get; set; }
+    public int AantalVanGrasveldVerplaatst { get; set; }
     public List<OptimalisatieSuggestieDto> Suggesties { get; set; } = new();
     public string HtmlPlanner { get; set; } = "";
     public bool VoldoendeRuimte { get; set; }
@@ -226,7 +226,7 @@ public class VeldCapaciteitDto
     public int TotaalBeschikbareMinuten { get; set; }
     public int TotaalBezettMinuten { get; set; }
     public double BezettingsPercentage { get; set; }
-    public int AantalWedstrijdenOpVeld5 { get; set; }
+    public int AantalWedstrijdenOpGrasveld { get; set; }
     public int AantalLegeVelden { get; set; }
 }
 

--- a/BlazorAdmin/Pages/Dagplanning.razor
+++ b/BlazorAdmin/Pages/Dagplanning.razor
@@ -21,7 +21,7 @@
                 <label class="form-label">Optimalisatiedoel</label>
                 <select class="form-select" @bind="_doel">
                     <option value="">(geen voorkeur)</option>
-                    <option value="veld5-ontlasten">Veld 5 ontlasten</option>
+                    <option value="grasveld-ontlasten">Grasveld(en) ontlasten</option>
                     <option value="strakker-plannen">Strakker plannen</option>
                 </select>
             </div>
@@ -73,8 +73,8 @@
                     <small class="text-muted">Verplaatsingen</small>
                 </div>
                 <div class="col-md-2 col-6 mb-2">
-                    <div class="fs-5 fw-bold">@_resultaat.AantalVanVeld5Verplaatst</div>
-                    <small class="text-muted">Van veld 5 verplaatst</small>
+                    <div class="fs-5 fw-bold">@_resultaat.AantalVanGrasveldVerplaatst</div>
+                    <small class="text-muted">Van grasveld verplaatst</small>
                 </div>
                 @if (_resultaat.CapaciteitOverzicht != null)
                 {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- Veldplanner toonde alle 5 velden ongeacht de club (#364): de dagplanning en optimalisatie tonen nu alleen de velden die bij de actieve club horen (gefilterd op ClubCode). AllStars FC (3 velden) ziet voortaan niet meer de velden van andere clubs.
+- Veldplanner-optimalisatie was afhankelijk van hardcoded "veld 5 = grasveld": alle logica is nu gebaseerd op het `VeldType`-veld in de database (`kunstgras`/`gras`). Clubs met een ander aantal velden of een andere indeling worden correct behandeld.
+- Dagplanning UI: "Veld 5 ontlasten" hernoemd naar "Grasveld(en) ontlasten"; statistiek "Van veld 5 verplaatst" wordt nu "Van grasveld verplaatst".
+
 ## [2.6.0.1] — 2026-05-26
 
 ### Added

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -96,11 +96,12 @@ namespace SportlinkFunction.Planner
             return results;
         }
 
-        public static async Task<List<VeldBeschikbaarheidInfo>> GetAvailableFieldsAsync(DateOnly date)
+        public static async Task<List<VeldBeschikbaarheidInfo>> GetAvailableFieldsAsync(DateOnly date, string? clubCode = null)
         {
             var results = new List<VeldBeschikbaarheidInfo>();
             // DayOfWeek: .NET Maandag=1 komt overeen met onze DB-conventie (1=Maandag...7=Zondag)
             int dagVanWeek = ((int)date.DayOfWeek == 0) ? 7 : (int)date.DayOfWeek;
+            clubCode ??= SystemUtilities.AppSettings.GetPrimaryClubCode();
 
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
@@ -108,10 +109,11 @@ namespace SportlinkFunction.Planner
                 SELECT vb.[VeldNummer], vb.[BeschikbaarVanaf], vb.[BeschikbaarTot], vb.[GebruikZonsondergang]
                 FROM [dbo].[VeldBeschikbaarheid] vb
                 INNER JOIN [dbo].[Velden] v ON v.[VeldNummer] = vb.[VeldNummer]
-                WHERE v.[Actief] = 1 AND vb.[DagVanWeek] = @dag
+                WHERE v.[Actief] = 1 AND vb.[DagVanWeek] = @dag AND vb.[ClubCode] = @clubCode
                 ORDER BY vb.[VeldNummer]
             ", conn);
             cmd.Parameters.AddWithValue("@dag", dagVanWeek);
+            cmd.Parameters.AddWithValue("@clubCode", clubCode);
 
             using var reader = await cmd.ExecuteReaderAsync();
             while (await reader.ReadAsync())
@@ -127,13 +129,15 @@ namespace SportlinkFunction.Planner
             return results;
         }
 
-        public static async Task<List<VeldInfo>> GetVeldenAsync()
+        public static async Task<List<VeldInfo>> GetVeldenAsync(string? clubCode = null)
         {
+            clubCode ??= SystemUtilities.AppSettings.GetPrimaryClubCode();
             var results = new List<VeldInfo>();
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
             using var cmd = new SqlCommand(
-                "SELECT [VeldNummer], [VeldNaam], ISNULL([VeldType], 'kunstgras') AS [VeldType], [HeeftKunstlicht] FROM [dbo].[Velden] WHERE [Actief] = 1 ORDER BY [VeldNummer]", conn);
+                "SELECT [VeldNummer], [VeldNaam], ISNULL([VeldType], 'kunstgras') AS [VeldType], [HeeftKunstlicht] FROM [dbo].[Velden] WHERE [Actief] = 1 AND [ClubCode] = @clubCode ORDER BY [VeldNummer]", conn);
+            cmd.Parameters.AddWithValue("@clubCode", clubCode);
             using var reader = await cmd.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {

--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -173,9 +173,10 @@ namespace SportlinkFunction.Planner
                 if (request == null || string.IsNullOrEmpty(request.Datum))
                     return new BadRequestObjectResult(new { error = "Request body met 'datum' is verplicht." });
 
-                log.LogInformation("Optimaliseer: datum={Datum}, doel={Doel}", request.Datum, request.Doel);
+                var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
+                log.LogInformation("Optimaliseer: datum={Datum}, doel={Doel}, clubCode={ClubCode}", request.Datum, request.Doel, clubCode);
 
-                var response = await PlannerService.OptimaliseerAsync(request, log);
+                var response = await PlannerService.OptimaliseerAsync(request, clubCode, log);
 
                 var format = req.Query.ContainsKey("format") ? req.Query["format"].ToString() : "";
 
@@ -197,8 +198,8 @@ namespace SportlinkFunction.Planner
                         DateOnly.Parse(request.Datum),
                         await SportlinkApiClient.GetFieldOccupationsWithApiAsync(DateOnly.Parse(request.Datum), log),
                         response.Suggesties,
-                        await PlannerDataAccess.GetVeldenAsync(),
-                        request.Doel ?? "veld5-ontlasten",
+                        await PlannerDataAccess.GetVeldenAsync(clubCode),
+                        request.Doel ?? "grasveld-ontlasten",
                         browserUrl);
                     return new ContentResult { Content = emailHtml, ContentType = "text/html", StatusCode = 200 };
                 }

--- a/FunctionApp/Planner/PlannerHtmlGenerator.cs
+++ b/FunctionApp/Planner/PlannerHtmlGenerator.cs
@@ -41,7 +41,8 @@ namespace SportlinkFunction.Planner
         {
             var sb = new StringBuilder();
             var nl = new System.Globalization.CultureInfo("nl-NL");
-            var actieveVelden = velden.Where(v => v.VeldNummer <= 5).OrderBy(v => v.VeldNummer).ToList();
+            var grasveldNummers = velden.Where(v => v.VeldType != "kunstgras").Select(v => v.VeldNummer).ToHashSet();
+            var actieveVelden = velden.OrderBy(v => v.VeldNummer).ToList();
 
             // Dedup wedstrijden
             var wedstrijden = alleWedstrijden
@@ -140,7 +141,7 @@ namespace SportlinkFunction.Planner
             // Samenvatting
             var plannerNaam = SystemUtilities.AppSettings.GetSetting("plannerAfzenderNaam")
                 ?? throw new InvalidOperationException("Vereiste instelling 'plannerAfzenderNaam' ontbreekt in dbo.AppSettings");
-            sb.AppendLine($"<p style='margin:10px 0;color:{TXT_DIM};font-size:11px;'>Suggesties: {suggesties.Count} | Van veld 5 verplaatst: {suggesties.Count(s => s.HuidigVeldNummer == 5)} | Gegenereerd door {plannerNaam}</p>");
+            sb.AppendLine($"<p style='margin:10px 0;color:{TXT_DIM};font-size:11px;'>Suggesties: {suggesties.Count} | Van grasveld verplaatst: {suggesties.Count(s => grasveldNummers.Contains(s.HuidigVeldNummer))} | Gegenereerd door {plannerNaam}</p>");
 
             // JavaScript: klik-interactie
             sb.AppendLine("<script>");

--- a/FunctionApp/Planner/PlannerModels.cs
+++ b/FunctionApp/Planner/PlannerModels.cs
@@ -125,7 +125,7 @@ namespace SportlinkFunction.Planner
     public class OptimaliseerRequest
     {
         public string Datum { get; set; } = string.Empty;
-        public string? Doel { get; set; } // optioneel: veld5-ontlasten, strakker-plannen. Leeg = beide combineren
+        public string? Doel { get; set; } // optioneel: grasveld-ontlasten, strakker-plannen. Leeg = beide combineren
         public string? GewensteEindtijd { get; set; } // optioneel, standaard "16:15". Alles voor dit tijdstip = extra buffer
         public int? BufferMinuten { get; set; } // optioneel, standaard 15 min. Overschrijft de standaard buffer tussen wedstrijden
     }
@@ -136,7 +136,7 @@ namespace SportlinkFunction.Planner
         public string HuidigeEindtijd { get; set; } = string.Empty;
         public string? GeschatteNieuweEindtijd { get; set; }
         public int AantalVerplaatsingen { get; set; }
-        public int AantalVanVeld5Verplaatst { get; set; }
+        public int AantalVanGrasveldVerplaatst { get; set; }
         public List<OptimalisatieSuggestie> Suggesties { get; set; } = new();
         public string HtmlPlanner { get; set; } = string.Empty;
         public bool VoldoendeRuimte { get; set; }
@@ -149,7 +149,7 @@ namespace SportlinkFunction.Planner
         public int TotaalBeschikbareMinuten { get; set; }
         public int TotaalBezettMinuten { get; set; }
         public double BezettingsPercentage { get; set; }
-        public int AantalWedstrijdenOpVeld5 { get; set; }
+        public int AantalWedstrijdenOpGrasveld { get; set; }
         public int AantalLegeVelden { get; set; }
     }
 

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -256,8 +256,9 @@ namespace SportlinkFunction.Planner
         {
             var endTime = preferredTime.AddMinutes(duurMinuten);
 
-            // Elk veld proberen in voorkeursvolgorde (veld 1-4 voor veld 5)
-            foreach (var field in availableFields.OrderBy(f => f.VeldNummer == 5 ? 1 : 0))
+            // Kunstgrasvelden prefereren boven grasvelden (grasvelden laatste keuze)
+            var grasveldNummers = velden.Where(v => v.VeldType != "kunstgras").Select(v => v.VeldNummer).ToHashSet();
+            foreach (var field in availableFields.OrderBy(f => grasveldNummers.Contains(f.VeldNummer) ? 1 : 0))
             {
                 // Controleer binnen beschikbaarheidsvenster
                 if (preferredTime < field.BeschikbaarVanaf || endTime > field.BeschikbaarTot)
@@ -377,8 +378,9 @@ namespace SportlinkFunction.Planner
                 }
             }
 
-            // Sorteren: veld 1-4 prefereren boven veld 5
-            return candidates.OrderBy(c => c.VeldNummer == 5 ? 1 : 0)
+            // Sorteren: kunstgrasvelden prefereren boven grasvelden
+            var grasveldNummersSort = velden.Where(v => v.VeldType != "kunstgras").Select(v => v.VeldNummer).ToHashSet();
+            return candidates.OrderBy(c => grasveldNummersSort.Contains(c.VeldNummer) ? 1 : 0)
                              .ThenBy(c => c.AanvangsTijd.ToTimeSpan().TotalMinutes)
                              .ToList();
         }
@@ -625,7 +627,7 @@ namespace SportlinkFunction.Planner
             if (date.DayOfWeek >= DayOfWeek.Monday && date.DayOfWeek <= DayOfWeek.Thursday)
             {
                 response.Waarschuwingen.Add(
-                    $"{date.ToString("dddd", NL)}: alleen veld 5 beschikbaar (veld 1-4 training).");
+                    $"{date.ToString("dddd", NL)}: doordeweeks — kunstgrasvelden mogelijk in gebruik voor training. Controleer veldbeschikbaarheid.");
             }
         }
 
@@ -738,7 +740,7 @@ namespace SportlinkFunction.Planner
         // ── Optimalisatie logica ──
 
         public static async Task<OptimaliseerResponse> OptimaliseerAsync(
-            OptimaliseerRequest request, ILogger log)
+            OptimaliseerRequest request, string? clubCode, ILogger log)
         {
             var nl = new System.Globalization.CultureInfo("nl-NL");
             var response = new OptimaliseerResponse { Datum = request.Datum };
@@ -751,8 +753,10 @@ namespace SportlinkFunction.Planner
 
             // Data laden (real-time API of DB als fallback)
             var occupations = await SportlinkApiClient.GetFieldOccupationsWithApiAsync(date, log);
-            var velden = await PlannerDataAccess.GetVeldenAsync();
-            var availableFields = await PlannerDataAccess.GetAvailableFieldsAsync(date);
+            var velden = await PlannerDataAccess.GetVeldenAsync(clubCode);
+            var availableFields = await PlannerDataAccess.GetAvailableFieldsAsync(date, clubCode);
+            var grasveldNummers = velden.Where(v => v.VeldType != "kunstgras").Select(v => v.VeldNummer).ToHashSet();
+            var kunstgrasNummers = velden.Where(v => v.VeldType == "kunstgras").Select(v => v.VeldNummer).ToHashSet();
 
             // Dedup bezettingen
             var bezettingen = occupations
@@ -793,31 +797,30 @@ namespace SportlinkFunction.Planner
             int bufferMin = request.BufferMinuten ?? StandardBufferMinutes;
 
             // Capaciteitsberekening en optimalisatie-noodzaak analyse
-            var capaciteit = BerekenCapaciteit(bezettingen, availableFields);
+            var capaciteit = BerekenCapaciteit(bezettingen, availableFields, grasveldNummers);
             response.CapaciteitOverzicht = capaciteit;
 
             // Bepaal welke optimalisaties zinvol zijn voor deze specifieke dag en het opgegeven doel.
             //
-            // veld5-ontlasten: zinvol als veld 1-4 beschikbaar zijn (zaterdag) én er wedstrijden op
-            //   veld 5 staan. Op doordeweekse dagen zijn veld 1-4 in gebruik voor training en zijn er
-            //   geen alternatieve velden — veld 5 is dan per definitie de juiste plek.
+            // grasveld-ontlasten: zinvol als kunstgrasvelden beschikbaar zijn (zaterdag) én er wedstrijden op
+            //   grasveld staan. Op doordeweekse dagen zijn kunstgrasvelden mogelijk in gebruik voor training.
             //
             // strakker-plannen: zinvol als de gebruiker een gewenste eindtijd heeft opgegeven of
             //   het doel expliciet op 'strakker-plannen' gezet heeft. Zonder die grenswaarde weet
             //   de planner niet wat 'beter' is en genereert hij onnodig suggesties.
             var doel = (request.Doel ?? "").ToLowerInvariant().Trim();
-            bool alleenVeld5Beschikbaar = availableFields.Count > 0 && !availableFields.Any(f => f.VeldNummer <= 4);
+            bool alleenGrasveldBeschikbaar = availableFields.Count > 0 && !availableFields.Any(f => kunstgrasNummers.Contains(f.VeldNummer));
             bool gewensteEindtijdOpgegeven = !string.IsNullOrEmpty(request.GewensteEindtijd);
-            bool veld5OntlastenZinvol = !alleenVeld5Beschikbaar && capaciteit.AantalWedstrijdenOpVeld5 > 0;
+            bool grasveldOntlastenZinvol = !alleenGrasveldBeschikbaar && capaciteit.AantalWedstrijdenOpGrasveld > 0;
             bool strakkerPlannenZinvol = gewensteEindtijdOpgegeven || doel == "strakker-plannen";
 
-            // Check 1: laag bezettingspercentage én geen veld 5 gebruik (bestaande check)
-            if (capaciteit.AantalWedstrijdenOpVeld5 == 0 && capaciteit.BezettingsPercentage < MaxBezettingsPercentageVoorOverslaan)
+            // Check 1: laag bezettingspercentage én geen grasveld gebruik
+            if (capaciteit.AantalWedstrijdenOpGrasveld == 0 && capaciteit.BezettingsPercentage < MaxBezettingsPercentageVoorOverslaan)
             {
                 response.VoldoendeRuimte = true;
                 response.VoldoendeRuimteMelding =
                     $"Voldoende ruimte op {date.ToString("dddd d MMMM", nl)}: " +
-                    $"geen wedstrijden op veld 5, {capaciteit.BezettingsPercentage:F0}% bezet " +
+                    $"geen wedstrijden op grasveld, {capaciteit.BezettingsPercentage:F0}% bezet " +
                     $"({capaciteit.AantalLegeVelden} veld(en) ongebruikt). Geen optimalisatie nodig.";
                 response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(
                     date, bezettingen, new List<OptimalisatieSuggestie>(), velden, doel);
@@ -825,11 +828,11 @@ namespace SportlinkFunction.Planner
             }
 
             // Check 2: geen enkel optimalisatiedoel is zinvol voor deze dag
-            if (!veld5OntlastenZinvol && !strakkerPlannenZinvol)
+            if (!grasveldOntlastenZinvol && !strakkerPlannenZinvol)
             {
-                string redenDetail = alleenVeld5Beschikbaar
-                    ? "doordeweekse dag — veld 1-4 niet beschikbaar, veld 5 is de enige optie en er is geen gewenste eindtijd opgegeven"
-                    : "geen wedstrijden op veld 5 en geen gewenste eindtijd opgegeven";
+                string redenDetail = alleenGrasveldBeschikbaar
+                    ? "doordeweekse dag — alleen grasveld beschikbaar, kunstgrasvelden niet beschikbaar, en er is geen gewenste eindtijd opgegeven"
+                    : "geen wedstrijden op grasveld en geen gewenste eindtijd opgegeven";
                 response.VoldoendeRuimte = true;
                 response.VoldoendeRuimteMelding = $"Geen optimalisatie nodig op {date.ToString("dddd d MMMM", nl)}: {redenDetail}.";
                 response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(
@@ -841,17 +844,17 @@ namespace SportlinkFunction.Planner
 
             switch (doel)
             {
-                case "veld5-ontlasten":
-                    if (veld5OntlastenZinvol)
-                        suggesties = OptimaliseerVeld5Ontlasten(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
+                case "grasveld-ontlasten":
+                    if (grasveldOntlastenZinvol)
+                        suggesties = OptimaliseerGrasveldOntlasten(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
                     break;
                 case "strakker-plannen":
                     if (strakkerPlannenZinvol)
                         suggesties = OptimaliseerStrakkerPlannen(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
                     break;
                 default:
-                    if (veld5OntlastenZinvol)
-                        suggesties = OptimaliseerVeld5Ontlasten(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
+                    if (grasveldOntlastenZinvol)
+                        suggesties = OptimaliseerGrasveldOntlasten(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
                     if (strakkerPlannenZinvol)
                     {
                         var strakkerSuggesties = OptimaliseerStrakkerPlannen(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
@@ -899,7 +902,7 @@ namespace SportlinkFunction.Planner
 
             response.Suggesties = suggesties;
             response.AantalVerplaatsingen = suggesties.Count;
-            response.AantalVanVeld5Verplaatst = suggesties.Count(s => s.HuidigVeldNummer == 5);
+            response.AantalVanGrasveldVerplaatst = suggesties.Count(s => grasveldNummers.Contains(s.HuidigVeldNummer));
 
             // HTML genereren
             response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(date, bezettingen, suggesties, velden, request.Doel ?? "optimaliseren");
@@ -909,7 +912,8 @@ namespace SportlinkFunction.Planner
 
         private static VeldCapaciteitInfo BerekenCapaciteit(
             List<BestaandeWedstrijd> bezettingen,
-            List<VeldBeschikbaarheidInfo> beschikbareVelden)
+            List<VeldBeschikbaarheidInfo> beschikbareVelden,
+            HashSet<int> grasveldNummers)
         {
             int totaalBeschikbaar = 0;
             foreach (var veld in beschikbareVelden)
@@ -928,12 +932,12 @@ namespace SportlinkFunction.Planner
                 TotaalBezettMinuten = totaalBezet,
                 BezettingsPercentage = totaalBeschikbaar > 0
                     ? (double)totaalBezet / totaalBeschikbaar * 100.0 : 0,
-                AantalWedstrijdenOpVeld5 = bezettingen.Count(b => b.VeldNummer == 5),
+                AantalWedstrijdenOpGrasveld = bezettingen.Count(b => grasveldNummers.Contains(b.VeldNummer)),
                 AantalLegeVelden = aantalLegeVelden
             };
         }
 
-        private static List<OptimalisatieSuggestie> OptimaliseerVeld5Ontlasten(
+        private static List<OptimalisatieSuggestie> OptimaliseerGrasveldOntlasten(
             List<BestaandeWedstrijd> bezettingen,
             List<VeldInfo> velden,
             List<VeldBeschikbaarheidInfo> beschikbareVelden,
@@ -941,11 +945,13 @@ namespace SportlinkFunction.Planner
             Dictionary<string, List<TeamRegel>> allTeamRules,
             int bufferMin = 15)
         {
+            var grasveldNummers = velden.Where(v => v.VeldType != "kunstgras").Select(v => v.VeldNummer).ToHashSet();
+            var kunstgrasNummers = velden.Where(v => v.VeldType == "kunstgras").Select(v => v.VeldNummer).ToHashSet();
             var suggesties = new List<OptimalisatieSuggestie>();
 
-            // Wedstrijden op veld 5 die verplaatst mogen worden
-            var veld5Wedstrijden = bezettingen
-                .Where(b => b.VeldNummer == 5)
+            // Wedstrijden op grasvelden die verplaatst mogen worden
+            var grasveldWedstrijden = bezettingen
+                .Where(b => grasveldNummers.Contains(b.VeldNummer))
                 .Where(b => !vasteWedstrijden.Contains($"{b.VeldNummer}_{b.AanvangsTijd:HH:mm}_{b.Wedstrijd?.Trim()}"))
                 .OrderBy(b => b.AanvangsTijd)
                 .ToList();
@@ -953,21 +959,22 @@ namespace SportlinkFunction.Planner
             // Werk met een kopie van bezettingen die we aanpassen naarmate we suggesties doen
             var werkBezettingen = bezettingen.ToList();
 
-            foreach (var wedstrijd in veld5Wedstrijden)
+            foreach (var wedstrijd in grasveldWedstrijden)
             {
                 int duur = (int)(wedstrijd.EindTijd - wedstrijd.AanvangsTijd).TotalMinutes;
                 decimal fractie = wedstrijd.VeldDeelGebruik;
+                var huidigVeldNaam = velden.FirstOrDefault(v => v.VeldNummer == wedstrijd.VeldNummer)?.VeldNaam ?? $"veld {wedstrijd.VeldNummer}";
 
-                // Zoek een plek op veld 1-4 die EERDER is dan huidige tijd op veld 5
+                // Zoek een plek op kunstgrasveld die EERDER is dan huidige tijd op grasveld
                 // Alleen verplaatsen als het een verbetering is (eerder of gelijktijdig op kunstgras)
                 CandidateSlot? besteSlot = null;
-                foreach (var veldBesch in beschikbareVelden.Where(f => f.VeldNummer <= 4).OrderBy(f => f.VeldNummer))
+                foreach (var veldBesch in beschikbareVelden.Where(f => kunstgrasNummers.Contains(f.VeldNummer)).OrderBy(f => f.VeldNummer))
                 {
                     var veldBezetting = werkBezettingen.Where(b => b.VeldNummer == veldBesch.VeldNummer).ToList();
 
                     for (var tijd = veldBesch.BeschikbaarVanaf; tijd.AddMinutes(duur) <= veldBesch.BeschikbaarTot; tijd = tijd.AddMinutes(5))
                     {
-                        // Alleen accepteren als het niet later is dan de huidige tijd op veld 5
+                        // Alleen accepteren als het niet later is dan de huidige tijd op grasveld
                         if (tijd > wedstrijd.AanvangsTijd) break;
 
                         var eindTijd = tijd.AddMinutes(duur);
@@ -992,13 +999,13 @@ namespace SportlinkFunction.Planner
                     suggesties.Add(new OptimalisatieSuggestie
                     {
                         Wedstrijd = wedstrijd.Wedstrijd?.Trim() ?? "",
-                        HuidigVeldNummer = 5,
-                        HuidigVeld = "veld 5",
+                        HuidigVeldNummer = wedstrijd.VeldNummer,
+                        HuidigVeld = huidigVeldNaam,
                         HuidigeTijd = wedstrijd.AanvangsTijd.ToString("HH:mm"),
                         NieuwVeldNummer = besteSlot.VeldNummer,
                         NieuwVeld = veldNaam,
                         NieuweTijd = RondAfOp5Min(besteSlot.AanvangsTijd).ToString("HH:mm"),
-                        Reden = $"Verplaats van veld 5 (geen kunstlicht) naar {veldNaam}"
+                        Reden = $"Verplaats van {huidigVeldNaam} (grasveld) naar {veldNaam} (kunstgras)"
                     });
 
                     // Werkbezetting bijwerken zodat volgende suggesties deze plek als bezet zien

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -96,6 +96,8 @@ namespace SportlinkFunction
                 return settings.TryGetValue(key, out var value) ? value : null;
             }
 
+            public static string GetPrimaryClubCode() => GetSetting("clubCode") ?? "";
+
             public static async Task SaveLastSyncTimestampAsync(ILogger log)
             {
                 try

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.6.0.1</Version>
-    <AssemblyVersion>2.6.0.1</AssemblyVersion>
-    <FileVersion>2.6.0.1</FileVersion>
+    <Version>2.6.1.0</Version>
+    <AssemblyVersion>2.6.1.0</AssemblyVersion>
+    <FileVersion>2.6.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
## Probleem

De dagplanning-optimalisatie toonde altijd alle 5 velden, ongeacht de actieve club. AllStars FC (3 velden) zag velden van de primaire club. Bovendien was de optimalisatie-logica hardcoded op "VeldNummer == 5 = grasveld", wat breekt zodra een club een ander aantal velden of andere indeling heeft.

## Oplossing

- `GetVeldenAsync` en `GetAvailableFieldsAsync` filteren nu altijd op `ClubCode` — elke club ziet alleen zijn eigen velden
- `GetPrimaryClubCode()` toegevoegd aan `AppSettings` als standaard fallback voor endpoints zonder Entra-auth
- Hardcoded `VeldNummer == 5` (grasveld) en `VeldNummer <= 4` (kunstgras) vervangen door dynamische `VeldType`-detectie uit de database
- `OptimaliseerAsync` accepteert nu `string? clubCode` en geeft de velden van de juiste club door aan alle sub-functies
- `OptimaliseerVeld5Ontlasten` → hernoemd naar `OptimaliseerGrasveldOntlasten`, volledig VeldType-gebaseerd
- Dagplanning UI: dropdown-optie "Veld 5 ontlasten" → "Grasveld(en) ontlasten"; statistiekveld "Van veld 5 verplaatst" → "Van grasveld verplaatst"
- HTML-planner toont nu alle velden van de club (geen `VeldNummer <= 5`-filter meer)

## Technische details

- `VeldInfo.VeldType` (`kunstgras`/`gras`) is de enige autoriteitswaarde voor veldtype
- `grasveldNummers` en `kunstgrasNummers` worden per aanroep opgebouwd uit de geladen velden (geen shared state)
- Alle sortering (kunstgras prefereren boven gras) en filtering in `TryExactTime`, `FindAllSlots` en `OptimaliseerGrasveldOntlasten` gebruikt nu de dynamische sets

Closes #364

🤖 Generated with [Claude Code](https://claude.ai/claude-code)