### PR TITLE
feat(#365): test data modus (ALLSTARS) — invoergrid voor fictieve wedstrijden

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.8.0.1</Version>
-    <AssemblyVersion>2.8.0.1</AssemblyVersion>
-    <FileVersion>2.8.0.1</FileVersion>
+    <Version>2.11.0.0</Version>
+    <AssemblyVersion>2.11.0.0</AssemblyVersion>
+    <FileVersion>2.11.0.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.8.0.0</Version>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
-    <FileVersion>2.8.0.0</FileVersion>
+    <Version>2.8.0.1</Version>
+    <AssemblyVersion>2.8.0.1</AssemblyVersion>
+    <FileVersion>2.8.0.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.11.0.0</Version>
-    <AssemblyVersion>2.11.0.0</AssemblyVersion>
-    <FileVersion>2.11.0.0</FileVersion>
+    <Version>2.6.0.15</Version>
+    <AssemblyVersion>2.6.0.15</AssemblyVersion>
+    <FileVersion>2.6.0.15</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.6.0.1</Version>
-    <AssemblyVersion>2.6.0.1</AssemblyVersion>
-    <FileVersion>2.6.0.1</FileVersion>
+    <Version>2.7.0.0</Version>
+    <AssemblyVersion>2.7.0.0</AssemblyVersion>
+    <FileVersion>2.7.0.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.7.0.0</Version>
-    <AssemblyVersion>2.7.0.0</AssemblyVersion>
-    <FileVersion>2.7.0.0</FileVersion>
+    <Version>2.8.0.0</Version>
+    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <FileVersion>2.8.0.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/Layout/MainLayout.razor
+++ b/BlazorAdmin/Layout/MainLayout.razor
@@ -17,7 +17,7 @@
             <div class="d-flex justify-content-center">
                 @if (_clubs.Count > 1)
                 {
-                    <select class="form-select form-select-sm club-selector" style="min-width:200px" @onchange="OnClubChanged" value="@ClubSelector.SelectedClubCode">
+                    <select class="form-select form-select-sm club-selector" style="min-width:200px" @onchange="OnClubChanged" value="@ClubSelector.SelectedClubCode" disabled="@(ClubSelector.SelectedClubCode == "ALLSTARS")">
                         @foreach (var club in _clubs)
                         {
                             <option value="@club.ClubCode">@club.ClubName</option>
@@ -66,7 +66,8 @@
             {
                 _clubs = result.Data;
                 if (ClubSelector.SelectedClubCode == null ||
-                    !_clubs.Any(c => c.ClubCode == ClubSelector.SelectedClubCode))
+                    (!_clubs.Any(c => c.ClubCode == ClubSelector.SelectedClubCode) &&
+                     ClubSelector.SelectedClubCode != "ALLSTARS"))
                 {
                     var primary = _clubs.FirstOrDefault(c => c.SyncEnabled)?.ClubCode ?? _clubs[0].ClubCode;
                     await ClubSelector.SelectClubAsync(primary);

--- a/BlazorAdmin/Layout/MainLayout.razor
+++ b/BlazorAdmin/Layout/MainLayout.razor
@@ -4,6 +4,7 @@
 @using BlazorAdmin.Services
 @inject AdminApiClient Api
 @inject ClubSelectorService ClubSelector
+@inject ApiStatusService ApiStatus
 @implements IDisposable
 
 <div class="page">
@@ -24,13 +25,6 @@
                         }
                     </select>
                 }
-                else if (_backendBezig)
-                {
-                    <span class="text-muted small d-flex align-items-center gap-1">
-                        <span class="spinner-border spinner-border-sm" style="width:.8rem;height:.8rem;" role="status"></span>
-                        Backend start op…
-                    </span>
-                }
             </div>
             <div class="flex-fill d-flex align-items-center justify-content-end gap-2">
                 <span class="text-muted small">v@(Assembly.GetExecutingAssembly().GetName().Version?.ToString(4) ?? "?")</span>
@@ -38,6 +32,24 @@
                 <a href="https://github.com/Jaapbeus/Sportlink-wedstrijdzaken" target="_blank">About</a>
             </div>
         </div>
+
+        @if (ApiStatus.Status != BackendStatus.Ok)
+        {
+            <div class="backend-status-banner @(ApiStatus.Status == BackendStatus.StartingUp ? "banner-warning" : "banner-error")">
+                @if (ApiStatus.Status == BackendStatus.StartingUp)
+                {
+                    <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+                    <span><strong>Backend start op…</strong> Even geduld, dit duurt ca. 15 seconden na een (her)start.</span>
+                }
+                else
+                {
+                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="me-2" viewBox="0 0 16 16">
+                        <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5m.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2"/>
+                    </svg>
+                    <span><strong>Backend niet bereikbaar.</strong> @ApiStatus.Foutmelding</span>
+                }
+            </div>
+        }
 
         <article class="content px-4">
             @Body
@@ -47,14 +59,17 @@
 
 @code {
     private List<ClubDto> _clubs = new();
-    private bool _backendBezig = true;
     private CancellationTokenSource _cts = new();
 
     protected override async Task OnInitializedAsync()
     {
+        ApiStatus.OnChanged += OnApiStatusChanged;
+        ApiStatus.MeldStartend();
         await ClubSelector.InitializeAsync();
         await LaadClubsAsync(_cts.Token);
     }
+
+    private void OnApiStatusChanged() => InvokeAsync(StateHasChanged);
 
     private async Task LaadClubsAsync(CancellationToken ct)
     {
@@ -72,17 +87,19 @@
                     var primary = _clubs.FirstOrDefault(c => c.SyncEnabled)?.ClubCode ?? _clubs[0].ClubCode;
                     await ClubSelector.SelectClubAsync(primary);
                 }
-                _backendBezig = false;
+                // ApiStatusService.Herstel() wordt al aangeroepen door AdminApiClient bij succesvolle call
                 return;
             }
 
             if (poging < 11)
             {
-                StateHasChanged(); // toon spinner na eerste mislukte poging
+                StateHasChanged();
                 try { await Task.Delay(3000, ct); } catch (OperationCanceledException) { return; }
             }
         }
-        _backendBezig = false; // stop spinner na time-out
+        // Na 36 s timeout: zet expliciete foutmelding als de ApiStatusService nog geen fout heeft
+        if (ApiStatus.Status != BackendStatus.Fout)
+            ApiStatus.MeldFout("Backend niet bereikbaar na meerdere pogingen. Controleer of de FunctionApp draait (poort 7094).");
     }
 
     private async Task OnClubChanged(ChangeEventArgs e)
@@ -92,5 +109,9 @@
             await ClubSelector.SelectClubAsync(code);
     }
 
-    public void Dispose() => _cts.Cancel();
+    public void Dispose()
+    {
+        ApiStatus.OnChanged -= OnApiStatusChanged;
+        _cts.Cancel();
+    }
 }

--- a/BlazorAdmin/Layout/MainLayout.razor.css
+++ b/BlazorAdmin/Layout/MainLayout.razor.css
@@ -37,6 +37,26 @@ main {
         text-overflow: ellipsis;
     }
 
+.backend-status-banner {
+    padding: 0.65rem 1.25rem;
+    font-size: 0.9rem;
+    display: flex;
+    align-items: center;
+    border-bottom: 2px solid transparent;
+}
+
+.banner-warning {
+    background-color: #fff3cd;
+    color: #664d03;
+    border-bottom-color: #ffc107;
+}
+
+.banner-error {
+    background-color: #f8d7da;
+    color: #58151c;
+    border-bottom-color: #dc3545;
+}
+
 .club-selector {
     min-width: 130px;
     max-width: 200px;

--- a/BlazorAdmin/Layout/NavMenu.razor
+++ b/BlazorAdmin/Layout/NavMenu.razor
@@ -1,6 +1,7 @@
 @inject IAuthService Auth
 @inject BlazorAdmin.Services.AdminApiClient Api
 @inject BlazorAdmin.Services.ThemeService ThemeService
+@inject BlazorAdmin.Services.ClubSelectorService ClubSelector
 @inject NavigationManager Navigation
 @implements IDisposable
 
@@ -86,10 +87,44 @@
             }
         </div>
 
+        @* Test data — alleen zichtbaar in ALLSTARS modus *@
+        @if (ClubSelector.SelectedClubCode == "ALLSTARS")
+        {
+            <div class="nav-item px-3">
+                <button class="nav-link btn btn-link text-start w-100 d-flex justify-content-between align-items-center px-0 py-1"
+                        @onclick="ToggleTestData" @onclick:stopPropagation="true">
+                    <span><i class="bi bi-database-gear me-1" aria-hidden="true"></i> Test data</span>
+                    <i class="bi @(_testDataOpen ? "bi-chevron-down" : "bi-chevron-right") ms-1 small" aria-hidden="true"></i>
+                </button>
+                @if (_testDataOpen)
+                {
+                    <div class="ps-2">
+                        <div class="nav-item">
+                            <NavLink class="nav-link py-1" href="testdata/wedstrijden">
+                                <i class="bi bi-calendar-plus me-1" aria-hidden="true"></i> Wedstrijden
+                            </NavLink>
+                        </div>
+                    </div>
+                }
+            </div>
+        }
+
         @if (Auth.IsAuthenticated)
         {
             <div class="nav-item px-3 mt-3">
                 <small class="text-light px-2 d-block">Ingelogd als @Auth.UserName@(Auth.IsAdmin ? " (admin)" : "")</small>
+                @if (ClubSelector.SelectedClubCode == "ALLSTARS")
+                {
+                    <button class="btn btn-sm btn-warning mt-2 ms-2" @onclick="VerlatenTestmodusAsync">
+                        <i class="bi bi-database-gear me-1"></i> Testmodus — verlaten
+                    </button>
+                }
+                else
+                {
+                    <button class="btn btn-sm btn-outline-secondary mt-2 ms-2" @onclick="ActiveerTestmodusAsync">
+                        <i class="bi bi-database-gear me-1"></i> Testmodus
+                    </button>
+                }
                 <button class="btn btn-sm btn-outline-light mt-2 ms-2" @onclick="LogoutAsync">Uitloggen</button>
             </div>
         }
@@ -99,17 +134,21 @@
 @code {
     private bool collapseNavMenu = true;
     private bool _instellingenOpen;
+    private bool _testDataOpen;
     private string? _clubName;
 
     private string? NavMenuCssClass => collapseNavMenu ? "collapse" : null;
 
     private static readonly string[] InstellingenRoutes = ["/instellingen", "/voorkeurstijden", "/email-templates"];
+    private static readonly string[] TestDataRoutes     = ["/testdata"];
 
     protected override async Task OnInitializedAsync()
     {
         _instellingenOpen = IsInstellingenRoute(Navigation.Uri);
+        _testDataOpen     = IsTestDataRoute(Navigation.Uri);
         Navigation.LocationChanged += OnLocationChanged;
         ThemeService.OnThemeChanged += OnThemeChanged;
+        ClubSelector.OnChange       += OnClubChanged;
 
         var result = await Api.GetSettingsAsync();
         if (result.Success && !string.IsNullOrWhiteSpace(result.Data?.ClubName))
@@ -120,22 +159,42 @@
     {
         Navigation.LocationChanged -= OnLocationChanged;
         ThemeService.OnThemeChanged -= OnThemeChanged;
+        ClubSelector.OnChange       -= OnClubChanged;
     }
 
     private void OnThemeChanged() => _ = InvokeAsync(StateHasChanged);
+    private void OnClubChanged()  => _ = InvokeAsync(StateHasChanged);
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {
-        if (IsInstellingenRoute(e.Location))
-            _instellingenOpen = true;
+        if (IsInstellingenRoute(e.Location)) _instellingenOpen = true;
+        if (IsTestDataRoute(e.Location))     _testDataOpen     = true;
         _ = InvokeAsync(StateHasChanged);
     }
 
     private static bool IsInstellingenRoute(string uri) =>
         InstellingenRoutes.Any(r => uri.Contains(r, StringComparison.OrdinalIgnoreCase));
 
-    private void ToggleNavMenu() => collapseNavMenu = !collapseNavMenu;
+    private static bool IsTestDataRoute(string uri) =>
+        TestDataRoutes.Any(r => uri.Contains(r, StringComparison.OrdinalIgnoreCase));
+
+    private void ToggleNavMenu()    => collapseNavMenu    = !collapseNavMenu;
     private void ToggleInstellingen() => _instellingenOpen = !_instellingenOpen;
+    private void ToggleTestData()   => _testDataOpen      = !_testDataOpen;
+
+    private async Task ActiveerTestmodusAsync()
+    {
+        await ClubSelector.SelectClubAsync("ALLSTARS");
+        _testDataOpen = true;
+        Navigation.NavigateTo("testdata/wedstrijden");
+    }
+
+    private async Task VerlatenTestmodusAsync()
+    {
+        await ClubSelector.SelectClubAsync("");
+        _testDataOpen = false;
+        Navigation.NavigateTo("");
+    }
 
     private async Task LogoutAsync() => await Auth.LogoutAsync();
 }

--- a/BlazorAdmin/Layout/NavMenu.razor
+++ b/BlazorAdmin/Layout/NavMenu.razor
@@ -150,9 +150,16 @@
         ThemeService.OnThemeChanged += OnThemeChanged;
         ClubSelector.OnChange       += OnClubChanged;
 
-        var result = await Api.GetSettingsAsync();
-        if (result.Success && !string.IsNullOrWhiteSpace(result.Data?.ClubName))
-            _clubName = result.Data.ClubName;
+        if (ClubSelector.SelectedClubCode == "ALLSTARS")
+        {
+            _clubName = "ALLSTARS (testmodus)";
+        }
+        else
+        {
+            var result = await Api.GetSettingsAsync();
+            if (result.Success && !string.IsNullOrWhiteSpace(result.Data?.ClubName))
+                _clubName = result.Data.ClubName;
+        }
     }
 
     public void Dispose()

--- a/BlazorAdmin/Layout/NavMenu.razor
+++ b/BlazorAdmin/Layout/NavMenu.razor
@@ -150,6 +150,8 @@
         ThemeService.OnThemeChanged += OnThemeChanged;
         ClubSelector.OnChange       += OnClubChanged;
 
+        await ClubSelector.InitializeAsync();
+
         if (ClubSelector.SelectedClubCode == "ALLSTARS")
         {
             _clubName = "ALLSTARS (testmodus)";

--- a/BlazorAdmin/Layout/NavMenu.razor
+++ b/BlazorAdmin/Layout/NavMenu.razor
@@ -163,7 +163,21 @@
     }
 
     private void OnThemeChanged() => _ = InvokeAsync(StateHasChanged);
-    private void OnClubChanged()  => _ = InvokeAsync(StateHasChanged);
+
+    private void OnClubChanged() => _ = InvokeAsync(async () =>
+    {
+        if (ClubSelector.SelectedClubCode == "ALLSTARS")
+        {
+            _clubName = "ALLSTARS (testmodus)";
+        }
+        else
+        {
+            var result = await Api.GetSettingsAsync();
+            if (result.Success && !string.IsNullOrWhiteSpace(result.Data?.ClubName))
+                _clubName = result.Data.ClubName;
+        }
+        StateHasChanged();
+    });
 
     private void OnLocationChanged(object? sender, LocationChangedEventArgs e)
     {

--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -299,11 +299,12 @@ public class VeldDto
 
 public class AllstarsWedstrijdDto
 {
-    public string  BkMatches    { get; set; } = "";
-    public string? Datum        { get; set; }
-    public string? Aanvangstijd { get; set; }
-    public string? ThuisTeam    { get; set; }
-    public string? UitTeam      { get; set; }
-    public string? VeldNaam     { get; set; }
-    public string? Soort        { get; set; }
+    public string  BkMatches      { get; set; } = "";
+    public string? Datum          { get; set; }
+    public string? Aanvangstijd   { get; set; }
+    public string? ThuisTeam      { get; set; }
+    public string? UitTeam        { get; set; }
+    public string? VeldNaam       { get; set; }
+    public string? VeldSubpositie { get; set; }
+    public string? Soort          { get; set; }
 }

--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -286,3 +286,24 @@ public class ClubDto
     public string ClubName { get; set; } = "";
     public bool SyncEnabled { get; set; }
 }
+
+// ── Velden ──
+
+public class VeldDto
+{
+    public int    VeldNummer { get; set; }
+    public string VeldNaam   { get; set; } = "";
+}
+
+// ── Test data / ALLSTARS (#365) ──
+
+public class AllstarsWedstrijdDto
+{
+    public string  BkMatches    { get; set; } = "";
+    public string? Datum        { get; set; }
+    public string? Aanvangstijd { get; set; }
+    public string? ThuisTeam    { get; set; }
+    public string? UitTeam      { get; set; }
+    public string? VeldNaam     { get; set; }
+    public string? Soort        { get; set; }
+}

--- a/BlazorAdmin/Pages/Dagplanning.razor
+++ b/BlazorAdmin/Pages/Dagplanning.razor
@@ -21,7 +21,7 @@
                 <label class="form-label">Optimalisatiedoel</label>
                 <select class="form-select" @bind="_doel">
                     <option value="">(geen voorkeur)</option>
-                    <option value="veld5-ontlasten">Veld 5 ontlasten</option>
+                    <option value="veld5-ontlasten">Grasveld(en) ontlasten</option>
                     <option value="strakker-plannen">Strakker plannen</option>
                 </select>
             </div>
@@ -74,7 +74,7 @@
                 </div>
                 <div class="col-md-2 col-6 mb-2">
                     <div class="fs-5 fw-bold">@_resultaat.AantalVanVeld5Verplaatst</div>
-                    <small class="text-muted">Van veld 5 verplaatst</small>
+                    <small class="text-muted">Van grasveld verplaatst</small>
                 </div>
                 @if (_resultaat.CapaciteitOverzicht != null)
                 {

--- a/BlazorAdmin/Pages/Dagplanning.razor
+++ b/BlazorAdmin/Pages/Dagplanning.razor
@@ -27,7 +27,8 @@
             </div>
             <div class="col-md-2">
                 <label class="form-label">Gewenste eindtijd</label>
-                <input type="time" class="form-control" @bind="_gewensteEindtijd" @bind:format="HH:mm" />
+                <TimeInput Value="@_gewensteEindtijdStr"
+                           ValueChanged="@(v => _gewensteEindtijdStr = v ?? _gewensteEindtijdStr)" />
             </div>
             <div class="col-md-2">
                 <label class="form-label">Buffer (min)</label>
@@ -110,7 +111,7 @@
 @code {
     private DateTime _datumDt;
     private string _doel = "";
-    private TimeOnly _gewensteEindtijd = new TimeOnly(16, 15);
+    private string _gewensteEindtijdStr = "16:15";
     private int _bufferMinuten = 15;
     private bool _bezig;
     private string? _errorMessage;
@@ -118,7 +119,7 @@
     private OptimaliseerResponseDto? _resultaat;
 
     private string DatumStr => _datumDt.ToString("yyyy-MM-dd");
-    private string EindtijdStr => _gewensteEindtijd.ToString("HH:mm");
+    private string EindtijdStr => _gewensteEindtijdStr;
 
     protected override void OnInitialized()
     {

--- a/BlazorAdmin/Pages/Instellingen.razor
+++ b/BlazorAdmin/Pages/Instellingen.razor
@@ -17,71 +17,82 @@
     }
 </div>
 
-@* ── Synchronisatie (verplaatst van Dashboard #344) ── *@
-<div class="row mb-4">
-    <div class="col-md-6">
-        <div class="card shadow-sm h-100">
-            <div class="card-body">
-                <h5 class="card-title">Synchronisatie</h5>
-                @if (_syncLoading)
-                {
-                    <p class="text-muted">Laden...</p>
-                }
-                else if (_status == null)
-                {
-                    <p class="text-danger">Kon synchronisatiestatus niet ophalen.</p>
-                }
-                else
-                {
-                    <p>
-                        <strong>Laatste sync:</strong>
-                        @(_status.LastSyncTimestamp.HasValue
-                              ? _status.LastSyncTimestamp.Value.ToLocalTime().ToString("dd-MM-yyyy HH:mm")
-                              : "nog niet uitgevoerd")
-                    </p>
-                    <p>
-                        <strong>Schema:</strong> @CronNaarNederlands(_status.FetchSchedule)
-                        <small class="text-muted ms-1">(<code>@_status.FetchSchedule</code>)</small>
-                    </p>
-                    <p>
-                        <strong>Status:</strong>
-                        <span class="badge @(_status.Status == "ok" ? "bg-success" : "bg-warning")">
-                            @_status.Status
-                        </span>
-                    </p>
-                }
-                <button class="btn btn-primary btn-sm" @onclick="TriggerSyncAsync" disabled="@(_syncing)">
-                    @(_syncing ? "Synchroniseren..." : "Nu synchroniseren")
-                </button>
-                @if (!string.IsNullOrEmpty(_syncResult))
-                {
-                    <div class="alert alert-info mt-3">@_syncResult</div>
-                }
+@if (!_isTestmodus)
+{
+    @* ── Synchronisatie (verplaatst van Dashboard #344) ── *@
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Synchronisatie</h5>
+                    @if (_syncLoading)
+                    {
+                        <p class="text-muted">Laden...</p>
+                    }
+                    else if (_status == null)
+                    {
+                        <p class="text-danger">Kon synchronisatiestatus niet ophalen.</p>
+                    }
+                    else
+                    {
+                        <p>
+                            <strong>Laatste sync:</strong>
+                            @(_status.LastSyncTimestamp.HasValue
+                                  ? _status.LastSyncTimestamp.Value.ToLocalTime().ToString("dd-MM-yyyy HH:mm")
+                                  : "nog niet uitgevoerd")
+                        </p>
+                        <p>
+                            <strong>Schema:</strong> @CronNaarNederlands(_status.FetchSchedule)
+                            <small class="text-muted ms-1">(<code>@_status.FetchSchedule</code>)</small>
+                        </p>
+                        <p>
+                            <strong>Status:</strong>
+                            <span class="badge @(_status.Status == "ok" ? "bg-success" : "bg-warning")">
+                                @_status.Status
+                            </span>
+                        </p>
+                    }
+                    <button class="btn btn-primary btn-sm" @onclick="TriggerSyncAsync" disabled="@(_syncing)">
+                        @(_syncing ? "Synchroniseren..." : "Nu synchroniseren")
+                    </button>
+                    @if (!string.IsNullOrEmpty(_syncResult))
+                    {
+                        <div class="alert alert-info mt-3">@_syncResult</div>
+                    }
+                </div>
+            </div>
+        </div>
+        <div class="col-md-6">
+            <div class="card shadow-sm h-100">
+                <div class="card-body">
+                    <h5 class="card-title">Email verwerking (laatste 24u)</h5>
+                    @if (_emailLog == null && !_syncLoading)
+                    {
+                        <p class="text-muted">Niet beschikbaar.</p>
+                    }
+                    else if (_emailLog != null)
+                    {
+                        <p><strong>Verwerkt:</strong> @_emailVerwerkt</p>
+                        <p><strong>Fouten:</strong> @_emailFouten</p>
+                        <p><strong>Buiten scope:</strong> @_emailBuitenScope</p>
+                    }
+                </div>
             </div>
         </div>
     </div>
-    <div class="col-md-6">
-        <div class="card shadow-sm h-100">
-            <div class="card-body">
-                <h5 class="card-title">Email verwerking (laatste 24u)</h5>
-                @if (_emailLog == null && !_syncLoading)
-                {
-                    <p class="text-muted">Niet beschikbaar.</p>
-                }
-                else if (_emailLog != null)
-                {
-                    <p><strong>Verwerkt:</strong> @_emailVerwerkt</p>
-                    <p><strong>Fouten:</strong> @_emailFouten</p>
-                    <p><strong>Buiten scope:</strong> @_emailBuitenScope</p>
-                }
-            </div>
-        </div>
+
+    <hr class="mb-4" />
+}
+
+@if (_isTestmodus)
+{
+    <div class="alert alert-info">
+        <i class="bi bi-database-gear me-2"></i>
+        <strong>Testmodus actief</strong> — Instellingen, synchronisatie en e-mailverwerking zijn niet beschikbaar voor ALLSTARS testdata.
+        Gebruik de <strong>Testmodus — verlaten</strong>-knop in de zijbalk om terug te schakelen naar de normale clubweergave.
     </div>
-</div>
-
-<hr class="mb-4" />
-
-@if (settings == null && string.IsNullOrEmpty(errorMessage))
+}
+else if (settings == null && string.IsNullOrEmpty(errorMessage))
 {
     <p class="text-muted">Laden...</p>
 }
@@ -321,6 +332,8 @@ else
     private string? _syncResult;
     private int _emailVerwerkt, _emailFouten, _emailBuitenScope;
 
+    private bool _isTestmodus => ClubSelector.SelectedClubCode == "ALLSTARS";
+
     protected override async Task OnInitializedAsync()
     {
         ClubSelector.OnChange += OnClubChanged;
@@ -333,7 +346,16 @@ else
     private async Task LoadAsync()
     {
         errorMessage = null;
+        settings = null;
         _syncLoading = true;
+
+        if (_isTestmodus)
+        {
+            _status = null;
+            _emailLog = null;
+            _syncLoading = false;
+            return;
+        }
 
         var settingsTask = Api.GetSettingsAsync();
         var syncTask    = Api.GetSyncStatusAsync();

--- a/BlazorAdmin/Pages/TestData/Wedstrijden.razor
+++ b/BlazorAdmin/Pages/TestData/Wedstrijden.razor
@@ -31,7 +31,7 @@
 }
 
 @* ── Globale controls ── *@
-<div class="card mb-3">
+<div class="card mb-2">
     <div class="card-body py-2">
         <div class="row g-2 align-items-end">
             <div class="col-auto">
@@ -68,9 +68,39 @@
                 <button class="btn btn-sm btn-outline-primary" @onclick="VoegLegeRijToe">
                     <i class="bi bi-plus me-1"></i> Lege rij
                 </button>
-                <button class="btn btn-sm btn-outline-danger" @onclick="VerwijderAllesAsync"
-                        disabled="@(_rijen.Count == 0 || _bezig)">
-                    <i class="bi bi-trash me-1"></i> Verwijder alles
+            </div>
+        </div>
+    </div>
+</div>
+
+@* ── Filter + verwijder ── *@
+<div class="card mb-3">
+    <div class="card-body py-2">
+        <div class="row g-2 align-items-end">
+            <div class="col-auto">
+                <label class="form-label mb-1 small">Filter van</label>
+                <input type="date" class="form-control form-control-sm" style="width:150px"
+                       value="@_filterVan"
+                       @onchange="e => _filterVan = e.Value?.ToString() ?? _filterVan" />
+            </div>
+            <div class="col-auto">
+                <label class="form-label mb-1 small">tot</label>
+                <input type="date" class="form-control form-control-sm" style="width:150px"
+                       value="@_filterTot"
+                       @onchange="e => _filterTot = e.Value?.ToString() ?? _filterTot" />
+            </div>
+            <div class="col-auto mt-auto">
+                <button class="btn btn-sm btn-outline-secondary" @onclick="WisFilter"
+                        disabled="@(!FilterActief)">
+                    <i class="bi bi-x me-1"></i> Wis filter
+                </button>
+            </div>
+            <div class="col-auto mt-auto ms-auto">
+                <button class="btn btn-sm btn-outline-danger" @onclick="VerwijderGefilterdeAsync"
+                        disabled="@(!FilterActief || _bezig)"
+                        title="@(FilterActief ? "Verwijder wedstrijden in het geselecteerde datumbereik" : "Stel een datumbereik in om te verwijderen")">
+                    <i class="bi bi-trash me-1"></i>
+                    Verwijder @(FilterActief ? "gefilterd" : "(stel filter in)")
                 </button>
             </div>
         </div>
@@ -83,23 +113,32 @@
 }
 else
 {
+    <p class="text-muted small mb-1">
+        @GesorteerdeEnGefilterde.Count van @_rijen.Count wedstrijden
+        @if (FilterActief) { <span> (gefilterd)</span> }
+    </p>
+
     @* ── Invoergrid ── *@
     <div class="table-responsive">
         <table class="table table-sm table-bordered align-middle mb-1" style="font-size:0.875rem">
             <thead class="table-light">
                 <tr>
                     <th style="width:32px">#</th>
-                    <th style="width:140px">
-                        Datum
+                    <th style="width:150px" class="sortable-header" @onclick='() => SorteerOp("datum")'>
+                        Datum @SortIcon("datum")
                         <button class="btn btn-link btn-sm p-0 ms-1" title="Kopieer eerste waarde naar lege cellen"
-                                @onclick='() => VulKolom("datum")'>↓</button>
+                                @onclick='() => VulKolom("datum")' @onclick:stopPropagation="true">↓</button>
                     </th>
-                    <th style="width:190px">Team (thuis)</th>
-                    <th style="width:170px">Tegenstander</th>
-                    <th style="width:110px">
-                        Starttijd
+                    <th style="width:200px" class="sortable-header" @onclick='() => SorteerOp("thuisteam")'>
+                        Team (thuis) @SortIcon("thuisteam")
+                    </th>
+                    <th style="width:180px" class="sortable-header" @onclick='() => SorteerOp("uitteam")'>
+                        Tegenstander @SortIcon("uitteam")
+                    </th>
+                    <th style="width:110px" class="sortable-header" @onclick='() => SorteerOp("aanvangstijd")'>
+                        Starttijd @SortIcon("aanvangstijd")
                         <button class="btn btn-link btn-sm p-0 ms-1" title="Kopieer eerste waarde naar lege cellen"
-                                @onclick='() => VulKolom("aanvangstijd")'>↓</button>
+                                @onclick='() => VulKolom("aanvangstijd")' @onclick:stopPropagation="true">↓</button>
                     </th>
                     <th style="width:140px">Veld</th>
                     <th style="width:150px">Soort</th>
@@ -108,9 +147,10 @@ else
                 </tr>
             </thead>
             <tbody>
-                @for (int i = 0; i < _rijen.Count; i++)
+                @{ var weergave = GesorteerdeEnGefilterde; }
+                @for (int i = 0; i < weergave.Count; i++)
                 {
-                    var rij = _rijen[i];
+                    var rij = weergave[i];
                     var nr  = i + 1;
                     <tr class="@RijKlasse(rij)">
                         <td class="text-muted text-center">@nr</td>
@@ -195,11 +235,18 @@ else
                         </td>
                     </tr>
                 }
-                @if (_rijen.Count == 0)
+                @if (weergave.Count == 0)
                 {
                     <tr>
                         <td colspan="9" class="text-muted text-center py-3">
-                            Geen rijen. Klik <strong>Alle teams</strong> of <strong>Lege rij</strong>.
+                            @if (_rijen.Count == 0)
+                            {
+                                <span>Geen rijen. Klik <strong>Alle teams</strong> of <strong>Lege rij</strong>.</span>
+                            }
+                            else
+                            {
+                                <span>Geen wedstrijden in het geselecteerde datumbereik.</span>
+                            }
                         </td>
                     </tr>
                 }
@@ -212,6 +259,11 @@ else
         <i class="bi bi-exclamation-circle text-danger me-1"></i>Fout
     </p>
 }
+
+<style>
+    .sortable-header { cursor: pointer; user-select: none; }
+    .sortable-header:hover { background-color: #e9ecef; }
+</style>
 
 @code {
     // ── Model ──
@@ -256,7 +308,6 @@ else
         }
 
         public WedstrijdRij() { }
-
         private WedstrijdRij(string bk) { BkMatches = bk; }
     }
 
@@ -275,8 +326,55 @@ else
     private string _globalTegenstander = "FC Onbekend";
     private string _globalStarttijd    = "10:00";
 
+    // Filter
+    private string _filterVan = "";
+    private string _filterTot = "";
+
+    // Sortering — standaard datum aflopend
+    private string _sortKolom    = "datum";
+    private bool   _sortAflopend = true;
+
     private static readonly string[] SoortOpties =
-        ["Oefenwedstrijd", "Allstars", "Toernooi", "Vriendschappelijk"];
+        ["Competitie", "Oefenwedstrijd", "Toernooi", "Vriendschappelijk"];
+
+    // ── Computed ──
+
+    private bool FilterActief =>
+        !string.IsNullOrEmpty(_filterVan) || !string.IsNullOrEmpty(_filterTot);
+
+    private List<WedstrijdRij> GesorteerdeEnGefilterde
+    {
+        get
+        {
+            var q = _rijen.AsEnumerable();
+
+            if (!string.IsNullOrEmpty(_filterVan))
+                q = q.Where(r => string.Compare(r.Datum, _filterVan, StringComparison.Ordinal) >= 0);
+            if (!string.IsNullOrEmpty(_filterTot))
+                q = q.Where(r => string.Compare(r.Datum, _filterTot, StringComparison.Ordinal) <= 0);
+
+            q = (_sortKolom, _sortAflopend) switch
+            {
+                ("datum",        true)  => q.OrderByDescending(r => r.Datum),
+                ("datum",        false) => q.OrderBy(r => r.Datum),
+                ("thuisteam",    true)  => q.OrderByDescending(r => r.ThuisTeam),
+                ("thuisteam",    false) => q.OrderBy(r => r.ThuisTeam),
+                ("uitteam",      true)  => q.OrderByDescending(r => r.UitTeam),
+                ("uitteam",      false) => q.OrderBy(r => r.UitTeam),
+                ("aanvangstijd", true)  => q.OrderByDescending(r => r.Aanvangstijd),
+                ("aanvangstijd", false) => q.OrderBy(r => r.Aanvangstijd),
+                _                      => q.OrderByDescending(r => r.Datum),
+            };
+
+            return q.ToList();
+        }
+    }
+
+    private RenderFragment SortIcon(string kolom) => builder =>
+    {
+        if (_sortKolom != kolom) return;
+        builder.AddContent(0, _sortAflopend ? " ▼" : " ▲");
+    };
 
     // ── Lifecycle ──
 
@@ -316,6 +414,27 @@ else
         _loading = false;
     }
 
+    // ── Sorteren ──
+
+    private void SorteerOp(string kolom)
+    {
+        if (_sortKolom == kolom)
+            _sortAflopend = !_sortAflopend;
+        else
+        {
+            _sortKolom    = kolom;
+            _sortAflopend = true;
+        }
+    }
+
+    // ── Filter ──
+
+    private void WisFilter()
+    {
+        _filterVan = "";
+        _filterTot = "";
+    }
+
     // ── Cel-events ──
 
     private void OnThuisTeamChanged(WedstrijdRij rij, string? waarde)
@@ -323,6 +442,17 @@ else
         rij.ThuisTeam = waarde;
         if (string.IsNullOrEmpty(rij.Aanvangstijd))
             rij.Aanvangstijd = _globalStarttijd;
+
+        // Auto-fill tegenstander met suffix van het thuisteam
+        if (!string.IsNullOrEmpty(waarde))
+        {
+            var suffix = waarde.Contains(' ')
+                ? waarde[(waarde.IndexOf(' ') + 1)..]
+                : waarde;
+            if (string.IsNullOrEmpty(rij.UitTeam) || rij.UitTeam == _globalTegenstander)
+                rij.UitTeam = $"FC Onbekend {suffix}";
+        }
+
         _ = AutoSaveAsync(rij);
     }
 
@@ -362,13 +492,19 @@ else
     private async Task VoegAlleTeamsToeAsync()
     {
         _bezig = true;
-        var nieuweRijen = _teams.Select(team => new WedstrijdRij
+        var nieuweRijen = _teams.Select(team =>
         {
-            Datum        = _globalDatum,
-            ThuisTeam    = team,
-            UitTeam      = string.IsNullOrWhiteSpace(_globalTegenstander) ? null : _globalTegenstander,
-            Soort        = _globalSoort,
-            Aanvangstijd = _globalStarttijd,
+            var suffix = team.Contains(' ') ? team[(team.IndexOf(' ') + 1)..] : team;
+            return new WedstrijdRij
+            {
+                Datum        = _globalDatum,
+                ThuisTeam    = team,
+                UitTeam      = string.IsNullOrWhiteSpace(_globalTegenstander)
+                    ? $"FC Onbekend {suffix}"
+                    : $"{_globalTegenstander} {suffix}",
+                Soort        = _globalSoort,
+                Aanvangstijd = _globalStarttijd,
+            };
         }).ToList();
 
         _rijen.AddRange(nieuweRijen);
@@ -387,11 +523,16 @@ else
         _rijen.Remove(rij);
     }
 
-    private async Task VerwijderAllesAsync()
+    private async Task VerwijderGefilterdeAsync()
     {
+        if (!FilterActief) return;
         _bezig = true;
-        await Api.DeleteAlleAllstarsWedstrijdenAsync();
-        _rijen.Clear();
+        var van = string.IsNullOrEmpty(_filterVan) ? null : _filterVan;
+        var tot = string.IsNullOrEmpty(_filterTot) ? null : _filterTot;
+        await Api.DeleteAlleAllstarsWedstrijdenAsync(van, tot);
+        _rijen.RemoveAll(r =>
+            (van == null || string.Compare(r.Datum, van, StringComparison.Ordinal) >= 0) &&
+            (tot == null || string.Compare(r.Datum, tot, StringComparison.Ordinal) <= 0));
         _bezig = false;
     }
 
@@ -401,9 +542,9 @@ else
     {
         string? bronWaarde = kolom switch
         {
-            "datum"       => _rijen.Select(r => r.Datum).FirstOrDefault(v => !string.IsNullOrEmpty(v)),
-            "aanvangstijd"=> _rijen.Select(r => r.Aanvangstijd).FirstOrDefault(v => !string.IsNullOrEmpty(v)),
-            _             => null,
+            "datum"        => _rijen.Select(r => r.Datum).FirstOrDefault(v => !string.IsNullOrEmpty(v)),
+            "aanvangstijd" => _rijen.Select(r => r.Aanvangstijd).FirstOrDefault(v => !string.IsNullOrEmpty(v)),
+            _              => null,
         };
         if (bronWaarde == null) return;
 
@@ -416,7 +557,6 @@ else
                 _              => false,
             };
             if (!leeg) continue;
-
             if (kolom == "datum")        rij.Datum        = bronWaarde;
             if (kolom == "aanvangstijd") rij.Aanvangstijd = bronWaarde;
             _ = AutoSaveAsync(rij);

--- a/BlazorAdmin/Pages/TestData/Wedstrijden.razor
+++ b/BlazorAdmin/Pages/TestData/Wedstrijden.razor
@@ -151,6 +151,7 @@ else
                                 @onclick='() => VulKolom("aanvangstijd")' @onclick:stopPropagation="true">↓</button>
                     </th>
                     <th style="width:140px">Veld</th>
+                    <th style="width:105px" title="Velddeel op basis van speeltijden-tabel (0.25=A1-B2, 0.50=A-B)">Velddeel</th>
                     <th style="width:150px">Soort</th>
                     <th style="width:40px"></th>
                     <th style="width:32px"></th>
@@ -208,6 +209,26 @@ else
                         </td>
 
                         <td>
+                            @{ var velddeelopties = GetVelddeelopties(rij.ThuisTeam); }
+                            @if (velddeelopties != null)
+                            {
+                                <select class="form-select form-select-sm border-0"
+                                        value="@rij.VeldSubpositie"
+                                        @onchange="e => { rij.VeldSubpositie = e.Value?.ToString(); _ = AutoSaveAsync(rij); }">
+                                    <option value="">—</option>
+                                    @foreach (var o in velddeelopties)
+                                    {
+                                        <option value="@o">@o</option>
+                                    }
+                                </select>
+                            }
+                            else
+                            {
+                                <span class="text-muted small">heel veld</span>
+                            }
+                        </td>
+
+                        <td>
                             <select class="form-select form-select-sm border-0"
                                     value="@rij.Soort"
                                     @onchange="e => { rij.Soort = e.Value?.ToString(); _ = AutoSaveAsync(rij); }">
@@ -248,7 +269,7 @@ else
                 @if (weergave.Count == 0)
                 {
                     <tr>
-                        <td colspan="9" class="text-muted text-center py-3">
+                        <td colspan="10" class="text-muted text-center py-3">
                             @if (_rijen.Count == 0)
                             {
                                 <span>Geen rijen. Klik <strong>Alle teams</strong> of <strong>Lege rij</strong>.</span>
@@ -280,13 +301,14 @@ else
 
     private class WedstrijdRij
     {
-        public string  BkMatches    { get; } = $"ALLSTARS-{Guid.NewGuid():N}"[..28];
-        public string? Datum        { get; set; }
-        public string? Aanvangstijd { get; set; }
-        public string? ThuisTeam    { get; set; }
-        public string? UitTeam      { get; set; }
-        public string? VeldNaam     { get; set; }
-        public string? Soort        { get; set; } = "Oefenwedstrijd";
+        public string  BkMatches      { get; } = $"ALLSTARS-{Guid.NewGuid():N}"[..28];
+        public string? Datum          { get; set; }
+        public string? Aanvangstijd   { get; set; }
+        public string? ThuisTeam      { get; set; }
+        public string? UitTeam        { get; set; }
+        public string? VeldNaam       { get; set; }
+        public string? VeldSubpositie { get; set; }
+        public string? Soort          { get; set; } = "Oefenwedstrijd";
 
         public bool    IsSaving     { get; set; }
         public bool    IsOpgeslagen { get; set; }
@@ -295,25 +317,27 @@ else
 
         public AllstarsWedstrijdDto ToDto() => new()
         {
-            BkMatches    = BkMatches,
-            Datum        = Datum,
-            Aanvangstijd = Aanvangstijd,
-            ThuisTeam    = ThuisTeam,
-            UitTeam      = UitTeam,
-            VeldNaam     = VeldNaam,
-            Soort        = Soort,
+            BkMatches      = BkMatches,
+            Datum          = Datum,
+            Aanvangstijd   = Aanvangstijd,
+            ThuisTeam      = ThuisTeam,
+            UitTeam        = UitTeam,
+            VeldNaam       = VeldNaam,
+            VeldSubpositie = VeldSubpositie,
+            Soort          = Soort,
         };
 
         public static WedstrijdRij VanDto(AllstarsWedstrijdDto dto)
         {
             var rij = new WedstrijdRij(dto.BkMatches);
-            rij.Datum        = dto.Datum;
-            rij.Aanvangstijd = dto.Aanvangstijd;
-            rij.ThuisTeam    = dto.ThuisTeam;
-            rij.UitTeam      = dto.UitTeam;
-            rij.VeldNaam     = dto.VeldNaam;
-            rij.Soort        = dto.Soort ?? "Oefenwedstrijd";
-            rij.IsOpgeslagen = true;
+            rij.Datum          = dto.Datum;
+            rij.Aanvangstijd   = dto.Aanvangstijd;
+            rij.ThuisTeam      = dto.ThuisTeam;
+            rij.UitTeam        = dto.UitTeam;
+            rij.VeldNaam       = dto.VeldNaam;
+            rij.VeldSubpositie = dto.VeldSubpositie;
+            rij.Soort          = dto.Soort ?? "Oefenwedstrijd";
+            rij.IsOpgeslagen   = true;
             return rij;
         }
 
@@ -347,6 +371,33 @@ else
 
     private static readonly string[] SoortOpties =
         ["Competitie", "Oefenwedstrijd", "Toernooi", "Vriendschappelijk"];
+
+    // ── Velddeel opties op basis van Veldafmeting uit Speeltijden ──
+
+    private IReadOnlyList<string>? GetVelddeelopties(string? teamnaam)
+    {
+        if (string.IsNullOrEmpty(teamnaam)) return null;
+        var spatie1 = teamnaam.IndexOf(' ');
+        if (spatie1 < 0) return null;
+        var rest    = teamnaam[(spatie1 + 1)..];
+        var spatie2 = rest.IndexOf(' ');
+        var leeftijd = spatie2 >= 0 ? rest[..spatie2] : rest;
+        leeftijd = leeftijd switch
+        {
+            "Heren" or "Heer" => "1-99",
+            "Dames" or "Vrouwen" => "VR",
+            _ => leeftijd
+        };
+        var s = _speeltijden.FirstOrDefault(x => x.Leeftijd == leeftijd);
+        if (s == null || s.Veldafmeting >= 1.00m) return null;
+        return (int)Math.Round(1m / s.Veldafmeting) switch
+        {
+            2 => ["A",  "B"],
+            4 => ["A1", "A2", "B1", "B2"],
+            3 => ["A",  "B",  "C"],
+            _ => null
+        };
+    }
 
     // ── Computed ──
 

--- a/BlazorAdmin/Pages/TestData/Wedstrijden.razor
+++ b/BlazorAdmin/Pages/TestData/Wedstrijden.razor
@@ -1,0 +1,432 @@
+@page "/testdata/wedstrijden"
+@inject AdminApiClient Api
+@inject ClubSelectorService ClubSelector
+@using BlazorAdmin.Models
+@using BlazorAdmin.Services
+@implements IDisposable
+
+<PageTitle>Test data — Wedstrijden</PageTitle>
+
+@if (ClubSelector.SelectedClubCode != "ALLSTARS")
+{
+    <div class="alert alert-warning">
+        <i class="bi bi-exclamation-triangle me-2"></i>
+        Activeer eerst de <strong>testmodus</strong> via de knop in de zijbalk.
+    </div>
+    return;
+}
+
+<div class="d-flex align-items-center gap-2 mb-1">
+    <h1 class="mb-0">Test data — Wedstrijden</h1>
+    <span class="badge bg-warning text-dark">ALLSTARS</span>
+</div>
+<p class="text-muted small mb-3">
+    Wedstrijden worden direct opgeslagen zodra je een cel verlaat.
+    Alle rijen gebruiken <code>ClubCode = ALLSTARS</code> — geen impact op echte data.
+</p>
+
+@if (_error != null)
+{
+    <div class="alert alert-danger">@_error</div>
+}
+
+@* ── Globale controls ── *@
+<div class="card mb-3">
+    <div class="card-body py-2">
+        <div class="row g-2 align-items-end">
+            <div class="col-auto">
+                <label class="form-label mb-1 small">Datum (nieuw)</label>
+                <input type="date" class="form-control form-control-sm" style="width:150px"
+                       value="@_globalDatum"
+                       @onchange="e => _globalDatum = e.Value?.ToString() ?? _globalDatum" />
+            </div>
+            <div class="col-auto">
+                <label class="form-label mb-1 small">Soort (nieuw)</label>
+                <select class="form-select form-select-sm" style="width:160px" @bind="_globalSoort">
+                    @foreach (var s in SoortOpties)
+                    {
+                        <option value="@s">@s</option>
+                    }
+                </select>
+            </div>
+            <div class="col-auto">
+                <label class="form-label mb-1 small">Tegenstander (nieuw)</label>
+                <input type="text" class="form-control form-control-sm" style="width:160px"
+                       @bind="_globalTegenstander" placeholder="FC Onbekend" />
+            </div>
+            <div class="col-auto">
+                <label class="form-label mb-1 small">Starttijd (nieuw)</label>
+                <input type="time" class="form-control form-control-sm" style="width:120px"
+                       value="@_globalStarttijd"
+                       @onchange="e => _globalStarttijd = e.Value?.ToString() ?? _globalStarttijd" />
+            </div>
+            <div class="col-auto mt-auto d-flex gap-1 flex-wrap">
+                <button class="btn btn-sm btn-primary" @onclick="VoegAlleTeamsToeAsync"
+                        disabled="@(_teams.Count == 0 || _bezig)">
+                    <i class="bi bi-people me-1"></i> Alle teams
+                </button>
+                <button class="btn btn-sm btn-outline-primary" @onclick="VoegLegeRijToe">
+                    <i class="bi bi-plus me-1"></i> Lege rij
+                </button>
+                <button class="btn btn-sm btn-outline-danger" @onclick="VerwijderAllesAsync"
+                        disabled="@(_rijen.Count == 0 || _bezig)">
+                    <i class="bi bi-trash me-1"></i> Verwijder alles
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
+@if (_loading)
+{
+    <p>Laden...</p>
+}
+else
+{
+    @* ── Invoergrid ── *@
+    <div class="table-responsive">
+        <table class="table table-sm table-bordered align-middle mb-1" style="font-size:0.875rem">
+            <thead class="table-light">
+                <tr>
+                    <th style="width:32px">#</th>
+                    <th style="width:140px">
+                        Datum
+                        <button class="btn btn-link btn-sm p-0 ms-1" title="Kopieer eerste waarde naar lege cellen"
+                                @onclick='() => VulKolom("datum")'>↓</button>
+                    </th>
+                    <th style="width:190px">Team (thuis)</th>
+                    <th style="width:170px">Tegenstander</th>
+                    <th style="width:110px">
+                        Starttijd
+                        <button class="btn btn-link btn-sm p-0 ms-1" title="Kopieer eerste waarde naar lege cellen"
+                                @onclick='() => VulKolom("aanvangstijd")'>↓</button>
+                    </th>
+                    <th style="width:140px">Veld</th>
+                    <th style="width:150px">Soort</th>
+                    <th style="width:40px"></th>
+                    <th style="width:32px"></th>
+                </tr>
+            </thead>
+            <tbody>
+                @for (int i = 0; i < _rijen.Count; i++)
+                {
+                    var rij = _rijen[i];
+                    var nr  = i + 1;
+                    <tr class="@RijKlasse(rij)">
+                        <td class="text-muted text-center">@nr</td>
+
+                        <td>
+                            <input type="date" class="form-control form-control-sm border-0"
+                                   value="@rij.Datum"
+                                   @onchange="e => { rij.Datum = e.Value?.ToString(); _ = AutoSaveAsync(rij); }" />
+                        </td>
+
+                        <td>
+                            <select class="form-select form-select-sm border-0"
+                                    value="@rij.ThuisTeam"
+                                    @onchange="e => OnThuisTeamChanged(rij, e.Value?.ToString())">
+                                <option value="">— kies team —</option>
+                                @foreach (var t in _teams)
+                                {
+                                    <option value="@t">@t</option>
+                                }
+                            </select>
+                        </td>
+
+                        <td>
+                            <input type="text" class="form-control form-control-sm border-0"
+                                   value="@rij.UitTeam" placeholder="FC Onbekend"
+                                   @onchange="e => { rij.UitTeam = e.Value?.ToString(); _ = AutoSaveAsync(rij); }" />
+                        </td>
+
+                        <td>
+                            <input type="time" class="form-control form-control-sm border-0"
+                                   value="@rij.Aanvangstijd"
+                                   @onchange="e => { rij.Aanvangstijd = e.Value?.ToString(); _ = AutoSaveAsync(rij); }" />
+                        </td>
+
+                        <td>
+                            <select class="form-select form-select-sm border-0"
+                                    value="@rij.VeldNaam"
+                                    @onchange="e => { rij.VeldNaam = e.Value?.ToString(); _ = AutoSaveAsync(rij); }">
+                                <option value="">— geen —</option>
+                                @foreach (var v in _velden)
+                                {
+                                    <option value="@v.VeldNaam">@v.VeldNaam</option>
+                                }
+                            </select>
+                        </td>
+
+                        <td>
+                            <select class="form-select form-select-sm border-0"
+                                    value="@rij.Soort"
+                                    @onchange="e => { rij.Soort = e.Value?.ToString(); _ = AutoSaveAsync(rij); }">
+                                @foreach (var s in SoortOpties)
+                                {
+                                    <option value="@s">@s</option>
+                                }
+                            </select>
+                        </td>
+
+                        <td class="text-center">
+                            @if (rij.IsSaving)
+                            {
+                                <span class="spinner-border spinner-border-sm text-secondary"></span>
+                            }
+                            else if (rij.HeeftFout)
+                            {
+                                <i class="bi bi-exclamation-circle text-danger" title="@rij.SaveError"></i>
+                            }
+                            else if (rij.IsOpgeslagen)
+                            {
+                                <i class="bi bi-check-circle text-success"></i>
+                            }
+                            else
+                            {
+                                <i class="bi bi-circle text-muted"></i>
+                            }
+                        </td>
+
+                        <td class="text-center">
+                            <button class="btn btn-link btn-sm p-0 text-danger"
+                                    title="Verwijder rij" @onclick="() => VerwijderRijAsync(rij)">
+                                <i class="bi bi-x-lg"></i>
+                            </button>
+                        </td>
+                    </tr>
+                }
+                @if (_rijen.Count == 0)
+                {
+                    <tr>
+                        <td colspan="9" class="text-muted text-center py-3">
+                            Geen rijen. Klik <strong>Alle teams</strong> of <strong>Lege rij</strong>.
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+    <p class="text-muted small">
+        <i class="bi bi-circle me-1"></i>Niet opgeslagen &nbsp;
+        <i class="bi bi-check-circle text-success me-1"></i>Opgeslagen &nbsp;
+        <i class="bi bi-exclamation-circle text-danger me-1"></i>Fout
+    </p>
+}
+
+@code {
+    // ── Model ──
+
+    private class WedstrijdRij
+    {
+        public string  BkMatches    { get; } = $"ALLSTARS-{Guid.NewGuid():N}"[..28];
+        public string? Datum        { get; set; }
+        public string? Aanvangstijd { get; set; }
+        public string? ThuisTeam    { get; set; }
+        public string? UitTeam      { get; set; }
+        public string? VeldNaam     { get; set; }
+        public string? Soort        { get; set; } = "Oefenwedstrijd";
+
+        public bool    IsSaving     { get; set; }
+        public bool    IsOpgeslagen { get; set; }
+        public bool    HeeftFout    { get; set; }
+        public string? SaveError    { get; set; }
+
+        public AllstarsWedstrijdDto ToDto() => new()
+        {
+            BkMatches    = BkMatches,
+            Datum        = Datum,
+            Aanvangstijd = Aanvangstijd,
+            ThuisTeam    = ThuisTeam,
+            UitTeam      = UitTeam,
+            VeldNaam     = VeldNaam,
+            Soort        = Soort,
+        };
+
+        public static WedstrijdRij VanDto(AllstarsWedstrijdDto dto)
+        {
+            var rij = new WedstrijdRij(dto.BkMatches);
+            rij.Datum        = dto.Datum;
+            rij.Aanvangstijd = dto.Aanvangstijd;
+            rij.ThuisTeam    = dto.ThuisTeam;
+            rij.UitTeam      = dto.UitTeam;
+            rij.VeldNaam     = dto.VeldNaam;
+            rij.Soort        = dto.Soort ?? "Oefenwedstrijd";
+            rij.IsOpgeslagen = true;
+            return rij;
+        }
+
+        public WedstrijdRij() { }
+
+        private WedstrijdRij(string bk) { BkMatches = bk; }
+    }
+
+    // ── State ──
+
+    private List<WedstrijdRij>  _rijen       = new();
+    private List<string>        _teams       = new();
+    private List<VeldDto>       _velden      = new();
+    private List<SpeeltijdDto>  _speeltijden = new();
+    private bool    _loading = true;
+    private bool    _bezig;
+    private string? _error;
+
+    private string _globalDatum        = DateTime.Today.ToString("yyyy-MM-dd");
+    private string _globalSoort        = "Oefenwedstrijd";
+    private string _globalTegenstander = "FC Onbekend";
+    private string _globalStarttijd    = "10:00";
+
+    private static readonly string[] SoortOpties =
+        ["Oefenwedstrijd", "Allstars", "Toernooi", "Vriendschappelijk"];
+
+    // ── Lifecycle ──
+
+    protected override async Task OnInitializedAsync()
+    {
+        ClubSelector.OnChange += OnClubChanged;
+        await LaadAsync();
+    }
+
+    public void Dispose() => ClubSelector.OnChange -= OnClubChanged;
+
+    private void OnClubChanged() => _ = InvokeAsync(StateHasChanged);
+
+    private async Task LaadAsync()
+    {
+        _loading = true;
+        _error   = null;
+
+        var tWedstrijden = Api.GetAllstarsWedstrijdenAsync();
+        var tTeams       = Api.GetAllstarsTeamsAsync();
+        var tVelden      = Api.GetVeldenAsync();
+        var tSpeeltijden = Api.GetSpeeltijdenAsync();
+        await Task.WhenAll(tWedstrijden, tTeams, tVelden, tSpeeltijden);
+
+        var wedstrijden = await tWedstrijden;
+        var teams       = await tTeams;
+        var velden      = await tVelden;
+        var speeltijden = await tSpeeltijden;
+
+        if (wedstrijden.Success) _rijen       = wedstrijden.Data?.Select(WedstrijdRij.VanDto).ToList() ?? new();
+        if (teams.Success)       _teams       = teams.Data       ?? new();
+        if (velden.Success)      _velden      = velden.Data      ?? new();
+        if (speeltijden.Success) _speeltijden = speeltijden.Data ?? new();
+
+        if (!teams.Success) _error = $"Teams ophalen mislukt: {teams.ErrorMessage}";
+
+        _loading = false;
+    }
+
+    // ── Cel-events ──
+
+    private void OnThuisTeamChanged(WedstrijdRij rij, string? waarde)
+    {
+        rij.ThuisTeam = waarde;
+        if (string.IsNullOrEmpty(rij.Aanvangstijd))
+            rij.Aanvangstijd = _globalStarttijd;
+        _ = AutoSaveAsync(rij);
+    }
+
+    private async Task AutoSaveAsync(WedstrijdRij rij)
+    {
+        if (string.IsNullOrWhiteSpace(rij.ThuisTeam) && string.IsNullOrWhiteSpace(rij.Datum))
+            return;
+
+        rij.IsSaving  = true;
+        rij.HeeftFout = false;
+        rij.SaveError = null;
+        StateHasChanged();
+
+        var result = await Api.UpsertAllstarsWedstrijdAsync(rij.ToDto());
+
+        rij.IsSaving     = false;
+        rij.IsOpgeslagen = result.Success;
+        rij.HeeftFout    = !result.Success;
+        rij.SaveError    = result.Success ? null : result.ErrorMessage;
+        StateHasChanged();
+    }
+
+    // ── Knoppen ──
+
+    private void VoegLegeRijToe()
+    {
+        var rij = new WedstrijdRij
+        {
+            Datum        = _globalDatum,
+            Soort        = _globalSoort,
+            UitTeam      = string.IsNullOrWhiteSpace(_globalTegenstander) ? null : _globalTegenstander,
+            Aanvangstijd = _globalStarttijd,
+        };
+        _rijen.Add(rij);
+    }
+
+    private async Task VoegAlleTeamsToeAsync()
+    {
+        _bezig = true;
+        var nieuweRijen = _teams.Select(team => new WedstrijdRij
+        {
+            Datum        = _globalDatum,
+            ThuisTeam    = team,
+            UitTeam      = string.IsNullOrWhiteSpace(_globalTegenstander) ? null : _globalTegenstander,
+            Soort        = _globalSoort,
+            Aanvangstijd = _globalStarttijd,
+        }).ToList();
+
+        _rijen.AddRange(nieuweRijen);
+        StateHasChanged();
+
+        foreach (var rij in nieuweRijen)
+            await AutoSaveAsync(rij);
+
+        _bezig = false;
+    }
+
+    private async Task VerwijderRijAsync(WedstrijdRij rij)
+    {
+        if (rij.IsOpgeslagen)
+            await Api.DeleteAllstarsWedstrijdAsync(rij.BkMatches);
+        _rijen.Remove(rij);
+    }
+
+    private async Task VerwijderAllesAsync()
+    {
+        _bezig = true;
+        await Api.DeleteAlleAllstarsWedstrijdenAsync();
+        _rijen.Clear();
+        _bezig = false;
+    }
+
+    // ── Fill-down per kolom ──
+
+    private void VulKolom(string kolom)
+    {
+        string? bronWaarde = kolom switch
+        {
+            "datum"       => _rijen.Select(r => r.Datum).FirstOrDefault(v => !string.IsNullOrEmpty(v)),
+            "aanvangstijd"=> _rijen.Select(r => r.Aanvangstijd).FirstOrDefault(v => !string.IsNullOrEmpty(v)),
+            _             => null,
+        };
+        if (bronWaarde == null) return;
+
+        foreach (var rij in _rijen)
+        {
+            var leeg = kolom switch
+            {
+                "datum"        => string.IsNullOrEmpty(rij.Datum),
+                "aanvangstijd" => string.IsNullOrEmpty(rij.Aanvangstijd),
+                _              => false,
+            };
+            if (!leeg) continue;
+
+            if (kolom == "datum")        rij.Datum        = bronWaarde;
+            if (kolom == "aanvangstijd") rij.Aanvangstijd = bronWaarde;
+            _ = AutoSaveAsync(rij);
+        }
+    }
+
+    // ── Helpers ──
+
+    private static string RijKlasse(WedstrijdRij rij) =>
+        rij.HeeftFout    ? "table-danger"  :
+        rij.IsOpgeslagen ? ""              :
+                           "table-warning";
+}

--- a/BlazorAdmin/Pages/TestData/Wedstrijden.razor
+++ b/BlazorAdmin/Pages/TestData/Wedstrijden.razor
@@ -56,9 +56,9 @@
             </div>
             <div class="col-auto">
                 <label class="form-label mb-1 small">Starttijd (nieuw)</label>
-                <input type="time" class="form-control form-control-sm" style="width:120px"
-                       value="@_globalStarttijd"
-                       @onchange="e => _globalStarttijd = e.Value?.ToString() ?? _globalStarttijd" />
+                <TimeInput Value="@_globalStarttijd"
+                           ValueChanged="@(v => _globalStarttijd = v ?? _globalStarttijd)"
+                           Class="form-control-sm" Style="width:120px" />
             </div>
             <div class="col-auto">
                 <label class="form-label mb-1 small">Veld (nieuw)</label>
@@ -190,9 +190,9 @@ else
                         </td>
 
                         <td>
-                            <input type="time" class="form-control form-control-sm border-0"
-                                   value="@rij.Aanvangstijd"
-                                   @onchange="e => { rij.Aanvangstijd = e.Value?.ToString(); _ = AutoSaveAsync(rij); }" />
+                            <TimeInput Value="@rij.Aanvangstijd"
+                                       ValueChanged="@(v => { rij.Aanvangstijd = v; _ = AutoSaveAsync(rij); })"
+                                       Class="form-control-sm border-0" />
                         </td>
 
                         <td>
@@ -392,6 +392,7 @@ else
     protected override async Task OnInitializedAsync()
     {
         ClubSelector.OnChange += OnClubChanged;
+        await ClubSelector.InitializeAsync();
         await LaadAsync();
     }
 

--- a/BlazorAdmin/Pages/TestData/Wedstrijden.razor
+++ b/BlazorAdmin/Pages/TestData/Wedstrijden.razor
@@ -60,6 +60,16 @@
                        value="@_globalStarttijd"
                        @onchange="e => _globalStarttijd = e.Value?.ToString() ?? _globalStarttijd" />
             </div>
+            <div class="col-auto">
+                <label class="form-label mb-1 small">Veld (nieuw)</label>
+                <select class="form-select form-select-sm" style="width:140px" @bind="_globalVeldNaam">
+                    <option value="">— geen —</option>
+                    @foreach (var v in _velden)
+                    {
+                        <option value="@v.VeldNaam">@v.VeldNaam</option>
+                    }
+                </select>
+            </div>
             <div class="col-auto mt-auto d-flex gap-1 flex-wrap">
                 <button class="btn btn-sm btn-primary" @onclick="VoegAlleTeamsToeAsync"
                         disabled="@(_teams.Count == 0 || _bezig)">
@@ -325,6 +335,7 @@ else
     private string _globalSoort        = "Oefenwedstrijd";
     private string _globalTegenstander = "FC Onbekend";
     private string _globalStarttijd    = "10:00";
+    private string _globalVeldNaam     = "";
 
     // Filter
     private string _filterVan = "";
@@ -485,6 +496,7 @@ else
             Soort        = _globalSoort,
             UitTeam      = string.IsNullOrWhiteSpace(_globalTegenstander) ? null : _globalTegenstander,
             Aanvangstijd = _globalStarttijd,
+            VeldNaam     = string.IsNullOrEmpty(_globalVeldNaam) ? null : _globalVeldNaam,
         };
         _rijen.Add(rij);
     }
@@ -504,6 +516,7 @@ else
                     : $"{_globalTegenstander} {suffix}",
                 Soort        = _globalSoort,
                 Aanvangstijd = _globalStarttijd,
+                VeldNaam     = string.IsNullOrEmpty(_globalVeldNaam) ? null : _globalVeldNaam,
             };
         }).ToList();
 

--- a/BlazorAdmin/Pages/Voorkeurstijden.razor
+++ b/BlazorAdmin/Pages/Voorkeurstijden.razor
@@ -67,8 +67,8 @@ else
         <hr />
         <h3>@(isNew ? "Nieuwe voorkeur" : $"Bewerken: {editing.TeamNaam} #{editing.Id}")</h3>
         <EditForm Model="editing" OnValidSubmit="OpslaanAsync">
-            <div class="row">
-                <div class="col-md-4 mb-3">
+            <div class="row align-items-end">
+                <div class="col-md-3 mb-3">
                     <label class="form-label">Team</label>
                     <select class="form-select" @bind="editing.TeamNaam">
                         <option value="">— Kies een team —</option>
@@ -78,7 +78,7 @@ else
                         }
                     </select>
                 </div>
-                <div class="col-md-3 mb-3">
+                <div class="col-md-2 mb-3">
                     <label class="form-label">Dag</label>
                     <select class="form-select" @bind="editing.DagVanWeek">
                         <option value="1">Maandag</option>
@@ -91,20 +91,24 @@ else
                     </select>
                 </div>
                 <div class="col-md-2 mb-3">
-                    <label class="form-label">Tijd (HH:mm)</label>
-                    <input class="form-control" @bind="editing.VoorkeurTijd" placeholder="14:30" />
+                    <label class="form-label">Tijd</label>
+                    <TimeInput Value="@editing.VoorkeurTijd"
+                               ValueChanged="@(v => editing.VoorkeurTijd = v)" />
                 </div>
                 <div class="col-md-2 mb-3">
-                    <label class="form-label">Prioriteit</label>
+                    <label class="form-label">Prioriteit <span class="text-muted small fw-normal">(1–10)</span></label>
                     <input class="form-control" type="number" min="1" max="10" @bind="editing.Prioriteit" />
+                    <div class="form-text">1 = hoogste prioriteit, 10 = laagste. De planner kiest de voorkeurstijd met het laagste getal.</div>
                 </div>
                 <div class="col-md-1 mb-3">
                     <label class="form-label d-block">Actief</label>
                     <input type="checkbox" class="form-check-input mt-2" @bind="editing.Actief" />
                 </div>
+                <div class="col-md-2 mb-3 d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">Opslaan</button>
+                    <button type="button" class="btn btn-secondary" @onclick="() => editing = null">Annuleren</button>
+                </div>
             </div>
-            <button type="submit" class="btn btn-primary">Opslaan</button>
-            <button type="button" class="btn btn-secondary" @onclick="() => editing = null">Annuleren</button>
         </EditForm>
     }
 
@@ -182,8 +186,9 @@ else
                     </select>
                 </div>
                 <div class="col-md-2 mb-3">
-                    <label class="form-label">Prioriteit</label>
+                    <label class="form-label">Prioriteit <span class="text-muted small fw-normal">(0–99)</span></label>
                     <input class="form-control" type="number" min="0" max="99" @bind="editingRegel.Prioriteit" />
+                    <div class="form-text">Hoger getal = eerder toegepast. 0 = laagste prioriteit.</div>
                 </div>
                 <div class="col-md-2 mb-3">
                     <label class="form-label d-block">Actief</label>
@@ -207,15 +212,23 @@ else
             {
                 <div class="row">
                     <div class="col-md-3 mb-3">
-                        <label class="form-label">Veldnummer</label>
-                        <input class="form-control" type="number" min="1" max="99"
-                               value="@editingRegel.WaardeVeldNummer"
-                               @onchange="e => editingRegel.WaardeVeldNummer = int.TryParse(e.Value?.ToString(), out var v) ? v : null" />
+                        <label class="form-label">Veld</label>
+                        <select class="form-select"
+                                value="@editingRegel.WaardeVeldNummer"
+                                @onchange="e => editingRegel.WaardeVeldNummer = int.TryParse(e.Value?.ToString(), out var v) ? v : null">
+                            <option value="">— Kies een veld —</option>
+                            @foreach (var v in velden)
+                            {
+                                <option value="@v.VeldNummer">@v.VeldNaam (@v.VeldNummer)</option>
+                            }
+                        </select>
                     </div>
                     <div class="col-md-3 mb-3">
-                        <label class="form-label">Aanvangstijd (optioneel, HH:mm)</label>
-                        <input class="form-control" @bind="editingRegel.WaardeTijd" placeholder="bijv. 12:00" />
-                        <small class="form-text text-muted">Laat leeg als er geen vaste tijd is</small>
+                        <label class="form-label">Aanvangstijd (optioneel)</label>
+                        <TimeInput Value="@editingRegel.WaardeTijd"
+                                   ValueChanged="@(v => editingRegel.WaardeTijd = v)"
+                                   Placeholder="bijv. 12:00" />
+                        <div class="form-text">Laat leeg als er geen vaste tijd is</div>
                     </div>
                 </div>
             }
@@ -240,6 +253,7 @@ else
     private List<VoorkeurTijdDto> items = new();
     private List<TeamRegelDto> teamRegels = new();
     private List<string> teams = new();
+    private List<VeldDto> velden = new();
     private VoorkeurTijdDto? editing;
     private TeamRegelDto? editingRegel;
     private bool isNew;
@@ -269,12 +283,15 @@ else
     private async Task LoadAsync()
     {
         loading = true;
-        var teamsResult = await Api.GetTeamsAsync();
-        teams = teamsResult.Success ? teamsResult.Data ?? new() : new();
-        var r = await Api.GetVoorkeurTijdenAsync();
-        items = r.Success ? r.Data ?? new() : new();
-        var regelsResult = await Api.GetTeamRegelsAsync();
-        teamRegels = regelsResult.Success ? regelsResult.Data ?? new() : new();
+        var teamsTask  = Api.GetTeamsAsync();
+        var voeorkeurTask = Api.GetVoorkeurTijdenAsync();
+        var regelsTask = Api.GetTeamRegelsAsync();
+        var veldenTask = Api.GetVeldenAsync();
+        await Task.WhenAll(teamsTask, voeorkeurTask, regelsTask, veldenTask);
+        teams     = (await teamsTask).Data     ?? new();
+        items     = (await voeorkeurTask).Data ?? new();
+        teamRegels= (await regelsTask).Data    ?? new();
+        velden    = (await veldenTask).Data    ?? new();
         loading = false;
     }
 

--- a/BlazorAdmin/Program.cs
+++ b/BlazorAdmin/Program.cs
@@ -70,7 +70,7 @@ if (builder.HostEnvironment.IsProduction())
             InnerHandler = authHandler
         };
         var http = new HttpClient(clubHandler) { BaseAddress = new Uri(capturedFunctionBaseUrl) };
-        return new AdminApiClient(http);
+        return new AdminApiClient(http, sp.GetRequiredService<ApiStatusService>());
     });
 }
 else
@@ -87,11 +87,12 @@ else
             InnerHandler = new HttpClientHandler()
         };
         var http = new HttpClient(clubHandler) { BaseAddress = new Uri(functionBaseUrl) };
-        return new AdminApiClient(http);
+        return new AdminApiClient(http, sp.GetRequiredService<ApiStatusService>());
     });
 }
 
 builder.Services.AddScoped<ClubSelectorService>();
 builder.Services.AddScoped<ThemeService>();
+builder.Services.AddScoped<ApiStatusService>();
 
 await builder.Build().RunAsync();

--- a/BlazorAdmin/Services/AdminApiClient.cs
+++ b/BlazorAdmin/Services/AdminApiClient.cs
@@ -215,8 +215,15 @@ public class AdminApiClient
     public async Task<ApiResult<object>> DeleteAllstarsWedstrijdAsync(string bk)
         => await DeleteAsync<object>($"api/beheer/testdata/wedstrijden/{Uri.EscapeDataString(bk)}");
 
-    public async Task<ApiResult<object>> DeleteAlleAllstarsWedstrijdenAsync()
-        => await DeleteAsync<object>("api/beheer/testdata/wedstrijden");
+    public async Task<ApiResult<object>> DeleteAlleAllstarsWedstrijdenAsync(string? van = null, string? tot = null)
+    {
+        var path = "api/beheer/testdata/wedstrijden";
+        var qp = new List<string>();
+        if (!string.IsNullOrEmpty(van)) qp.Add($"van={Uri.EscapeDataString(van)}");
+        if (!string.IsNullOrEmpty(tot)) qp.Add($"tot={Uri.EscapeDataString(tot)}");
+        if (qp.Count > 0) path += "?" + string.Join("&", qp);
+        return await DeleteAsync<object>(path);
+    }
 
     // ── Feedback widget ──
 

--- a/BlazorAdmin/Services/AdminApiClient.cs
+++ b/BlazorAdmin/Services/AdminApiClient.cs
@@ -196,6 +196,28 @@ public class AdminApiClient
     public async Task<ApiResult<ThemeExtractResultDto>> ExtractThemeColorsAsync(string url)
         => await PostAsync<ThemeExtractResultDto>($"api/beheer/theme/extract?url={Uri.EscapeDataString(url)}", new { });
 
+    // ── Velden ──
+
+    public async Task<ApiResult<List<VeldDto>>> GetVeldenAsync()
+        => await GetAsync<List<VeldDto>>("api/beheer/velden");
+
+    // ── Test data / ALLSTARS (#365) ──
+
+    public async Task<ApiResult<List<AllstarsWedstrijdDto>>> GetAllstarsWedstrijdenAsync()
+        => await GetAsync<List<AllstarsWedstrijdDto>>("api/beheer/testdata/wedstrijden");
+
+    public async Task<ApiResult<List<string>>> GetAllstarsTeamsAsync()
+        => await GetAsync<List<string>>("api/beheer/testdata/teams");
+
+    public async Task<ApiResult<object>> UpsertAllstarsWedstrijdAsync(AllstarsWedstrijdDto dto)
+        => await PostAsync<object>("api/beheer/testdata/wedstrijden", dto);
+
+    public async Task<ApiResult<object>> DeleteAllstarsWedstrijdAsync(string bk)
+        => await DeleteAsync<object>($"api/beheer/testdata/wedstrijden/{Uri.EscapeDataString(bk)}");
+
+    public async Task<ApiResult<object>> DeleteAlleAllstarsWedstrijdenAsync()
+        => await DeleteAsync<object>("api/beheer/testdata/wedstrijden");
+
     // ── Feedback widget ──
 
     public async Task<ApiResult<FeedbackValidateResponse>> ValidateFeedbackAsync(FeedbackValidateRequest dto)

--- a/BlazorAdmin/Services/AdminApiClient.cs
+++ b/BlazorAdmin/Services/AdminApiClient.cs
@@ -12,11 +12,13 @@ namespace BlazorAdmin.Services;
 public class AdminApiClient
 {
     private readonly HttpClient _http;
+    private readonly ApiStatusService _status;
     private static readonly JsonSerializerOptions _jsonOpts = new(JsonSerializerDefaults.Web);
 
-    public AdminApiClient(HttpClient http)
+    public AdminApiClient(HttpClient http, ApiStatusService status)
     {
         _http = http;
+        _status = status;
     }
 
     // ── Settings ──
@@ -242,7 +244,7 @@ public class AdminApiClient
             var resp = await _http.GetAsync(path);
             return await HandleAsync<T>(resp);
         }
-        catch (Exception ex) { return ApiResult<T>.Fail(ex.Message); }
+        catch (Exception ex) { return Fout<T>(ex.Message); }
     }
 
     private async Task<ApiResult<T>> PostAsync<T>(string path, object body)
@@ -252,7 +254,7 @@ public class AdminApiClient
             var resp = await _http.PostAsJsonAsync(path, body);
             return await HandleAsync<T>(resp);
         }
-        catch (Exception ex) { return ApiResult<T>.Fail(ex.Message); }
+        catch (Exception ex) { return Fout<T>(ex.Message); }
     }
 
     private async Task<ApiResult<T>> PutAsync<T>(string path, object body)
@@ -262,7 +264,7 @@ public class AdminApiClient
             var resp = await _http.PutAsJsonAsync(path, body);
             return await HandleAsync<T>(resp);
         }
-        catch (Exception ex) { return ApiResult<T>.Fail(ex.Message); }
+        catch (Exception ex) { return Fout<T>(ex.Message); }
     }
 
     private async Task<ApiResult<T>> DeleteAsync<T>(string path)
@@ -272,14 +274,25 @@ public class AdminApiClient
             var resp = await _http.DeleteAsync(path);
             return await HandleAsync<T>(resp);
         }
-        catch (Exception ex) { return ApiResult<T>.Fail(ex.Message); }
+        catch (Exception ex) { return Fout<T>(ex.Message); }
     }
 
-    private static async Task<ApiResult<T>> HandleAsync<T>(HttpResponseMessage resp)
+    private async Task<ApiResult<T>> HandleAsync<T>(HttpResponseMessage resp)
     {
         var text = await resp.Content.ReadAsStringAsync();
         if (!resp.IsSuccessStatusCode)
-            return ApiResult<T>.Fail($"HTTP {(int)resp.StatusCode}: {text}", (int)resp.StatusCode);
+        {
+            var statusCode = (int)resp.StatusCode;
+            if (statusCode >= 500)
+            {
+                // Korte foutmelding voor de banner — zonder de volledige response body
+                var korteBeschrijving = text.Length > 200 ? text[..200] + "…" : text;
+                _status.MeldFout($"HTTP {statusCode} — controleer de FunctionApp-logs. {korteBeschrijving}");
+            }
+            return ApiResult<T>.Fail($"HTTP {statusCode}: {text}", statusCode);
+        }
+
+        _status.Herstel();
 
         if (string.IsNullOrWhiteSpace(text))
             return ApiResult<T>.Ok(default!, (int)resp.StatusCode);
@@ -293,5 +306,11 @@ public class AdminApiClient
         {
             return ApiResult<T>.Fail($"Deserialisatie mislukt: {ex.Message}");
         }
+    }
+
+    private ApiResult<T> Fout<T>(string melding)
+    {
+        _status.MeldFout($"Geen verbinding met de backend — controleer of de FunctionApp draait. ({melding})");
+        return ApiResult<T>.Fail(melding);
     }
 }

--- a/BlazorAdmin/Services/ApiStatusService.cs
+++ b/BlazorAdmin/Services/ApiStatusService.cs
@@ -1,0 +1,38 @@
+namespace BlazorAdmin.Services;
+
+public enum BackendStatus { Ok, StartingUp, Fout }
+
+/// <summary>
+/// Houdt globale API-bereikbaarheidsstatus bij zodat MainLayout een banner kan tonen
+/// wanneer de backend niet beschikbaar is of 5xx-fouten geeft.
+/// </summary>
+public class ApiStatusService
+{
+    public BackendStatus Status { get; private set; } = BackendStatus.Ok;
+    public string? Foutmelding { get; private set; }
+    public event Action? OnChanged;
+
+    public void MeldStartend()
+    {
+        if (Status == BackendStatus.StartingUp) return;
+        Status = BackendStatus.StartingUp;
+        Foutmelding = null;
+        OnChanged?.Invoke();
+    }
+
+    public void MeldFout(string melding)
+    {
+        if (Status == BackendStatus.Fout && Foutmelding == melding) return;
+        Status = BackendStatus.Fout;
+        Foutmelding = melding;
+        OnChanged?.Invoke();
+    }
+
+    public void Herstel()
+    {
+        if (Status == BackendStatus.Ok) return;
+        Status = BackendStatus.Ok;
+        Foutmelding = null;
+        OnChanged?.Invoke();
+    }
+}

--- a/BlazorAdmin/Shared/TimeInput.razor
+++ b/BlazorAdmin/Shared/TimeInput.razor
@@ -72,8 +72,8 @@
     {
         var s = raw.Trim().Replace(" ", "");
 
-        // Only digits and one optional colon allowed
-        if (!System.Text.RegularExpressions.Regex.IsMatch(s, @"^\d{1,2}(:\d{0,2})?$"))
+        // 1-4 digits, optionally followed by colon + 0-2 digits
+        if (!System.Text.RegularExpressions.Regex.IsMatch(s, @"^\d{1,4}(:\d{0,2})?$"))
             return (null, "Voer een geldige tijd in (bijv. 14:30 of 1430)");
 
         int h, m;

--- a/BlazorAdmin/Shared/TimeInput.razor
+++ b/BlazorAdmin/Shared/TimeInput.razor
@@ -1,0 +1,117 @@
+@* Reusable 24-hour time input.
+   Accepts "14:30" or "1430" — normalizes to "HH:mm" on blur.
+   Validates: hours 0-23, minutes 0-59, no letters, no impossible values.
+   Use for all time fields so validation is always in one place.
+*@
+
+<input type="text"
+       class="@_inputClass"
+       id="@Id"
+       style="@Style"
+       placeholder="@Placeholder"
+       value="@_display"
+       disabled="@Disabled"
+       @oninput="OnInput"
+       @onblur="OnBlurAsync" />
+@if (_error != null)
+{
+    <div class="invalid-feedback d-block">@_error</div>
+}
+
+@code {
+    [Parameter] public string?  Value        { get; set; }
+    [Parameter] public EventCallback<string?> ValueChanged { get; set; }
+    [Parameter] public string?  Id           { get; set; }
+    [Parameter] public string?  Class        { get; set; }
+    [Parameter] public string   Placeholder  { get; set; } = "14:30";
+    [Parameter] public bool     Disabled     { get; set; }
+    [Parameter] public string?  Style        { get; set; }
+
+    private string  _display    = "";
+    private string? _error;
+    private string  _inputClass => $"form-control {Class} {(_error != null ? "is-invalid" : "")}".Trim();
+
+    protected override void OnParametersSet()
+    {
+        // Sync display with bound value when parent changes it (e.g. initial load)
+        if (_error == null)
+            _display = Value ?? "";
+    }
+
+    private void OnInput(ChangeEventArgs e)
+    {
+        _display = e.Value?.ToString() ?? "";
+        _error   = null;
+    }
+
+    private async Task OnBlurAsync()
+    {
+        var raw = _display.Trim();
+
+        if (string.IsNullOrEmpty(raw))
+        {
+            _error = null;
+            await ValueChanged.InvokeAsync(null);
+            return;
+        }
+
+        var (normalized, error) = Normalize(raw);
+        if (error != null)
+        {
+            _error = error;
+        }
+        else
+        {
+            _error   = null;
+            _display = normalized!;
+            await ValueChanged.InvokeAsync(normalized);
+        }
+    }
+
+    internal static (string? normalized, string? error) Normalize(string raw)
+    {
+        var s = raw.Trim().Replace(" ", "");
+
+        // Only digits and one optional colon allowed
+        if (!System.Text.RegularExpressions.Regex.IsMatch(s, @"^\d{1,2}(:\d{0,2})?$"))
+            return (null, "Voer een geldige tijd in (bijv. 14:30 of 1430)");
+
+        int h, m;
+
+        if (s.Contains(':'))
+        {
+            var parts = s.Split(':');
+            if (!int.TryParse(parts[0], out h)) return (null, "Uur is ongeldig");
+            m = parts.Length > 1 && parts[1].Length > 0
+                ? int.TryParse(parts[1], out var pm) ? pm : -1
+                : 0;
+            if (m < 0) return (null, "Minuten zijn ongeldig");
+        }
+        else if (s.Length <= 2)
+        {
+            if (!int.TryParse(s, out h)) return (null, "Voer een geldige tijd in");
+            m = 0;
+        }
+        else if (s.Length == 3)
+        {
+            // e.g. "930" → 9:30
+            if (!int.TryParse(s[..1], out h) || !int.TryParse(s[1..], out m))
+                return (null, "Voer een geldige tijd in (bijv. 14:30 of 1430)");
+        }
+        else if (s.Length == 4)
+        {
+            // e.g. "1430" → 14:30
+            if (!int.TryParse(s[..2], out h) || !int.TryParse(s[2..], out m))
+                return (null, "Voer een geldige tijd in (bijv. 14:30 of 1430)");
+        }
+        else
+        {
+            return (null, "Voer een geldige tijd in (bijv. 14:30 of 1430)");
+        }
+
+        if (h is < 0 or > 23) return (null, $"Uur moet 0–23 zijn (opgegeven: {h})");
+        if (m is < 0 or > 59) return (null, $"Minuten moeten 0–59 zijn (opgegeven: {m})");
+
+        return ($"{h:D2}:{m:D2}", null);
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,15 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 ## [Unreleased]
 
 ### Added
+- Nieuw herbruikbaar tijdinvoerveld (`TimeInput`) voor alle tijdvelden in de applicatie: accepteert `14:30` én `1430` (wordt automatisch genormaliseerd naar `HH:mm`), valideert uren 0–23 en minuten 0–59, toont een foutmelding bij ongeldige invoer (#365)
+- Voorkeurstijden: veldkeuze in Teamregels (regeltype "Voorkeursveld") toont nu een dropdown met de clubvelden in plaats van een vrij invoerveld — velden worden gefilterd op ClubCode (#365)
+- Voorkeurstijden: prioriteit-uitleg toegevoegd in het invoerecran voor zowel Voorkeurstijden (1=hoogste, 10=laagste) als Teamregels (hoger=eerder toegepast) (#365)
+- Handleiding: nieuwe sectie 14 "Voorkeurstijden & Teamregels" met uitleg over Prioriteit, Teamregel-types en API-endpoints
 - Dagplanning in ALLSTARS-modus laadt nu fictieve testwedstrijden uit `his.matches WHERE ClubCode='ALLSTARS'` in plaats van de Sportlink API — de planner-optimalisatie werkt volledig met testdata (#365)
 - Grasveld-logica in de planner is nu dynamisch op basis van `VeldType = 'gras'` in `dbo.Velden` — geen hardcoded verwijzing naar veldnummer 5 meer; werkt correct voor clubs met andere veldindelingen
 
 ### Fixed
+- Wedstrijden-pagina toonde VRC-velden in de dropdown in ALLSTARS-modus door een race-conditie: `ClubSelector.InitializeAsync()` werd niet afgewacht vóór de API-aanroep in `OnInitializedAsync` (#365)
 - Zijbalk toonde "v.v. VRC" in ALLSTARS-modus door een race-conditie: NavMenu las `SelectedClubCode` uit vóórdat `ClubSelectorService.InitializeAsync()` de localStorage had ingelezen; opgelost door await toe te voegen in `NavMenu.OnInitializedAsync` (#365)
 - Dagplanning in ALLSTARS-modus toonde VRC-velden (1–6) in plaats van ALLSTARS-velden (101–103): planner-queries filteren nu op `VeldNummer >= 100` voor ALLSTARS en `< 100` voor VRC (#365)
 - Wedstrijden zonder veld in ALLSTARS-modus belandden op VRC-veld 1 (fout `CROSS APPLY MIN(VeldNummer)` over alle velden) — fallback gebruikt nu het laagste ALLSTARS-veld (101) (#365)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,48 +19,20 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 ## [Unreleased]
 
 ### Added
-- Speeltijden per club: `dbo.Speeltijden` heeft nu een composite primary key `(Leeftijd, ClubCode)` — elke club kan eigen speeltijden configureren; ALLSTARS-speeltijden zijn gekopieerd van VRC (#365)
-- Nieuw herbruikbaar tijdinvoerveld (`TimeInput`) voor alle tijdvelden in de applicatie: accepteert `14:30` én `1430` (wordt automatisch genormaliseerd naar `HH:mm`), valideert uren 0–23 en minuten 0–59, toont een foutmelding bij ongeldige invoer (#365)
-- Voorkeurstijden: veldkeuze in Teamregels (regeltype "Voorkeursveld") toont nu een dropdown met de clubvelden in plaats van een vrij invoerveld — velden worden gefilterd op ClubCode (#365)
-- Voorkeurstijden: prioriteit-uitleg toegevoegd in het invoerecran voor zowel Voorkeurstijden (1=hoogste, 10=laagste) als Teamregels (hoger=eerder toegepast) (#365)
-- Handleiding: nieuwe sectie 14 "Voorkeurstijden & Teamregels" met uitleg over Prioriteit, Teamregel-types en API-endpoints
-- Dagplanning in ALLSTARS-modus laadt nu fictieve testwedstrijden uit `his.matches WHERE ClubCode='ALLSTARS'` in plaats van de Sportlink API — de planner-optimalisatie werkt volledig met testdata (#365)
-- Grasveld-logica in de planner is nu dynamisch op basis van `VeldType = 'gras'` in `dbo.Velden` — geen hardcoded verwijzing naar veldnummer 5 meer; werkt correct voor clubs met andere veldindelingen
+- Globale backend-statusbanner: bovenaan elk scherm verschijnt nu een zichtbare gele banner ("Backend start op…") tijdens het opstarten van de FunctionApp, en een rode banner ("Backend niet bereikbaar") wanneer de API 5xx-fouten geeft of onbereikbaar is — lege schermen zonder uitleg zijn niet meer mogelijk (#365)
+- Velddeel-selector in testdata invoergrid: per wedstrijd kan nu een deelveld worden gekozen op basis van de speeltijden-tabel — JO7-JO10 (0.25 veld) toont A1/A2/B1/B2, JO11-JO12 (0.50 veld) toont A/B, volledig-veld-leeftijden tonen geen dropdown (#365)
+- Nieuw herbruikbaar tijdinvoerveld (`TimeInput`) voor alle tijdvelden in de applicatie (#365)
+- Voorkeurstijden: veldkeuze in Teamregels toont nu een dropdown met de clubvelden (#365)
+- Dagplanning: ALLSTARS-modus laadt fictieve testwedstrijden uit de database (#365)
+- Speeltijden per club: composite primary key `(Leeftijd, ClubCode)` — elke club kan eigen speeltijden configureren (#365)
 
 ### Fixed
-- Planner-queries joinden `dbo.Speeltijden` zonder ClubCode-filter: bij multi-club data werden dubbele rijen teruggegeven; alle 5 JOIN-condities en de 2 standalone queries filteren nu op `ClubCode` (#365)
-- Wedstrijden-pagina toonde VRC-velden in de dropdown in ALLSTARS-modus door een race-conditie: `ClubSelector.InitializeAsync()` werd niet afgewacht vóór de API-aanroep in `OnInitializedAsync` (#365)
-- Zijbalk toonde "v.v. VRC" in ALLSTARS-modus door een race-conditie: NavMenu las `SelectedClubCode` uit vóórdat `ClubSelectorService.InitializeAsync()` de localStorage had ingelezen; opgelost door await toe te voegen in `NavMenu.OnInitializedAsync` (#365)
-- Dagplanning in ALLSTARS-modus toonde VRC-velden (1–6) in plaats van ALLSTARS-velden (101–103): planner-queries filteren nu op `VeldNummer >= 100` voor ALLSTARS en `< 100` voor VRC (#365)
-- Wedstrijden zonder veld in ALLSTARS-modus belandden op VRC-veld 1 (fout `CROSS APPLY MIN(VeldNummer)` over alle velden) — fallback gebruikt nu het laagste ALLSTARS-veld (101) (#365)
-- Dagplanning in ALLSTARS-modus toonde "✓ Geen optimalisatie nodig — huidige planning is al optimaal" terwijl veel wedstrijden nog geen veld hadden; vervangen door een informatieve testmodus-melding met aantal ongeplaatste wedstrijden en een verwijzing naar Test data → Wedstrijden (#365)
-- Clubnaam in de zijbalk wordt nu direct bijgewerkt na wisselen van club: "ALLSTARS (testmodus)" bij testmodus, clubnaam uit AppSettings bij terugkeren (#365)
-- Optimalisatiedoel "Veld 5 ontlasten" hernoemd naar "Grasveld(en) ontlasten" en statistiek "Van veld 5 verplaatst" → "Van grasveld verplaatst" in dagplanning (#365)
-- Planner-suggesties tonen nu de juiste (dynamische) veldnaam en reden op basis van het werkelijke grasveld
-- ALLSTARS testmodus reset niet langer naar VRC bij iedere paginawissel — geselecteerde club blijft bewaard (#365)
-- Instellingen-pagina toont een heldere testmodus-melding in ALLSTARS-modus; synchronisatie- en e-mailverwerkingssecties zijn verborgen omdat deze niet van toepassing zijn op testdata (#365)
-- Dagplanning in ALLSTARS-modus toonde "geen wedstrijden" als veld leeg was of niet overeenkwam — query gebruikt nu volledige veldnaam-match en valt terug op laagste VeldNummer bij ontbrekend veld (#365)
-- Testdata-formulier: globaal veld-dropdown toegevoegd zodat "Alle teams" meteen het gekozen veld meeneemt (#365)
-- AdminThemeGet crashte bij koude start met `InvalidOperationException: clubCode ontbreekt` — GetClubCodeFromRequest werd aangeroepen vóór WaitForDatabaseAsync, waardoor AppSettings nog null waren; volgorde gecorrigeerd (#365)
-- Testdata invoergrid (Wedstrijden): velddeel-selector per rij op basis van Speeltijden.Veldafmeting — JO7-JO10 (0.25 veld) toont A1/A2/B1/B2, JO11-JO12 (0.50 veld) toont A/B, volledige-veld-leeftijden tonen "heel veld" (#365)
-- ALLSTARS dagplanning toonde onzichtbare blokken voor JO-teams omdat leeftijdscategorie werd geëxtraheerd met een koppelteken-gebaseerde splitser (werkt voor "VRC JO10-1" maar niet voor "AllStars JO10 1"): query gebruikt nu de tweede spatie-gescheiden token van de teamnaam, met mapping Heren→1-99 en Dames/Vrouwen→VR (#365)
-- Dagplanning ALLSTARS-testmelding toonde alleen een aantal ("2 van 10 wedstrijden op standaard veld"): melding toont nu ook welke teams geen veld hebben toegewezen zodat direct duidelijk is wat er bijgewerkt moet worden (#365)
+- ALLSTARS dagplanning toonde onzichtbare blokken voor JO-teams door slechte leeftijdscategorie-extractie — opgelost met tweede spatie-gescheiden token van de teamnaam (#365)
+- Dagplanning ALLSTARS-testmelding toont nu welke teams geen veld hebben toegewezen (#365)
+- Planner-queries joinden `dbo.Speeltijden` zonder ClubCode-filter — dubbele rijen bij multi-club data opgelost (#365)
+- Wedstrijden-pagina, zijbalk en dagplanning toonden VRC-data in ALLSTARS-modus door race-condities bij initialisatie (#365)
+- Start-Debug.ps1: runtimeconfig.json lock-fout bij dotnet watch herstart opgelost via 4s sleep en MSBUILDDISABLENODEREUSE=1 (#365)
 
-### Added (eerder in 2.7.0.0)
-- Test data modus (ALLSTARS) — beheerders kunnen fictieve wedstrijden aanmaken via een invoergrid (#365): klik "Testmodus" in de zijbalk om de ALLSTARS-modus te activeren. Onder "Test data → Wedstrijden" verschijnt een grid met de volgende mogelijkheden:
-  - Teams-dropdown toont uitsluitend teams gekoppeld aan ALLSTARS-teambegeleiding
-  - Tegenstander-veld wordt automatisch gevuld met het suffix van het thuisteam (bijv. "FC Onbekend JO9-2")
-  - Datumfilter (van/tot) om de weergave te beperken; de "Verwijder gefilterd"-knop verwijdert alleen wedstrijden in het geselecteerde bereik (verwijder-alles vereist een filter)
-  - Klikbare kolomkoppen (Datum, Thuis, Tegenstander, Starttijd) voor oplopend/aflopend sorteren; standaard datum aflopend
-  - Competitietypes: Competitie, Oefenwedstrijd, Toernooi, Vriendschappelijk
-  - Globale datum/soort/tegenstander/starttijd invullen, op "Alle teams" klikken voor één rij per team, of losse lege rijen toevoegen
-  - Elke cel sla je op door hem te verlaten (auto-save) — fill-down (↓) kopieert de eerste ingevulde waarde naar lege cellen
-  - Alle testdata gebruikt `ClubCode = ALLSTARS` — echte wedstrijden blijven onaangetast
-
-### Fixed
-- Veldplanner toonde alle 5 velden ongeacht de club (#364): de dagplanning en optimalisatie tonen nu alleen de velden die bij de actieve club horen (gefilterd op ClubCode). AllStars FC (3 velden) ziet voortaan niet meer de velden van andere clubs.
-- Veldplanner-optimalisatie was afhankelijk van hardcoded "veld 5 = grasveld": alle logica is nu gebaseerd op het `VeldType`-veld in de database (`kunstgras`/`gras`). Clubs met een ander aantal velden of een andere indeling worden correct behandeld.
-- Dagplanning UI: "Veld 5 ontlasten" hernoemd naar "Grasveld(en) ontlasten"; statistiek "Van veld 5 verplaatst" wordt nu "Van grasveld verplaatst".
 ## [2.6.0.1] — 2026-05-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Dagplanning in ALLSTARS-modus toonde "geen wedstrijden" als veld leeg was of niet overeenkwam — query gebruikt nu volledige veldnaam-match en valt terug op laagste VeldNummer bij ontbrekend veld (#365)
 - Testdata-formulier: globaal veld-dropdown toegevoegd zodat "Alle teams" meteen het gekozen veld meeneemt (#365)
 - AdminThemeGet crashte bij koude start met `InvalidOperationException: clubCode ontbreekt` — GetClubCodeFromRequest werd aangeroepen vóór WaitForDatabaseAsync, waardoor AppSettings nog null waren; volgorde gecorrigeerd (#365)
+- ALLSTARS dagplanning toonde onzichtbare blokken voor JO-teams omdat leeftijdscategorie werd geëxtraheerd met een koppelteken-gebaseerde splitser (werkt voor "VRC JO10-1" maar niet voor "AllStars JO10 1"): query gebruikt nu de tweede spatie-gescheiden token van de teamnaam, met mapping Heren→1-99 en Dames/Vrouwen→VR (#365)
+- Dagplanning ALLSTARS-testmelding toonde alleen een aantal ("2 van 10 wedstrijden op standaard veld"): melding toont nu ook welke teams geen veld hebben toegewezen zodat direct duidelijk is wat er bijgewerkt moet worden (#365)
 
 ### Added (eerder in 2.7.0.0)
 - Test data modus (ALLSTARS) — beheerders kunnen fictieve wedstrijden aanmaken via een invoergrid (#365): klik "Testmodus" in de zijbalk om de ALLSTARS-modus te activeren. Onder "Test data → Wedstrijden" verschijnt een grid met de volgende mogelijkheden:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 ## [Unreleased]
 
 ### Added
+- Dagplanning in ALLSTARS-modus laadt nu fictieve testwedstrijden uit `his.matches WHERE ClubCode='ALLSTARS'` in plaats van de Sportlink API — de planner-optimalisatie werkt volledig met testdata (#365)
+- Grasveld-logica in de planner is nu dynamisch op basis van `VeldType = 'gras'` in `dbo.Velden` — geen hardcoded verwijzing naar veldnummer 5 meer; werkt correct voor clubs met andere veldindelingen
+
+### Fixed
+- Clubnaam in de zijbalk wordt nu direct bijgewerkt na wisselen van club: "ALLSTARS (testmodus)" bij testmodus, clubnaam uit AppSettings bij terugkeren (#365)
+- Optimalisatiedoel "Veld 5 ontlasten" hernoemd naar "Grasveld(en) ontlasten" en statistiek "Van veld 5 verplaatst" → "Van grasveld verplaatst" in dagplanning (#365)
+- Planner-suggesties tonen nu de juiste (dynamische) veldnaam en reden op basis van het werkelijke grasveld
+
+### Added (eerder in 2.7.0.0)
 - Test data modus (ALLSTARS) — beheerders kunnen fictieve wedstrijden aanmaken via een invoergrid (#365): klik "Testmodus" in de zijbalk om de ALLSTARS-modus te activeren. Onder "Test data → Wedstrijden" verschijnt een grid met de volgende mogelijkheden:
   - Teams-dropdown toont uitsluitend teams gekoppeld aan ALLSTARS-teambegeleiding
   - Tegenstander-veld wordt automatisch gevuld met het suffix van het thuisteam (bijv. "FC Onbekend JO9-2")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Planner-suggesties tonen nu de juiste (dynamische) veldnaam en reden op basis van het werkelijke grasveld
 - ALLSTARS testmodus reset niet langer naar VRC bij iedere paginawissel — geselecteerde club blijft bewaard (#365)
 - Instellingen-pagina toont een heldere testmodus-melding in ALLSTARS-modus; synchronisatie- en e-mailverwerkingssecties zijn verborgen omdat deze niet van toepassing zijn op testdata (#365)
+- Dagplanning in ALLSTARS-modus toonde "geen wedstrijden" als veld leeg was of niet overeenkwam — query gebruikt nu volledige veldnaam-match en valt terug op laagste VeldNummer bij ontbrekend veld (#365)
+- Testdata-formulier: globaal veld-dropdown toegevoegd zodat "Alle teams" meteen het gekozen veld meeneemt (#365)
 
 ### Added (eerder in 2.7.0.0)
 - Test data modus (ALLSTARS) — beheerders kunnen fictieve wedstrijden aanmaken via een invoergrid (#365): klik "Testmodus" in de zijbalk om de ALLSTARS-modus te activeren. Onder "Test data → Wedstrijden" verschijnt een grid met de volgende mogelijkheden:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Clubnaam in de zijbalk wordt nu direct bijgewerkt na wisselen van club: "ALLSTARS (testmodus)" bij testmodus, clubnaam uit AppSettings bij terugkeren (#365)
 - Optimalisatiedoel "Veld 5 ontlasten" hernoemd naar "Grasveld(en) ontlasten" en statistiek "Van veld 5 verplaatst" → "Van grasveld verplaatst" in dagplanning (#365)
 - Planner-suggesties tonen nu de juiste (dynamische) veldnaam en reden op basis van het werkelijke grasveld
+- ALLSTARS testmodus reset niet langer naar VRC bij iedere paginawissel — geselecteerde club blijft bewaard (#365)
+- Instellingen-pagina toont een heldere testmodus-melding in ALLSTARS-modus; synchronisatie- en e-mailverwerkingssecties zijn verborgen omdat deze niet van toepassing zijn op testdata (#365)
 
 ### Added (eerder in 2.7.0.0)
 - Test data modus (ALLSTARS) — beheerders kunnen fictieve wedstrijden aanmaken via een invoergrid (#365): klik "Testmodus" in de zijbalk om de ALLSTARS-modus te activeren. Onder "Test data → Wedstrijden" verschijnt een grid met de volgende mogelijkheden:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 ## [Unreleased]
 
 ### Added
+- Speeltijden per club: `dbo.Speeltijden` heeft nu een composite primary key `(Leeftijd, ClubCode)` — elke club kan eigen speeltijden configureren; ALLSTARS-speeltijden zijn gekopieerd van VRC (#365)
 - Nieuw herbruikbaar tijdinvoerveld (`TimeInput`) voor alle tijdvelden in de applicatie: accepteert `14:30` én `1430` (wordt automatisch genormaliseerd naar `HH:mm`), valideert uren 0–23 en minuten 0–59, toont een foutmelding bij ongeldige invoer (#365)
 - Voorkeurstijden: veldkeuze in Teamregels (regeltype "Voorkeursveld") toont nu een dropdown met de clubvelden in plaats van een vrij invoerveld — velden worden gefilterd op ClubCode (#365)
 - Voorkeurstijden: prioriteit-uitleg toegevoegd in het invoerecran voor zowel Voorkeurstijden (1=hoogste, 10=laagste) als Teamregels (hoger=eerder toegepast) (#365)
@@ -27,6 +28,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Grasveld-logica in de planner is nu dynamisch op basis van `VeldType = 'gras'` in `dbo.Velden` — geen hardcoded verwijzing naar veldnummer 5 meer; werkt correct voor clubs met andere veldindelingen
 
 ### Fixed
+- Planner-queries joinden `dbo.Speeltijden` zonder ClubCode-filter: bij multi-club data werden dubbele rijen teruggegeven; alle 5 JOIN-condities en de 2 standalone queries filteren nu op `ClubCode` (#365)
 - Wedstrijden-pagina toonde VRC-velden in de dropdown in ALLSTARS-modus door een race-conditie: `ClubSelector.InitializeAsync()` werd niet afgewacht vóór de API-aanroep in `OnInitializedAsync` (#365)
 - Zijbalk toonde "v.v. VRC" in ALLSTARS-modus door een race-conditie: NavMenu las `SelectedClubCode` uit vóórdat `ClubSelectorService.InitializeAsync()` de localStorage had ingelezen; opgelost door await toe te voegen in `NavMenu.OnInitializedAsync` (#365)
 - Dagplanning in ALLSTARS-modus toonde VRC-velden (1–6) in plaats van ALLSTARS-velden (101–103): planner-queries filteren nu op `VeldNummer >= 100` voor ALLSTARS en `< 100` voor VRC (#365)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Instellingen-pagina toont een heldere testmodus-melding in ALLSTARS-modus; synchronisatie- en e-mailverwerkingssecties zijn verborgen omdat deze niet van toepassing zijn op testdata (#365)
 - Dagplanning in ALLSTARS-modus toonde "geen wedstrijden" als veld leeg was of niet overeenkwam — query gebruikt nu volledige veldnaam-match en valt terug op laagste VeldNummer bij ontbrekend veld (#365)
 - Testdata-formulier: globaal veld-dropdown toegevoegd zodat "Alle teams" meteen het gekozen veld meeneemt (#365)
+- AdminThemeGet crashte bij koude start met `InvalidOperationException: clubCode ontbreekt` — GetClubCodeFromRequest werd aangeroepen vóór WaitForDatabaseAsync, waardoor AppSettings nog null waren; volgorde gecorrigeerd (#365)
 
 ### Added (eerder in 2.7.0.0)
 - Test data modus (ALLSTARS) — beheerders kunnen fictieve wedstrijden aanmaken via een invoergrid (#365): klik "Testmodus" in de zijbalk om de ALLSTARS-modus te activeren. Onder "Test data → Wedstrijden" verschijnt een grid met de volgende mogelijkheden:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Added
+- Test data modus (ALLSTARS) — beheerders kunnen fictieve wedstrijden aanmaken via een invoergrid (#365): klik "Testmodus" in de zijbalk om de ALLSTARS-modus te activeren. Onder "Test data → Wedstrijden" verschijnt een grid waarmee je snel meerdere wedstrijden aanmaakt: globale datum/soort/tegenstander/starttijd invullen, op "Alle teams" klikken om één rij per team te genereren, of losse lege rijen toevoegen. Elke cel sla je op door hem te verlaten (auto-save). Fill-down (↓) kopieert een waarde naar alle lege cellen in dezelfde kolom. Verwijder één rij of verwijder alles. Alle testdata gebruikt `ClubCode = ALLSTARS` — echte wedstrijden blijven onaangetast.
+
+### Fixed
+- Veldplanner toonde alle 5 velden ongeacht de club (#364): de dagplanning en optimalisatie tonen nu alleen de velden die bij de actieve club horen (gefilterd op ClubCode). AllStars FC (3 velden) ziet voortaan niet meer de velden van andere clubs.
+- Veldplanner-optimalisatie was afhankelijk van hardcoded "veld 5 = grasveld": alle logica is nu gebaseerd op het `VeldType`-veld in de database (`kunstgras`/`gras`). Clubs met een ander aantal velden of een andere indeling worden correct behandeld.
+- Dagplanning UI: "Veld 5 ontlasten" hernoemd naar "Grasveld(en) ontlasten"; statistiek "Van veld 5 verplaatst" wordt nu "Van grasveld verplaatst".
 ## [2.6.0.1] — 2026-05-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Dagplanning in ALLSTARS-modus toonde "geen wedstrijden" als veld leeg was of niet overeenkwam — query gebruikt nu volledige veldnaam-match en valt terug op laagste VeldNummer bij ontbrekend veld (#365)
 - Testdata-formulier: globaal veld-dropdown toegevoegd zodat "Alle teams" meteen het gekozen veld meeneemt (#365)
 - AdminThemeGet crashte bij koude start met `InvalidOperationException: clubCode ontbreekt` — GetClubCodeFromRequest werd aangeroepen vóór WaitForDatabaseAsync, waardoor AppSettings nog null waren; volgorde gecorrigeerd (#365)
+- Testdata invoergrid (Wedstrijden): velddeel-selector per rij op basis van Speeltijden.Veldafmeting — JO7-JO10 (0.25 veld) toont A1/A2/B1/B2, JO11-JO12 (0.50 veld) toont A/B, volledige-veld-leeftijden tonen "heel veld" (#365)
 - ALLSTARS dagplanning toonde onzichtbare blokken voor JO-teams omdat leeftijdscategorie werd geëxtraheerd met een koppelteken-gebaseerde splitser (werkt voor "VRC JO10-1" maar niet voor "AllStars JO10 1"): query gebruikt nu de tweede spatie-gescheiden token van de teamnaam, met mapping Heren→1-99 en Dames/Vrouwen→VR (#365)
 - Dagplanning ALLSTARS-testmelding toonde alleen een aantal ("2 van 10 wedstrijden op standaard veld"): melding toont nu ook welke teams geen veld hebben toegewezen zodat direct duidelijk is wat er bijgewerkt moet worden (#365)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Grasveld-logica in de planner is nu dynamisch op basis van `VeldType = 'gras'` in `dbo.Velden` — geen hardcoded verwijzing naar veldnummer 5 meer; werkt correct voor clubs met andere veldindelingen
 
 ### Fixed
+- Zijbalk toonde "v.v. VRC" in ALLSTARS-modus door een race-conditie: NavMenu las `SelectedClubCode` uit vóórdat `ClubSelectorService.InitializeAsync()` de localStorage had ingelezen; opgelost door await toe te voegen in `NavMenu.OnInitializedAsync` (#365)
+- Dagplanning in ALLSTARS-modus toonde VRC-velden (1–6) in plaats van ALLSTARS-velden (101–103): planner-queries filteren nu op `VeldNummer >= 100` voor ALLSTARS en `< 100` voor VRC (#365)
+- Wedstrijden zonder veld in ALLSTARS-modus belandden op VRC-veld 1 (fout `CROSS APPLY MIN(VeldNummer)` over alle velden) — fallback gebruikt nu het laagste ALLSTARS-veld (101) (#365)
+- Dagplanning in ALLSTARS-modus toonde "✓ Geen optimalisatie nodig — huidige planning is al optimaal" terwijl veel wedstrijden nog geen veld hadden; vervangen door een informatieve testmodus-melding met aantal ongeplaatste wedstrijden en een verwijzing naar Test data → Wedstrijden (#365)
 - Clubnaam in de zijbalk wordt nu direct bijgewerkt na wisselen van club: "ALLSTARS (testmodus)" bij testmodus, clubnaam uit AppSettings bij terugkeren (#365)
 - Optimalisatiedoel "Veld 5 ontlasten" hernoemd naar "Grasveld(en) ontlasten" en statistiek "Van veld 5 verplaatst" → "Van grasveld verplaatst" in dagplanning (#365)
 - Planner-suggesties tonen nu de juiste (dynamische) veldnaam en reden op basis van het werkelijke grasveld

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,15 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 ## [Unreleased]
 
 ### Added
-- Test data modus (ALLSTARS) — beheerders kunnen fictieve wedstrijden aanmaken via een invoergrid (#365): klik "Testmodus" in de zijbalk om de ALLSTARS-modus te activeren. Onder "Test data → Wedstrijden" verschijnt een grid waarmee je snel meerdere wedstrijden aanmaakt: globale datum/soort/tegenstander/starttijd invullen, op "Alle teams" klikken om één rij per team te genereren, of losse lege rijen toevoegen. Elke cel sla je op door hem te verlaten (auto-save). Fill-down (↓) kopieert een waarde naar alle lege cellen in dezelfde kolom. Verwijder één rij of verwijder alles. Alle testdata gebruikt `ClubCode = ALLSTARS` — echte wedstrijden blijven onaangetast.
+- Test data modus (ALLSTARS) — beheerders kunnen fictieve wedstrijden aanmaken via een invoergrid (#365): klik "Testmodus" in de zijbalk om de ALLSTARS-modus te activeren. Onder "Test data → Wedstrijden" verschijnt een grid met de volgende mogelijkheden:
+  - Teams-dropdown toont uitsluitend teams gekoppeld aan ALLSTARS-teambegeleiding
+  - Tegenstander-veld wordt automatisch gevuld met het suffix van het thuisteam (bijv. "FC Onbekend JO9-2")
+  - Datumfilter (van/tot) om de weergave te beperken; de "Verwijder gefilterd"-knop verwijdert alleen wedstrijden in het geselecteerde bereik (verwijder-alles vereist een filter)
+  - Klikbare kolomkoppen (Datum, Thuis, Tegenstander, Starttijd) voor oplopend/aflopend sorteren; standaard datum aflopend
+  - Competitietypes: Competitie, Oefenwedstrijd, Toernooi, Vriendschappelijk
+  - Globale datum/soort/tegenstander/starttijd invullen, op "Alle teams" klikken voor één rij per team, of losse lege rijen toevoegen
+  - Elke cel sla je op door hem te verlaten (auto-save) — fill-down (↓) kopieert de eerste ingevulde waarde naar lege cellen
+  - Alle testdata gebruikt `ClubCode = ALLSTARS` — echte wedstrijden blijven onaangetast
 
 ### Fixed
 - Veldplanner toonde alle 5 velden ongeacht de club (#364): de dagplanning en optimalisatie tonen nu alleen de velden die bij de actieve club horen (gefilterd op ClubCode). AllStars FC (3 velden) ziet voortaan niet meer de velden van andere clubs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -654,23 +654,40 @@ Versienummering volgt `MAJOR.MINOR.PATCH`:
 
 Het versienummer heeft vier cijfers: `MAJOR.MINOR.PATCH.REVISION`
 
-| Commit-type | Versie-impact | Voorbeeld |
-|---|---|---|
-| `feat:` | MINOR bump — Patch en Revision resetten naar 0 | `2.5.0.3 → 2.6.0.0` |
-| `fix:` of `security:` | PATCH bump — Revision reset naar 0 | `2.5.0.3 → 2.5.1.0` |
-| `BREAKING CHANGE:` in commit-body | MAJOR bump | `2.5.x.x → 3.0.0.0` |
-| Kleine fix, CSS, UX, chore **met zichtbaar effect** | REVISION bump | `2.5.0.0 → 2.5.0.1` |
-| Puur intern (refactor zonder effect, docs, CLAUDE.md) | Geen bump | — |
+**Twee fasen — development vs. release:**
 
-> **Reden voor Revision:** de beheerder ziet het versienummer in de header. Na een deployment
-> kan de beheerder bevestigen dat de juiste versie actief is. Zonder Revision-bump is elke
-> kleine fix onzichtbaar in de UI.
+#### Tijdens development (feature/* en develop branches)
+
+Bump uitsluitend de **REVISION** bij elke commit met een zichtbaar effect voor de beheerder.
+MAJOR/MINOR/PATCH blijven ongewijzigd totdat de code naar main gaat.
+
+| Commit-type | Versie-impact tijdens development | Voorbeeld |
+|---|---|---|
+| `feat:`, `fix:`, `security:`, UX-verbetering | REVISION bump | `2.6.0.1 → 2.6.0.2 → ... → 2.6.0.42` |
+| Puur intern (refactor, docs, CLAUDE.md) | Geen bump | — |
+
+> **Reden:** Productie staat op bijv. `2.6.0.1`. Een dev-versie van `2.11.0.0` in de header
+> tijdens lokaal testen creëert een gat dat nooit in de release-history verschijnt en verwarrend
+> is. `2.6.0.42` communiceert duidelijk: dit is dezelfde release-lijn, maar met veel
+> lokale wijzigingen die nog niet zijn uitgerold.
+
+#### Op het moment van release (develop → main PR)
+
+Bekijk alle `## [Unreleased]` entries en pas de versie aan op basis van de inhoud:
+
+| Wat zit er in [Unreleased]? | Versie-impact | Voorbeeld |
+|---|---|---|
+| Een of meer `feat:` commits | MINOR bump — Patch en Revision resetten naar 0 | `2.6.0.42 → 2.7.0.0` |
+| Alleen `fix:` of `security:` | PATCH bump — Revision reset naar 0 | `2.6.0.42 → 2.6.1.0` |
+| `BREAKING CHANGE:` in commit-body | MAJOR bump | `2.6.0.42 → 3.0.0.0` |
+
+De release-versie (bijv. `2.7.0.0`) wordt gezet in de release-commit op develop, vóór de PR naar main.
 
 Zet alle drie velden synchroon in **beide** csproj's:
 ```xml
-<Version>2.5.0.1</Version>
-<AssemblyVersion>2.5.0.1</AssemblyVersion>
-<FileVersion>2.5.0.1</FileVersion>
+<Version>2.6.0.15</Version>
+<AssemblyVersion>2.6.0.15</AssemblyVersion>
+<FileVersion>2.6.0.15</FileVersion>
 ```
 
 ### CHANGELOG.md bijhouden
@@ -681,10 +698,11 @@ Zet alle drie velden synchroon in **beide** csproj's:
 2. Gebruik de secties `### Added`, `### Changed`, `### Fixed`, `### Security`, `### Removed`
 3. Schrijf voor de gebruiker, niet voor de developer: "Beheerders kunnen nu X" i.p.v. "Methode Y refactored"
 
-**Verplicht vóór een release:**
-1. Verplaats alles van `## [Unreleased]` naar `## [x.y.z] — YYYY-MM-DD`
-2. Voeg een lege `## [Unreleased]` terug bovenaan
-3. Bump de versie in `FunctionApp/fa-dev-sportlink-01.csproj` en `BlazorAdmin/BlazorAdmin.csproj`
+**Verplicht vóór een release (develop → main PR):**
+1. Bepaal de release-versie op basis van de [Unreleased] inhoud (zie tabel hierboven)
+2. Verplaats alles van `## [Unreleased]` naar `## [x.y.z] — YYYY-MM-DD`
+3. Voeg een lege `## [Unreleased]` terug bovenaan
+4. Zet de release-versie in beide csproj's
 
 ### Release-workflow
 

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -661,3 +661,12 @@ BEGIN
     );
 END
 GO
+
+-- ============================================================
+-- #365: veld_subpositie — ALLSTARS testdata veldsplitsing
+-- Slaat het velddeel op (A, B, A1, A2, B1, B2) zodat de planner
+-- deelvelden correct visualiseert voor leeftijden met Veldafmeting < 1.00
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('his.matches') AND name = 'veld_subpositie')
+    ALTER TABLE [his].[matches] ADD [veld_subpositie] NVARCHAR(5) NULL;
+GO

--- a/Database/dbo/Tables/Speeltijden.sql
+++ b/Database/dbo/Tables/Speeltijden.sql
@@ -5,5 +5,5 @@ CREATE TABLE [dbo].[Speeltijden] (
     [WedstrijdHelft]  INT          NOT NULL,
     [WedstrijdRust]   INT          NOT NULL,
     [ClubCode]        NVARCHAR(20)  NOT NULL CONSTRAINT [DF_Speeltijden_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
-    CONSTRAINT [PK_Speeltijden] PRIMARY KEY CLUSTERED ([Leeftijd] ASC)
+    CONSTRAINT [PK_Speeltijden] PRIMARY KEY CLUSTERED ([Leeftijd] ASC, [ClubCode] ASC)
 ) ON [PRIMARY]

--- a/Database/his/Tables/Matches.sql
+++ b/Database/his/Tables/Matches.sql
@@ -33,6 +33,7 @@ CREATE TABLE [his].[matches](
     [scheidsrechters]           NVARCHAR(500)   NULL,
     [scheidsrechter]            NVARCHAR(200)   NULL,
     [veld]                      NVARCHAR(100)   NULL,
+    [veld_subpositie]           NVARCHAR(5)     NULL,   -- ALLSTARS testdata: A, B, A1, A2, B1, B2
     [locatie]                   NVARCHAR(100)   NULL,
     [plaats]                    NVARCHAR(100)   NULL,
     [rijders]                   NVARCHAR(200)   NULL,

--- a/FunctionApp/Admin/AdminTestDataFunction.cs
+++ b/FunctionApp/Admin/AdminTestDataFunction.cs
@@ -54,7 +54,7 @@ public static class AdminTestDataFunction
         }
     }
 
-    // GET /api/beheer/testdata/teams — alle teams ongeacht ClubCode (voor dropdown)
+    // GET /api/beheer/testdata/teams — teams uit avg.Teambegeleiding voor ALLSTARS
     [Function("TestDataTeamsGet")]
     public static async Task<IActionResult> GetTeams(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "beheer/testdata/teams")] HttpRequest req,
@@ -69,10 +69,10 @@ public static class AdminTestDataFunction
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
             using var command = new SqlCommand(@"
-                SELECT DISTINCT [teamnaam]
-                FROM   [his].[teams]
-                WHERE  [ClubCode] != 'ALLSTARS'
-                ORDER  BY [teamnaam]",
+                SELECT DISTINCT [Team]
+                FROM   [avg].[Teambegeleiding]
+                WHERE  [Team] IS NOT NULL AND [ClubCode] = 'ALLSTARS'
+                ORDER  BY [Team]",
                 connection);
             using var reader = await command.ExecuteReaderAsync();
             var teams = new List<string>();
@@ -188,7 +188,8 @@ public static class AdminTestDataFunction
         }
     }
 
-    // DELETE /api/beheer/testdata/wedstrijden — verwijder alle ALLSTARS wedstrijden
+    // DELETE /api/beheer/testdata/wedstrijden?van=YYYY-MM-DD&tot=YYYY-MM-DD
+    // Verwijdert ALLSTARS-wedstrijden voor het opgegeven datumbereik (beide params optioneel).
     [Function("TestDataWedstrijdenDeleteAlle")]
     public static async Task<IActionResult> DeleteAlle(
         [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "beheer/testdata/wedstrijden")] HttpRequest req,
@@ -199,18 +200,25 @@ public static class AdminTestDataFunction
         if (authResult != null) return authResult;
         try
         {
+            var vanStr = req.Query.ContainsKey("van") ? req.Query["van"].ToString() : null;
+            var totStr = req.Query.ContainsKey("tot") ? req.Query["tot"].ToString() : null;
+
+            var sql = "DELETE FROM [his].[matches] WHERE [ClubCode] = 'ALLSTARS'";
+            if (!string.IsNullOrEmpty(vanStr)) sql += " AND [datum] >= @Van";
+            if (!string.IsNullOrEmpty(totStr)) sql += " AND [datum] <= @Tot";
+
             await SystemUtilities.WaitForDatabaseAsync(log);
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
-            using var command = new SqlCommand(@"
-                DELETE FROM [his].[matches] WHERE [ClubCode] = 'ALLSTARS'",
-                connection);
+            using var command = new SqlCommand(sql, connection);
+            if (!string.IsNullOrEmpty(vanStr)) command.Parameters.AddWithValue("@Van", vanStr);
+            if (!string.IsNullOrEmpty(totStr)) command.Parameters.AddWithValue("@Tot", totStr);
             await command.ExecuteNonQueryAsync();
             return new OkObjectResult(new { ok = true });
         }
         catch (Exception ex)
         {
-            log.LogError(ex, "Fout bij verwijderen alle ALLSTARS wedstrijden");
+            log.LogError(ex, "Fout bij verwijderen ALLSTARS wedstrijden");
             return new ObjectResult(new { error = "Verwijderen mislukt" }) { StatusCode = 500 };
         }
     }

--- a/FunctionApp/Admin/AdminTestDataFunction.cs
+++ b/FunctionApp/Admin/AdminTestDataFunction.cs
@@ -27,7 +27,7 @@ public static class AdminTestDataFunction
             await connection.OpenAsync();
             using var command = new SqlCommand(@"
                 SELECT [bk_matches], [datum], [aanvangstijd],
-                       [thuisteam], [uitteam], [veld], [competitiesoort]
+                       [thuisteam], [uitteam], [veld], [competitiesoort], [veld_subpositie]
                 FROM   [his].[matches]
                 WHERE  [ClubCode] = 'ALLSTARS'
                 ORDER  BY [datum], [aanvangstijd], [thuisteam]",
@@ -37,13 +37,14 @@ public static class AdminTestDataFunction
             while (await reader.ReadAsync())
                 list.Add(new
                 {
-                    BkMatches   = reader.GetString(0),
-                    Datum       = reader.IsDBNull(1) ? null : reader.GetString(1),
-                    Aanvangstijd = reader.IsDBNull(2) ? null : reader.GetString(2),
-                    ThuisTeam   = reader.IsDBNull(3) ? null : reader.GetString(3),
-                    UitTeam     = reader.IsDBNull(4) ? null : reader.GetString(4),
-                    VeldNaam    = reader.IsDBNull(5) ? null : reader.GetString(5),
-                    Soort       = reader.IsDBNull(6) ? null : reader.GetString(6),
+                    BkMatches      = reader.GetString(0),
+                    Datum          = reader.IsDBNull(1) ? null : reader.GetString(1),
+                    Aanvangstijd   = reader.IsDBNull(2) ? null : reader.GetString(2),
+                    ThuisTeam      = reader.IsDBNull(3) ? null : reader.GetString(3),
+                    UitTeam        = reader.IsDBNull(4) ? null : reader.GetString(4),
+                    VeldNaam       = reader.IsDBNull(5) ? null : reader.GetString(5),
+                    Soort          = reader.IsDBNull(6) ? null : reader.GetString(6),
+                    VeldSubpositie = reader.IsDBNull(7) ? null : reader.GetString(7),
                 });
             return new OkObjectResult(list);
         }
@@ -118,35 +119,37 @@ public static class AdminTestDataFunction
                 MERGE [his].[matches] AS target
                 USING (SELECT @BkMatches AS bk) AS source ON target.bk_matches = source.bk
                 WHEN MATCHED THEN UPDATE SET
-                    [datum]           = @Datum,
-                    [wedstrijddatum]  = @Wedstrijddatum,
-                    [kaledatum]       = @Kaledatum,
-                    [aanvangstijd]    = @Aanvangstijd,
-                    [thuisteam]       = @ThuisTeam,
-                    [teamnaam]        = @ThuisTeam,
-                    [uitteam]         = @UitTeam,
-                    [veld]            = @VeldNaam,
-                    [competitiesoort] = @Soort,
-                    [mta_modified]    = GETUTCDATE()
+                    [datum]            = @Datum,
+                    [wedstrijddatum]   = @Wedstrijddatum,
+                    [kaledatum]        = @Kaledatum,
+                    [aanvangstijd]     = @Aanvangstijd,
+                    [thuisteam]        = @ThuisTeam,
+                    [teamnaam]         = @ThuisTeam,
+                    [uitteam]          = @UitTeam,
+                    [veld]             = @VeldNaam,
+                    [veld_subpositie]  = @VeldSubpositie,
+                    [competitiesoort]  = @Soort,
+                    [mta_modified]     = GETUTCDATE()
                 WHEN NOT MATCHED THEN INSERT
                     ([bk_matches], [datum], [wedstrijddatum], [kaledatum], [aanvangstijd],
-                     [thuisteam], [teamnaam], [uitteam], [veld], [competitiesoort],
+                     [thuisteam], [teamnaam], [uitteam], [veld], [veld_subpositie], [competitiesoort],
                      [ClubCode], [mta_inserted], [mta_modified])
                 VALUES
                     (@BkMatches, @Datum, @Wedstrijddatum, @Kaledatum, @Aanvangstijd,
-                     @ThuisTeam, @ThuisTeam, @UitTeam, @VeldNaam, @Soort,
+                     @ThuisTeam, @ThuisTeam, @UitTeam, @VeldNaam, @VeldSubpositie, @Soort,
                      'ALLSTARS', GETUTCDATE(), GETUTCDATE());",
                 connection);
 
-            command.Parameters.AddWithValue("@BkMatches",    dto.BkMatches);
-            command.Parameters.AddWithValue("@Datum",        (object?)dto.Datum         ?? DBNull.Value);
-            command.Parameters.AddWithValue("@Wedstrijddatum",(object?)wedstrijddatum   ?? DBNull.Value);
-            command.Parameters.AddWithValue("@Kaledatum",    (object?)kaledatum         ?? DBNull.Value);
-            command.Parameters.AddWithValue("@Aanvangstijd", (object?)dto.Aanvangstijd  ?? DBNull.Value);
-            command.Parameters.AddWithValue("@ThuisTeam",    (object?)dto.ThuisTeam     ?? DBNull.Value);
-            command.Parameters.AddWithValue("@UitTeam",      (object?)dto.UitTeam       ?? DBNull.Value);
-            command.Parameters.AddWithValue("@VeldNaam",     (object?)dto.VeldNaam      ?? DBNull.Value);
-            command.Parameters.AddWithValue("@Soort",        (object?)dto.Soort         ?? DBNull.Value);
+            command.Parameters.AddWithValue("@BkMatches",      dto.BkMatches);
+            command.Parameters.AddWithValue("@Datum",         (object?)dto.Datum          ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Wedstrijddatum",(object?)wedstrijddatum     ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Kaledatum",     (object?)kaledatum          ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Aanvangstijd",  (object?)dto.Aanvangstijd   ?? DBNull.Value);
+            command.Parameters.AddWithValue("@ThuisTeam",     (object?)dto.ThuisTeam      ?? DBNull.Value);
+            command.Parameters.AddWithValue("@UitTeam",       (object?)dto.UitTeam        ?? DBNull.Value);
+            command.Parameters.AddWithValue("@VeldNaam",      (object?)dto.VeldNaam       ?? DBNull.Value);
+            command.Parameters.AddWithValue("@VeldSubpositie",(object?)dto.VeldSubpositie ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Soort",         (object?)dto.Soort          ?? DBNull.Value);
 
             await command.ExecuteNonQueryAsync();
             return new OkObjectResult(new { ok = true });
@@ -225,12 +228,13 @@ public static class AdminTestDataFunction
 
     private sealed class AllstarsWedstrijdInput
     {
-        public string  BkMatches    { get; set; } = "";
-        public string? Datum        { get; set; }
-        public string? Aanvangstijd { get; set; }
-        public string? ThuisTeam    { get; set; }
-        public string? UitTeam      { get; set; }
-        public string? VeldNaam     { get; set; }
-        public string? Soort        { get; set; }
+        public string  BkMatches       { get; set; } = "";
+        public string? Datum           { get; set; }
+        public string? Aanvangstijd    { get; set; }
+        public string? ThuisTeam       { get; set; }
+        public string? UitTeam         { get; set; }
+        public string? VeldNaam        { get; set; }
+        public string? VeldSubpositie  { get; set; }
+        public string? Soort           { get; set; }
     }
 }

--- a/FunctionApp/Admin/AdminTestDataFunction.cs
+++ b/FunctionApp/Admin/AdminTestDataFunction.cs
@@ -1,0 +1,228 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace SportlinkFunction.Admin;
+
+public static class AdminTestDataFunction
+{
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+
+    // GET /api/beheer/testdata/wedstrijden
+    [Function("TestDataWedstrijdenGet")]
+    public static async Task<IActionResult> GetWedstrijden(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "beheer/testdata/wedstrijden")] HttpRequest req,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("TestDataWedstrijdenGet");
+        var authResult = EasyAuthHelper.RequireAdmin(req);
+        if (authResult != null) return authResult;
+        try
+        {
+            await SystemUtilities.WaitForDatabaseAsync(log);
+            using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+            await connection.OpenAsync();
+            using var command = new SqlCommand(@"
+                SELECT [bk_matches], [datum], [aanvangstijd],
+                       [thuisteam], [uitteam], [veld], [competitiesoort]
+                FROM   [his].[matches]
+                WHERE  [ClubCode] = 'ALLSTARS'
+                ORDER  BY [datum], [aanvangstijd], [thuisteam]",
+                connection);
+            using var reader = await command.ExecuteReaderAsync();
+            var list = new List<object>();
+            while (await reader.ReadAsync())
+                list.Add(new
+                {
+                    BkMatches   = reader.GetString(0),
+                    Datum       = reader.IsDBNull(1) ? null : reader.GetString(1),
+                    Aanvangstijd = reader.IsDBNull(2) ? null : reader.GetString(2),
+                    ThuisTeam   = reader.IsDBNull(3) ? null : reader.GetString(3),
+                    UitTeam     = reader.IsDBNull(4) ? null : reader.GetString(4),
+                    VeldNaam    = reader.IsDBNull(5) ? null : reader.GetString(5),
+                    Soort       = reader.IsDBNull(6) ? null : reader.GetString(6),
+                });
+            return new OkObjectResult(list);
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij ophalen ALLSTARS wedstrijden");
+            return new ObjectResult(new { error = "Ophalen mislukt" }) { StatusCode = 500 };
+        }
+    }
+
+    // GET /api/beheer/testdata/teams — alle teams ongeacht ClubCode (voor dropdown)
+    [Function("TestDataTeamsGet")]
+    public static async Task<IActionResult> GetTeams(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "beheer/testdata/teams")] HttpRequest req,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("TestDataTeamsGet");
+        var authResult = EasyAuthHelper.RequireAdmin(req);
+        if (authResult != null) return authResult;
+        try
+        {
+            await SystemUtilities.WaitForDatabaseAsync(log);
+            using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+            await connection.OpenAsync();
+            using var command = new SqlCommand(@"
+                SELECT DISTINCT [teamnaam]
+                FROM   [his].[teams]
+                WHERE  [ClubCode] != 'ALLSTARS'
+                ORDER  BY [teamnaam]",
+                connection);
+            using var reader = await command.ExecuteReaderAsync();
+            var teams = new List<string>();
+            while (await reader.ReadAsync())
+                teams.Add(reader.GetString(0));
+            return new OkObjectResult(teams);
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij ophalen teams voor testdata");
+            return new ObjectResult(new { error = "Ophalen mislukt" }) { StatusCode = 500 };
+        }
+    }
+
+    // POST /api/beheer/testdata/wedstrijden — upsert één wedstrijd
+    [Function("TestDataWedstrijdUpsert")]
+    public static async Task<IActionResult> UpsertWedstrijd(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "beheer/testdata/wedstrijden")] HttpRequest req,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("TestDataWedstrijdUpsert");
+        var authResult = EasyAuthHelper.RequireAdmin(req);
+        if (authResult != null) return authResult;
+        try
+        {
+            var body = await new StreamReader(req.Body).ReadToEndAsync();
+            var dto = JsonSerializer.Deserialize<AllstarsWedstrijdInput>(body, _json);
+            if (dto == null || string.IsNullOrWhiteSpace(dto.BkMatches))
+                return new BadRequestObjectResult(new { error = "BkMatches verplicht" });
+
+            // Afleiden van wedstrijddatum en kaledatum vanuit datum-string ("2026-05-30")
+            var wedstrijddatum = (!string.IsNullOrWhiteSpace(dto.Datum) && !string.IsNullOrWhiteSpace(dto.Aanvangstijd))
+                ? $"{dto.Datum}T{dto.Aanvangstijd}:00"
+                : dto.Datum;
+            var kaledatum = !string.IsNullOrWhiteSpace(dto.Datum)
+                ? $"{dto.Datum} 00:00:00.00"
+                : null;
+
+            await SystemUtilities.WaitForDatabaseAsync(log);
+            using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+            await connection.OpenAsync();
+            using var command = new SqlCommand(@"
+                MERGE [his].[matches] AS target
+                USING (SELECT @BkMatches AS bk) AS source ON target.bk_matches = source.bk
+                WHEN MATCHED THEN UPDATE SET
+                    [datum]           = @Datum,
+                    [wedstrijddatum]  = @Wedstrijddatum,
+                    [kaledatum]       = @Kaledatum,
+                    [aanvangstijd]    = @Aanvangstijd,
+                    [thuisteam]       = @ThuisTeam,
+                    [teamnaam]        = @ThuisTeam,
+                    [uitteam]         = @UitTeam,
+                    [veld]            = @VeldNaam,
+                    [competitiesoort] = @Soort,
+                    [mta_modified]    = GETUTCDATE()
+                WHEN NOT MATCHED THEN INSERT
+                    ([bk_matches], [datum], [wedstrijddatum], [kaledatum], [aanvangstijd],
+                     [thuisteam], [teamnaam], [uitteam], [veld], [competitiesoort],
+                     [ClubCode], [mta_inserted], [mta_modified])
+                VALUES
+                    (@BkMatches, @Datum, @Wedstrijddatum, @Kaledatum, @Aanvangstijd,
+                     @ThuisTeam, @ThuisTeam, @UitTeam, @VeldNaam, @Soort,
+                     'ALLSTARS', GETUTCDATE(), GETUTCDATE());",
+                connection);
+
+            command.Parameters.AddWithValue("@BkMatches",    dto.BkMatches);
+            command.Parameters.AddWithValue("@Datum",        (object?)dto.Datum         ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Wedstrijddatum",(object?)wedstrijddatum   ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Kaledatum",    (object?)kaledatum         ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Aanvangstijd", (object?)dto.Aanvangstijd  ?? DBNull.Value);
+            command.Parameters.AddWithValue("@ThuisTeam",    (object?)dto.ThuisTeam     ?? DBNull.Value);
+            command.Parameters.AddWithValue("@UitTeam",      (object?)dto.UitTeam       ?? DBNull.Value);
+            command.Parameters.AddWithValue("@VeldNaam",     (object?)dto.VeldNaam      ?? DBNull.Value);
+            command.Parameters.AddWithValue("@Soort",        (object?)dto.Soort         ?? DBNull.Value);
+
+            await command.ExecuteNonQueryAsync();
+            return new OkObjectResult(new { ok = true });
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij upsert ALLSTARS wedstrijd");
+            return new ObjectResult(new { error = "Opslaan mislukt" }) { StatusCode = 500 };
+        }
+    }
+
+    // DELETE /api/beheer/testdata/wedstrijden/{bk} — verwijder één wedstrijd
+    [Function("TestDataWedstrijdDeleteEen")]
+    public static async Task<IActionResult> DeleteEen(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "beheer/testdata/wedstrijden/{bk}")] HttpRequest req,
+        string bk,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("TestDataWedstrijdDeleteEen");
+        var authResult = EasyAuthHelper.RequireAdmin(req);
+        if (authResult != null) return authResult;
+        try
+        {
+            await SystemUtilities.WaitForDatabaseAsync(log);
+            using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+            await connection.OpenAsync();
+            using var command = new SqlCommand(@"
+                DELETE FROM [his].[matches]
+                WHERE  [bk_matches] = @Bk AND [ClubCode] = 'ALLSTARS'",
+                connection);
+            command.Parameters.AddWithValue("@Bk", bk);
+            await command.ExecuteNonQueryAsync();
+            return new OkObjectResult(new { ok = true });
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij verwijderen ALLSTARS wedstrijd {Bk}", bk);
+            return new ObjectResult(new { error = "Verwijderen mislukt" }) { StatusCode = 500 };
+        }
+    }
+
+    // DELETE /api/beheer/testdata/wedstrijden — verwijder alle ALLSTARS wedstrijden
+    [Function("TestDataWedstrijdenDeleteAlle")]
+    public static async Task<IActionResult> DeleteAlle(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "beheer/testdata/wedstrijden")] HttpRequest req,
+        FunctionContext context)
+    {
+        var log = context.GetLogger("TestDataWedstrijdenDeleteAlle");
+        var authResult = EasyAuthHelper.RequireAdmin(req);
+        if (authResult != null) return authResult;
+        try
+        {
+            await SystemUtilities.WaitForDatabaseAsync(log);
+            using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+            await connection.OpenAsync();
+            using var command = new SqlCommand(@"
+                DELETE FROM [his].[matches] WHERE [ClubCode] = 'ALLSTARS'",
+                connection);
+            await command.ExecuteNonQueryAsync();
+            return new OkObjectResult(new { ok = true });
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Fout bij verwijderen alle ALLSTARS wedstrijden");
+            return new ObjectResult(new { error = "Verwijderen mislukt" }) { StatusCode = 500 };
+        }
+    }
+
+    private sealed class AllstarsWedstrijdInput
+    {
+        public string  BkMatches    { get; set; } = "";
+        public string? Datum        { get; set; }
+        public string? Aanvangstijd { get; set; }
+        public string? ThuisTeam    { get; set; }
+        public string? UitTeam      { get; set; }
+        public string? VeldNaam     { get; set; }
+        public string? Soort        { get; set; }
+    }
+}

--- a/FunctionApp/Admin/AdminThemeFunction.cs
+++ b/FunctionApp/Admin/AdminThemeFunction.cs
@@ -41,10 +41,10 @@ public static class AdminThemeFunction
         var log = context.GetLogger("AdminThemeGet");
         var authResult = EasyAuthHelper.RequireAdmin(req);
         if (authResult != null) return authResult;
-        var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
         try
         {
             await SystemUtilities.WaitForDatabaseAsync(log);
+            var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
             using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
             await connection.OpenAsync();
             using var command = new SqlCommand(@"

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -10,13 +10,14 @@ namespace SportlinkFunction.Planner
     {
         private static string ConnectionString => SystemUtilities.DatabaseConfig.ConnectionString;
 
-        public static async Task<Speeltijd?> GetSpeeltijdAsync(string leeftijdsCategorie)
+        public static async Task<Speeltijd?> GetSpeeltijdAsync(string leeftijdsCategorie, string clubCode = "VRC")
         {
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
             using var cmd = new SqlCommand(
-                "SELECT [Leeftijd], [Veldafmeting], [WedstrijdTotaal] FROM [dbo].[Speeltijden] WHERE [Leeftijd] = @cat", conn);
+                "SELECT [Leeftijd], [Veldafmeting], [WedstrijdTotaal] FROM [dbo].[Speeltijden] WHERE [Leeftijd] = @cat AND [ClubCode] = @clubCode", conn);
             cmd.Parameters.AddWithValue("@cat", leeftijdsCategorie);
+            cmd.Parameters.AddWithValue("@clubCode", clubCode);
             using var reader = await cmd.ExecuteReaderAsync();
             if (await reader.ReadAsync())
             {
@@ -48,7 +49,7 @@ namespace SportlinkFunction.Planner
                     'Competitie' AS Bron
                 FROM [his].[matches] m
                 LEFT JOIN [his].[teams] t ON t.[teamnaam] = m.[teamnaam]
-                LEFT JOIN [dbo].[Speeltijden] s ON s.[Leeftijd] = REPLACE(REPLACE(REPLACE(t.[leeftijdscategorie], 'Onder ', 'JO'), 'Meisjes ', 'MO'), 'Vrouwen', 'VR')
+                LEFT JOIN [dbo].[Speeltijden] s ON s.[Leeftijd] = REPLACE(REPLACE(REPLACE(t.[leeftijdscategorie], 'Onder ', 'JO'), 'Meisjes ', 'MO'), 'Vrouwen', 'VR') AND s.[ClubCode] = m.[ClubCode]
                 LEFT JOIN [dbo].[Velden] v ON RTRIM(LEFT(m.[veld], 6)) = v.[VeldNaam]
                 WHERE CAST(m.[kaledatum] AS DATE) = @date
                   AND m.[status] <> 'Afgelast'
@@ -218,13 +219,14 @@ namespace SportlinkFunction.Planner
         }
 
         // Lookup: Leeftijd → Speeltijd. Gebruikt door SportlinkApiClient.
-        public static async Task<Dictionary<string, Speeltijd>> GetSpeeltijdenLookupAsync()
+        public static async Task<Dictionary<string, Speeltijd>> GetSpeeltijdenLookupAsync(string clubCode = "VRC")
         {
             var result = new Dictionary<string, Speeltijd>(StringComparer.OrdinalIgnoreCase);
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
             using var cmd = new SqlCommand(
-                "SELECT [Leeftijd], [Veldafmeting], [WedstrijdTotaal] FROM [dbo].[Speeltijden]", conn);
+                "SELECT [Leeftijd], [Veldafmeting], [WedstrijdTotaal] FROM [dbo].[Speeltijden] WHERE [ClubCode] = @clubCode", conn);
+            cmd.Parameters.AddWithValue("@clubCode", clubCode);
             using var reader = await cmd.ExecuteReaderAsync();
             while (await reader.ReadAsync())
                 result[reader.GetString(0)] = new Speeltijd
@@ -409,7 +411,7 @@ namespace SportlinkFunction.Planner
                     COALESCE(s.[Veldafmeting], 1.00) AS Veldafmeting
                 FROM [his].[matches] m
                 LEFT JOIN [his].[teams] t ON t.[teamnaam] = m.[teamnaam] AND t.[leeftijdscategorie] IS NOT NULL AND t.[leeftijdscategorie] <> ''
-                LEFT JOIN [dbo].[Speeltijden] s ON s.[Leeftijd] = REPLACE(REPLACE(REPLACE(t.[leeftijdscategorie], 'Onder ', 'JO'), 'Meisjes ', 'MO'), 'Vrouwen', 'VR')
+                LEFT JOIN [dbo].[Speeltijden] s ON s.[Leeftijd] = REPLACE(REPLACE(REPLACE(t.[leeftijdscategorie], 'Onder ', 'JO'), 'Meisjes ', 'MO'), 'Vrouwen', 'VR') AND s.[ClubCode] = m.[ClubCode]
                 WHERE CAST(m.[kaledatum] AS DATE) = @date
                   AND m.[accommodatie] LIKE @accommodatiePattern
                   AND m.[status] <> 'Afgelast'
@@ -467,7 +469,7 @@ namespace SportlinkFunction.Planner
                     COALESCE(s.[Veldafmeting], 1.00)
                 FROM [his].[matches] m
                 LEFT JOIN [his].[teams] t ON t.[teamnaam] = m.[teamnaam] AND t.[leeftijdscategorie] IS NOT NULL AND t.[leeftijdscategorie] <> ''
-                LEFT JOIN [dbo].[Speeltijden] s ON s.[Leeftijd] = REPLACE(REPLACE(REPLACE(t.[leeftijdscategorie], 'Onder ', 'JO'), 'Meisjes ', 'MO'), 'Vrouwen', 'VR')
+                LEFT JOIN [dbo].[Speeltijden] s ON s.[Leeftijd] = REPLACE(REPLACE(REPLACE(t.[leeftijdscategorie], 'Onder ', 'JO'), 'Meisjes ', 'MO'), 'Vrouwen', 'VR') AND s.[ClubCode] = m.[ClubCode]
                 WHERE m.[accommodatie] LIKE @accommodatiePattern
                   AND m.[status] <> 'Afgelast'
                   AND m.[wedstrijd] LIKE @tegPattern
@@ -568,7 +570,7 @@ namespace SportlinkFunction.Planner
                     COALESCE(s.[Veldafmeting], 1.00) AS Veldafmeting
                 FROM [his].[matches] m
                 LEFT JOIN [his].[teams] t ON t.[teamnaam] = m.[teamnaam] AND t.[leeftijdscategorie] IS NOT NULL AND t.[leeftijdscategorie] <> ''
-                LEFT JOIN [dbo].[Speeltijden] s ON s.[Leeftijd] = REPLACE(REPLACE(REPLACE(t.[leeftijdscategorie], 'Onder ', 'JO'), 'Meisjes ', 'MO'), 'Vrouwen', 'VR')
+                LEFT JOIN [dbo].[Speeltijden] s ON s.[Leeftijd] = REPLACE(REPLACE(REPLACE(t.[leeftijdscategorie], 'Onder ', 'JO'), 'Meisjes ', 'MO'), 'Vrouwen', 'VR') AND s.[ClubCode] = m.[ClubCode]
                 WHERE CAST(m.[wedstrijdcode] AS BIGINT) = @code
                   AND m.[accommodatie] LIKE @accommodatiePattern
             ", conn);
@@ -729,6 +731,7 @@ namespace SportlinkFunction.Planner
                 CROSS APPLY (SELECT MIN([VeldNummer]) AS DefaultVeld FROM [dbo].[Velden] WHERE [VeldNummer] >= 100) d
                 LEFT JOIN [dbo].[Speeltijden] s
                     ON s.[Leeftijd] = LEFT(m.[teamnaam], CHARINDEX('-', m.[teamnaam] + '-') - 1)
+                   AND s.[ClubCode] = m.[ClubCode]
                 WHERE CAST(m.[kaledatum] AS DATE) = @date
                   AND m.[ClubCode] = 'ALLSTARS'
                   AND m.[aanvangstijd] IS NOT NULL

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -724,7 +724,8 @@ namespace SportlinkFunction.Planner
                     COALESCE(s.[Veldafmeting], 1.00)                                   AS VeldDeelGebruik,
                     m.[teamnaam]                                                        AS TeamNaam,
                     COALESCE(m.[thuisteam], '') + ' - ' + COALESCE(m.[uitteam], '')    AS Wedstrijd,
-                    m.[competitiesoort]                                                 AS LeeftijdsCategorie
+                    m.[competitiesoort]                                                 AS LeeftijdsCategorie,
+                    m.[veld_subpositie]                                                 AS VeldSubpositie
                 FROM [his].[matches] m
                 LEFT JOIN [dbo].[Velden] v
                     ON LTRIM(RTRIM(ISNULL(m.[veld], ''))) = v.[VeldNaam]
@@ -771,7 +772,7 @@ namespace SportlinkFunction.Planner
                     VeldDeelGebruik   = reader.GetDecimal(4),
                     TeamNaam          = reader.IsDBNull(5) ? null : reader.GetString(5),
                     Wedstrijd         = reader.GetString(6),
-                    VeldSubpositie    = null,
+                    VeldSubpositie    = reader.IsDBNull(8) ? null : reader.GetString(8),
                     Bron              = "ALLSTARS"
                 });
             }

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -704,20 +704,20 @@ namespace SportlinkFunction.Planner
                     CAST(m.[kaledatum] AS DATE)                                        AS Datum,
                     CAST(m.[aanvangstijd] AS TIME)                                     AS AanvangsTijd,
                     ISNULL(s.[WedstrijdTotaal], 90)                                    AS DuurMinuten,
-                    v.[VeldNummer],
+                    ISNULL(v.[VeldNummer], d.[DefaultVeld])                            AS VeldNummer,
                     COALESCE(s.[Veldafmeting], 1.00)                                   AS VeldDeelGebruik,
                     m.[teamnaam]                                                        AS TeamNaam,
                     COALESCE(m.[thuisteam], '') + ' - ' + COALESCE(m.[uitteam], '')    AS Wedstrijd,
                     m.[competitiesoort]                                                 AS LeeftijdsCategorie
                 FROM [his].[matches] m
                 LEFT JOIN [dbo].[Velden] v
-                    ON RTRIM(LEFT(m.[veld], 6)) = v.[VeldNaam]
+                    ON LTRIM(RTRIM(ISNULL(m.[veld], ''))) = v.[VeldNaam]
+                CROSS APPLY (SELECT MIN([VeldNummer]) AS DefaultVeld FROM [dbo].[Velden]) d
                 LEFT JOIN [dbo].[Speeltijden] s
                     ON s.[Leeftijd] = LEFT(m.[teamnaam], CHARINDEX('-', m.[teamnaam] + '-') - 1)
                 WHERE CAST(m.[kaledatum] AS DATE) = @date
                   AND m.[ClubCode] = 'ALLSTARS'
                   AND m.[aanvangstijd] IS NOT NULL
-                  AND v.[VeldNummer] IS NOT NULL
             ", conn);
             cmd.Parameters.AddWithValue("@date", date.ToDateTime(TimeOnly.MinValue));
 

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -729,8 +729,27 @@ namespace SportlinkFunction.Planner
                 LEFT JOIN [dbo].[Velden] v
                     ON LTRIM(RTRIM(ISNULL(m.[veld], ''))) = v.[VeldNaam]
                 CROSS APPLY (SELECT MIN([VeldNummer]) AS DefaultVeld FROM [dbo].[Velden] WHERE [VeldNummer] >= 100) d
+                CROSS APPLY (
+                    SELECT first_space,
+                           CHARINDEX(' ', m.[teamnaam], first_space + 1) AS second_space
+                    FROM (VALUES(CHARINDEX(' ', m.[teamnaam]))) x(first_space)
+                ) pos
+                CROSS APPLY (
+                    SELECT SUBSTRING(m.[teamnaam], pos.first_space + 1,
+                                     CASE WHEN pos.second_space > 0
+                                          THEN pos.second_space - pos.first_space - 1
+                                          ELSE LEN(m.[teamnaam]) - pos.first_space END) AS raw_cat
+                ) cat
+                CROSS APPLY (
+                    SELECT CASE cat.raw_cat
+                               WHEN 'Heren'   THEN '1-99'
+                               WHEN 'Dames'   THEN 'VR'
+                               WHEN 'Vrouwen' THEN 'VR'
+                               ELSE cat.raw_cat
+                           END AS Leeftijdscode
+                ) leeftijd
                 LEFT JOIN [dbo].[Speeltijden] s
-                    ON s.[Leeftijd] = LEFT(m.[teamnaam], CHARINDEX('-', m.[teamnaam] + '-') - 1)
+                    ON s.[Leeftijd] = leeftijd.Leeftijdscode
                    AND s.[ClubCode] = m.[ClubCode]
                 WHERE CAST(m.[kaledatum] AS DATE) = @date
                   AND m.[ClubCode] = 'ALLSTARS'

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -693,6 +693,55 @@ namespace SportlinkFunction.Planner
             return null;
         }
 
+        // ALLSTARS-modus: veldbezetting uit his.matches WHERE ClubCode='ALLSTARS' (test data)
+        public static async Task<List<BestaandeWedstrijd>> GetAllstarsOccupationsAsync(DateOnly date)
+        {
+            var results = new List<BestaandeWedstrijd>();
+            using var conn = new SqlConnection(ConnectionString);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(@"
+                SELECT
+                    CAST(m.[kaledatum] AS DATE)                                        AS Datum,
+                    CAST(m.[aanvangstijd] AS TIME)                                     AS AanvangsTijd,
+                    ISNULL(s.[WedstrijdTotaal], 90)                                    AS DuurMinuten,
+                    v.[VeldNummer],
+                    COALESCE(s.[Veldafmeting], 1.00)                                   AS VeldDeelGebruik,
+                    m.[teamnaam]                                                        AS TeamNaam,
+                    COALESCE(m.[thuisteam], '') + ' - ' + COALESCE(m.[uitteam], '')    AS Wedstrijd,
+                    m.[competitiesoort]                                                 AS LeeftijdsCategorie
+                FROM [his].[matches] m
+                LEFT JOIN [dbo].[Velden] v
+                    ON RTRIM(LEFT(m.[veld], 6)) = v.[VeldNaam]
+                LEFT JOIN [dbo].[Speeltijden] s
+                    ON s.[Leeftijd] = LEFT(m.[teamnaam], CHARINDEX('-', m.[teamnaam] + '-') - 1)
+                WHERE CAST(m.[kaledatum] AS DATE) = @date
+                  AND m.[ClubCode] = 'ALLSTARS'
+                  AND m.[aanvangstijd] IS NOT NULL
+                  AND v.[VeldNummer] IS NOT NULL
+            ", conn);
+            cmd.Parameters.AddWithValue("@date", date.ToDateTime(TimeOnly.MinValue));
+
+            using var reader = await cmd.ExecuteReaderAsync();
+            while (await reader.ReadAsync())
+            {
+                var aanvangsTijd = reader.GetTimeSpan(1);
+                var duur = reader.GetInt32(2);
+                results.Add(new BestaandeWedstrijd
+                {
+                    Datum             = DateOnly.FromDateTime(reader.GetDateTime(0)),
+                    AanvangsTijd      = TimeOnly.FromTimeSpan(aanvangsTijd),
+                    EindTijd          = TimeOnly.FromTimeSpan(aanvangsTijd).AddMinutes(duur),
+                    VeldNummer        = reader.GetInt32(3),
+                    VeldDeelGebruik   = reader.GetDecimal(4),
+                    TeamNaam          = reader.IsDBNull(5) ? null : reader.GetString(5),
+                    Wedstrijd         = reader.GetString(6),
+                    VeldSubpositie    = null,
+                    Bron              = "ALLSTARS"
+                });
+            }
+            return results;
+        }
+
         // ── Team-schedule (#70) ──
 
         public static async Task<bool> TeamExistsAsync(string team)

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -96,8 +96,21 @@ namespace SportlinkFunction.Planner
             return results;
         }
 
-        public static async Task<List<VeldBeschikbaarheidInfo>> GetAvailableFieldsAsync(DateOnly date)
+        public static async Task<List<VeldBeschikbaarheidInfo>> GetAvailableFieldsAsync(DateOnly date, bool allstarsOnly = false)
         {
+            if (allstarsOnly)
+            {
+                // ALLSTARS testmodus: synthetische beschikbaarheid 08:00-22:00 voor alle ALLSTARS velden
+                var allstarsVelden = await GetVeldenAsync(allstarsOnly: true);
+                return allstarsVelden.Select(v => new VeldBeschikbaarheidInfo
+                {
+                    VeldNummer = v.VeldNummer,
+                    BeschikbaarVanaf = new TimeOnly(8, 0),
+                    BeschikbaarTot = new TimeOnly(22, 0),
+                    GebruikZonsondergang = false
+                }).ToList();
+            }
+
             var results = new List<VeldBeschikbaarheidInfo>();
             // DayOfWeek: .NET Maandag=1 komt overeen met onze DB-conventie (1=Maandag...7=Zondag)
             int dagVanWeek = ((int)date.DayOfWeek == 0) ? 7 : (int)date.DayOfWeek;
@@ -108,7 +121,7 @@ namespace SportlinkFunction.Planner
                 SELECT vb.[VeldNummer], vb.[BeschikbaarVanaf], vb.[BeschikbaarTot], vb.[GebruikZonsondergang]
                 FROM [dbo].[VeldBeschikbaarheid] vb
                 INNER JOIN [dbo].[Velden] v ON v.[VeldNummer] = vb.[VeldNummer]
-                WHERE v.[Actief] = 1 AND vb.[DagVanWeek] = @dag
+                WHERE v.[Actief] = 1 AND vb.[DagVanWeek] = @dag AND v.[VeldNummer] < 100
                 ORDER BY vb.[VeldNummer]
             ", conn);
             cmd.Parameters.AddWithValue("@dag", dagVanWeek);
@@ -127,13 +140,14 @@ namespace SportlinkFunction.Planner
             return results;
         }
 
-        public static async Task<List<VeldInfo>> GetVeldenAsync()
+        public static async Task<List<VeldInfo>> GetVeldenAsync(bool allstarsOnly = false)
         {
             var results = new List<VeldInfo>();
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
+            string veldFilter = allstarsOnly ? "[VeldNummer] >= 100" : "[VeldNummer] < 100";
             using var cmd = new SqlCommand(
-                "SELECT [VeldNummer], [VeldNaam], ISNULL([VeldType], 'kunstgras') AS [VeldType], [HeeftKunstlicht] FROM [dbo].[Velden] WHERE [Actief] = 1 ORDER BY [VeldNummer]", conn);
+                $"SELECT [VeldNummer], [VeldNaam], ISNULL([VeldType], 'kunstgras') AS [VeldType], [HeeftKunstlicht] FROM [dbo].[Velden] WHERE [Actief] = 1 AND {veldFilter} ORDER BY [VeldNummer]", conn);
             using var reader = await cmd.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
@@ -712,7 +726,7 @@ namespace SportlinkFunction.Planner
                 FROM [his].[matches] m
                 LEFT JOIN [dbo].[Velden] v
                     ON LTRIM(RTRIM(ISNULL(m.[veld], ''))) = v.[VeldNaam]
-                CROSS APPLY (SELECT MIN([VeldNummer]) AS DefaultVeld FROM [dbo].[Velden]) d
+                CROSS APPLY (SELECT MIN([VeldNummer]) AS DefaultVeld FROM [dbo].[Velden] WHERE [VeldNummer] >= 100) d
                 LEFT JOIN [dbo].[Speeltijden] s
                     ON s.[Leeftijd] = LEFT(m.[teamnaam], CHARINDEX('-', m.[teamnaam] + '-') - 1)
                 WHERE CAST(m.[kaledatum] AS DATE) = @date

--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -173,9 +173,10 @@ namespace SportlinkFunction.Planner
                 if (request == null || string.IsNullOrEmpty(request.Datum))
                     return new BadRequestObjectResult(new { error = "Request body met 'datum' is verplicht." });
 
-                log.LogInformation("Optimaliseer: datum={Datum}, doel={Doel}", request.Datum, request.Doel);
+                var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
+                log.LogInformation("Optimaliseer: datum={Datum}, doel={Doel}, club={Club}", request.Datum, request.Doel, clubCode);
 
-                var response = await PlannerService.OptimaliseerAsync(request, log);
+                var response = await PlannerService.OptimaliseerAsync(request, log, clubCode);
 
                 var format = req.Query.ContainsKey("format") ? req.Query["format"].ToString() : "";
 
@@ -192,10 +193,14 @@ namespace SportlinkFunction.Planner
 
                 if (format == "email")
                 {
+                    var parsedDate = DateOnly.Parse(request.Datum);
                     var browserUrl = $"{req.Scheme}://{req.Host}/api/planner/optimaliseer?format=html";
+                    var emailOccupations = string.Equals(clubCode, "ALLSTARS", StringComparison.OrdinalIgnoreCase)
+                        ? await PlannerDataAccess.GetAllstarsOccupationsAsync(parsedDate)
+                        : await SportlinkApiClient.GetFieldOccupationsWithApiAsync(parsedDate, log);
                     var emailHtml = PlannerHtmlGenerator.GenereerEmailHtml(
-                        DateOnly.Parse(request.Datum),
-                        await SportlinkApiClient.GetFieldOccupationsWithApiAsync(DateOnly.Parse(request.Datum), log),
+                        parsedDate,
+                        emailOccupations,
                         response.Suggesties,
                         await PlannerDataAccess.GetVeldenAsync(),
                         request.Doel ?? "veld5-ontlasten",

--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -195,14 +195,15 @@ namespace SportlinkFunction.Planner
                 {
                     var parsedDate = DateOnly.Parse(request.Datum);
                     var browserUrl = $"{req.Scheme}://{req.Host}/api/planner/optimaliseer?format=html";
-                    var emailOccupations = string.Equals(clubCode, "ALLSTARS", StringComparison.OrdinalIgnoreCase)
+                    bool isAllstarsEmail = string.Equals(clubCode, "ALLSTARS", StringComparison.OrdinalIgnoreCase);
+                    var emailOccupations = isAllstarsEmail
                         ? await PlannerDataAccess.GetAllstarsOccupationsAsync(parsedDate)
                         : await SportlinkApiClient.GetFieldOccupationsWithApiAsync(parsedDate, log);
                     var emailHtml = PlannerHtmlGenerator.GenereerEmailHtml(
                         parsedDate,
                         emailOccupations,
                         response.Suggesties,
-                        await PlannerDataAccess.GetVeldenAsync(),
+                        await PlannerDataAccess.GetVeldenAsync(allstarsOnly: isAllstarsEmail),
                         request.Doel ?? "veld5-ontlasten",
                         browserUrl);
                     return new ContentResult { Content = emailHtml, ContentType = "text/html", StatusCode = 200 };

--- a/FunctionApp/Planner/PlannerHtmlGenerator.cs
+++ b/FunctionApp/Planner/PlannerHtmlGenerator.cs
@@ -41,7 +41,7 @@ namespace SportlinkFunction.Planner
         {
             var sb = new StringBuilder();
             var nl = new System.Globalization.CultureInfo("nl-NL");
-            var actieveVelden = velden.Where(v => v.VeldNummer <= 5).OrderBy(v => v.VeldNummer).ToList();
+            var actieveVelden = velden.OrderBy(v => v.VeldNummer).ToList();
 
             // Dedup wedstrijden
             var wedstrijden = alleWedstrijden
@@ -140,7 +140,9 @@ namespace SportlinkFunction.Planner
             // Samenvatting
             var plannerNaam = SystemUtilities.AppSettings.GetSetting("plannerAfzenderNaam")
                 ?? throw new InvalidOperationException("Vereiste instelling 'plannerAfzenderNaam' ontbreekt in dbo.AppSettings");
-            sb.AppendLine($"<p style='margin:10px 0;color:{TXT_DIM};font-size:11px;'>Suggesties: {suggesties.Count} | Van veld 5 verplaatst: {suggesties.Count(s => s.HuidigVeldNummer == 5)} | Gegenereerd door {plannerNaam}</p>");
+            var grasveldNrsHtml = velden.Where(v => v.VeldType == "gras").Select(v => v.VeldNummer).ToHashSet();
+            int aantalVanGrasveld = suggesties.Count(s => grasveldNrsHtml.Count == 0 ? s.HuidigVeldNummer == 5 : grasveldNrsHtml.Contains(s.HuidigVeldNummer));
+            sb.AppendLine($"<p style='margin:10px 0;color:{TXT_DIM};font-size:11px;'>Suggesties: {suggesties.Count} | Van grasveld verplaatst: {aantalVanGrasveld} | Gegenereerd door {plannerNaam}</p>");
 
             // JavaScript: klik-interactie
             sb.AppendLine("<script>");

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -256,8 +256,9 @@ namespace SportlinkFunction.Planner
         {
             var endTime = preferredTime.AddMinutes(duurMinuten);
 
-            // Elk veld proberen in voorkeursvolgorde (veld 1-4 voor veld 5)
-            foreach (var field in availableFields.OrderBy(f => f.VeldNummer == 5 ? 1 : 0))
+            // Kunstgrasvelden prefereren boven grasvelden (grasveld als laatste keuze)
+            var grasveldNrsSlot = new HashSet<int>(velden.Where(v => v.VeldType == "gras").Select(v => v.VeldNummer));
+            foreach (var field in availableFields.OrderBy(f => grasveldNrsSlot.Contains(f.VeldNummer) ? 1 : 0))
             {
                 // Controleer binnen beschikbaarheidsvenster
                 if (preferredTime < field.BeschikbaarVanaf || endTime > field.BeschikbaarTot)
@@ -377,8 +378,9 @@ namespace SportlinkFunction.Planner
                 }
             }
 
-            // Sorteren: veld 1-4 prefereren boven veld 5
-            return candidates.OrderBy(c => c.VeldNummer == 5 ? 1 : 0)
+            // Sorteren: kunstgrasvelden prefereren boven grasvelden
+            var grasveldNrsAll = new HashSet<int>(velden.Where(v => v.VeldType == "gras").Select(v => v.VeldNummer));
+            return candidates.OrderBy(c => grasveldNrsAll.Contains(c.VeldNummer) ? 1 : 0)
                              .ThenBy(c => c.AanvangsTijd.ToTimeSpan().TotalMinutes)
                              .ToList();
         }
@@ -738,7 +740,7 @@ namespace SportlinkFunction.Planner
         // ── Optimalisatie logica ──
 
         public static async Task<OptimaliseerResponse> OptimaliseerAsync(
-            OptimaliseerRequest request, ILogger log)
+            OptimaliseerRequest request, ILogger log, string clubCode = "")
         {
             var nl = new System.Globalization.CultureInfo("nl-NL");
             var response = new OptimaliseerResponse { Datum = request.Datum };
@@ -749,8 +751,10 @@ namespace SportlinkFunction.Planner
                 return response;
             }
 
-            // Data laden (real-time API of DB als fallback)
-            var occupations = await SportlinkApiClient.GetFieldOccupationsWithApiAsync(date, log);
+            // Data laden — voor ALLSTARS test data direct uit DB, anders real-time API of DB fallback
+            var occupations = string.Equals(clubCode, "ALLSTARS", StringComparison.OrdinalIgnoreCase)
+                ? await PlannerDataAccess.GetAllstarsOccupationsAsync(date)
+                : await SportlinkApiClient.GetFieldOccupationsWithApiAsync(date, log);
             var velden = await PlannerDataAccess.GetVeldenAsync();
             var availableFields = await PlannerDataAccess.GetAvailableFieldsAsync(date);
 
@@ -796,28 +800,33 @@ namespace SportlinkFunction.Planner
             var capaciteit = BerekenCapaciteit(bezettingen, availableFields);
             response.CapaciteitOverzicht = capaciteit;
 
+            // Grasveld-nummers bepalen via VeldType (vervangt hardcoded veldNummer==5 logica).
+            // Fallback naar {5} als geen grasvelden geconfigureerd zijn (achterwaartse compatibiliteit).
+            var grasveldNrs = new HashSet<int>(velden.Where(v => v.VeldType == "gras").Select(v => v.VeldNummer));
+            if (grasveldNrs.Count == 0) grasveldNrs.Add(5);
+
             // Bepaal welke optimalisaties zinvol zijn voor deze specifieke dag en het opgegeven doel.
             //
-            // veld5-ontlasten: zinvol als veld 1-4 beschikbaar zijn (zaterdag) én er wedstrijden op
-            //   veld 5 staan. Op doordeweekse dagen zijn veld 1-4 in gebruik voor training en zijn er
-            //   geen alternatieve velden — veld 5 is dan per definitie de juiste plek.
+            // grasveld-ontlasten: zinvol als er kunstgrasvelden beschikbaar zijn (zaterdag) én er
+            //   wedstrijden op grasveld staan. Op doordeweekse dagen zijn kunstgrasvelden in gebruik
+            //   voor training en zijn er geen alternatieve velden.
             //
             // strakker-plannen: zinvol als de gebruiker een gewenste eindtijd heeft opgegeven of
-            //   het doel expliciet op 'strakker-plannen' gezet heeft. Zonder die grenswaarde weet
-            //   de planner niet wat 'beter' is en genereert hij onnodig suggesties.
+            //   het doel expliciet op 'strakker-plannen' gezet heeft.
             var doel = (request.Doel ?? "").ToLowerInvariant().Trim();
-            bool alleenVeld5Beschikbaar = availableFields.Count > 0 && !availableFields.Any(f => f.VeldNummer <= 4);
+            bool alleenGrasveldBeschikbaar = availableFields.Count > 0 && !availableFields.Any(f => !grasveldNrs.Contains(f.VeldNummer));
+            int aantalOpGrasveld = bezettingen.Count(b => grasveldNrs.Contains(b.VeldNummer));
             bool gewensteEindtijdOpgegeven = !string.IsNullOrEmpty(request.GewensteEindtijd);
-            bool veld5OntlastenZinvol = !alleenVeld5Beschikbaar && capaciteit.AantalWedstrijdenOpVeld5 > 0;
+            bool grasveldOntlastenZinvol = !alleenGrasveldBeschikbaar && aantalOpGrasveld > 0;
             bool strakkerPlannenZinvol = gewensteEindtijdOpgegeven || doel == "strakker-plannen";
 
-            // Check 1: laag bezettingspercentage én geen veld 5 gebruik (bestaande check)
-            if (capaciteit.AantalWedstrijdenOpVeld5 == 0 && capaciteit.BezettingsPercentage < MaxBezettingsPercentageVoorOverslaan)
+            // Check 1: laag bezettingspercentage én geen grasveld gebruik
+            if (aantalOpGrasveld == 0 && capaciteit.BezettingsPercentage < MaxBezettingsPercentageVoorOverslaan)
             {
                 response.VoldoendeRuimte = true;
                 response.VoldoendeRuimteMelding =
                     $"Voldoende ruimte op {date.ToString("dddd d MMMM", nl)}: " +
-                    $"geen wedstrijden op veld 5, {capaciteit.BezettingsPercentage:F0}% bezet " +
+                    $"geen wedstrijden op grasveld, {capaciteit.BezettingsPercentage:F0}% bezet " +
                     $"({capaciteit.AantalLegeVelden} veld(en) ongebruikt). Geen optimalisatie nodig.";
                 response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(
                     date, bezettingen, new List<OptimalisatieSuggestie>(), velden, doel);
@@ -825,11 +834,11 @@ namespace SportlinkFunction.Planner
             }
 
             // Check 2: geen enkel optimalisatiedoel is zinvol voor deze dag
-            if (!veld5OntlastenZinvol && !strakkerPlannenZinvol)
+            if (!grasveldOntlastenZinvol && !strakkerPlannenZinvol)
             {
-                string redenDetail = alleenVeld5Beschikbaar
-                    ? "doordeweekse dag — veld 1-4 niet beschikbaar, veld 5 is de enige optie en er is geen gewenste eindtijd opgegeven"
-                    : "geen wedstrijden op veld 5 en geen gewenste eindtijd opgegeven";
+                string redenDetail = alleenGrasveldBeschikbaar
+                    ? "doordeweekse dag — alleen grasveld beschikbaar, kunstgrasvelden niet beschikbaar, en er is geen gewenste eindtijd opgegeven"
+                    : "geen wedstrijden op grasveld en geen gewenste eindtijd opgegeven";
                 response.VoldoendeRuimte = true;
                 response.VoldoendeRuimteMelding = $"Geen optimalisatie nodig op {date.ToString("dddd d MMMM", nl)}: {redenDetail}.";
                 response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(
@@ -842,7 +851,7 @@ namespace SportlinkFunction.Planner
             switch (doel)
             {
                 case "veld5-ontlasten":
-                    if (veld5OntlastenZinvol)
+                    if (grasveldOntlastenZinvol)
                         suggesties = OptimaliseerVeld5Ontlasten(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
                     break;
                 case "strakker-plannen":
@@ -850,7 +859,7 @@ namespace SportlinkFunction.Planner
                         suggesties = OptimaliseerStrakkerPlannen(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
                     break;
                 default:
-                    if (veld5OntlastenZinvol)
+                    if (grasveldOntlastenZinvol)
                         suggesties = OptimaliseerVeld5Ontlasten(bezettingen, velden, availableFields, vasteWedstrijden, allTeamRules, bufferMin);
                     if (strakkerPlannenZinvol)
                     {
@@ -899,7 +908,7 @@ namespace SportlinkFunction.Planner
 
             response.Suggesties = suggesties;
             response.AantalVerplaatsingen = suggesties.Count;
-            response.AantalVanVeld5Verplaatst = suggesties.Count(s => s.HuidigVeldNummer == 5);
+            response.AantalVanVeld5Verplaatst = suggesties.Count(s => grasveldNrs.Contains(s.HuidigVeldNummer));
 
             // HTML genereren
             response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(date, bezettingen, suggesties, velden, request.Doel ?? "optimaliseren");
@@ -941,11 +950,15 @@ namespace SportlinkFunction.Planner
             Dictionary<string, List<TeamRegel>> allTeamRules,
             int bufferMin = 15)
         {
+            // Grasveld-nummers bepalen via VeldType
+            var grasveldNrsOntlasten = new HashSet<int>(velden.Where(v => v.VeldType == "gras").Select(v => v.VeldNummer));
+            if (grasveldNrsOntlasten.Count == 0) grasveldNrsOntlasten.Add(5);
+
             var suggesties = new List<OptimalisatieSuggestie>();
 
-            // Wedstrijden op veld 5 die verplaatst mogen worden
+            // Wedstrijden op grasveld die verplaatst mogen worden
             var veld5Wedstrijden = bezettingen
-                .Where(b => b.VeldNummer == 5)
+                .Where(b => grasveldNrsOntlasten.Contains(b.VeldNummer))
                 .Where(b => !vasteWedstrijden.Contains($"{b.VeldNummer}_{b.AanvangsTijd:HH:mm}_{b.Wedstrijd?.Trim()}"))
                 .OrderBy(b => b.AanvangsTijd)
                 .ToList();
@@ -958,10 +971,9 @@ namespace SportlinkFunction.Planner
                 int duur = (int)(wedstrijd.EindTijd - wedstrijd.AanvangsTijd).TotalMinutes;
                 decimal fractie = wedstrijd.VeldDeelGebruik;
 
-                // Zoek een plek op veld 1-4 die EERDER is dan huidige tijd op veld 5
-                // Alleen verplaatsen als het een verbetering is (eerder of gelijktijdig op kunstgras)
+                // Zoek een plek op kunstgrasveld die EERDER is dan huidige tijd op grasveld
                 CandidateSlot? besteSlot = null;
-                foreach (var veldBesch in beschikbareVelden.Where(f => f.VeldNummer <= 4).OrderBy(f => f.VeldNummer))
+                foreach (var veldBesch in beschikbareVelden.Where(f => !grasveldNrsOntlasten.Contains(f.VeldNummer)).OrderBy(f => f.VeldNummer))
                 {
                     var veldBezetting = werkBezettingen.Where(b => b.VeldNummer == veldBesch.VeldNummer).ToList();
 
@@ -989,16 +1001,18 @@ namespace SportlinkFunction.Planner
                 if (besteSlot != null)
                 {
                     var veldNaam = velden.FirstOrDefault(v => v.VeldNummer == besteSlot.VeldNummer)?.VeldNaam ?? $"veld {besteSlot.VeldNummer}";
+                    var huidigVeldInfo = velden.FirstOrDefault(v => v.VeldNummer == wedstrijd.VeldNummer);
+                    var huidigVeldNaam = huidigVeldInfo?.VeldNaam ?? $"veld {wedstrijd.VeldNummer}";
                     suggesties.Add(new OptimalisatieSuggestie
                     {
                         Wedstrijd = wedstrijd.Wedstrijd?.Trim() ?? "",
-                        HuidigVeldNummer = 5,
-                        HuidigVeld = "veld 5",
+                        HuidigVeldNummer = wedstrijd.VeldNummer,
+                        HuidigVeld = huidigVeldNaam,
                         HuidigeTijd = wedstrijd.AanvangsTijd.ToString("HH:mm"),
                         NieuwVeldNummer = besteSlot.VeldNummer,
                         NieuwVeld = veldNaam,
                         NieuweTijd = RondAfOp5Min(besteSlot.AanvangsTijd).ToString("HH:mm"),
-                        Reden = $"Verplaats van veld 5 (geen kunstlicht) naar {veldNaam}"
+                        Reden = $"Verplaats van {huidigVeldNaam} (grasveld) naar {veldNaam} (kunstgras)"
                     });
 
                     // Werkbezetting bijwerken zodat volgende suggesties deze plek als bezet zien

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -751,12 +751,14 @@ namespace SportlinkFunction.Planner
                 return response;
             }
 
+            bool isAllstars = string.Equals(clubCode, "ALLSTARS", StringComparison.OrdinalIgnoreCase);
+
             // Data laden — voor ALLSTARS test data direct uit DB, anders real-time API of DB fallback
-            var occupations = string.Equals(clubCode, "ALLSTARS", StringComparison.OrdinalIgnoreCase)
+            var occupations = isAllstars
                 ? await PlannerDataAccess.GetAllstarsOccupationsAsync(date)
                 : await SportlinkApiClient.GetFieldOccupationsWithApiAsync(date, log);
-            var velden = await PlannerDataAccess.GetVeldenAsync();
-            var availableFields = await PlannerDataAccess.GetAvailableFieldsAsync(date);
+            var velden = await PlannerDataAccess.GetVeldenAsync(allstarsOnly: isAllstars);
+            var availableFields = await PlannerDataAccess.GetAvailableFieldsAsync(date, allstarsOnly: isAllstars);
 
             // Dedup bezettingen
             var bezettingen = occupations
@@ -771,6 +773,22 @@ namespace SportlinkFunction.Planner
                 response.VoldoendeRuimte = true;
                 response.VoldoendeRuimteMelding = $"Geen wedstrijden gepland op {date.ToString("dddd d MMMM", nl)}.";
                 response.HtmlPlanner = $"<p style='color:#8b949e;font-family:sans-serif;'>Geen wedstrijden gepland op {date.ToString("dddd d MMMM yyyy", nl)}.</p>";
+                return response;
+            }
+
+            // ALLSTARS testmodus: toon HTML-overzicht met informatieve melding over ontbrekende veld-toewijzingen
+            if (isAllstars)
+            {
+                int defaultVeld = availableFields.Any() ? availableFields.Min(f => f.VeldNummer) : 101;
+                int aantalOpStandaard = bezettingen.Count(b => b.VeldNummer == defaultVeld);
+                int totaal = bezettingen.Count;
+                string testmelding = aantalOpStandaard > 0
+                    ? $"Testmodus — {aantalOpStandaard} van {totaal} wedstrijden staan op het standaard veld (Kunstgras 1) omdat nog geen veld is ingesteld. Wijs velden toe via Test data → Wedstrijden."
+                    : $"Testmodus — alle {totaal} wedstrijden hebben een veld toegewezen.";
+                response.VoldoendeRuimte = true;
+                response.VoldoendeRuimteMelding = testmelding;
+                response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(
+                    date, bezettingen, new List<OptimalisatieSuggestie>(), velden, request.Doel ?? "veld5-ontlasten");
                 return response;
             }
 

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -780,11 +780,25 @@ namespace SportlinkFunction.Planner
             if (isAllstars)
             {
                 int defaultVeld = availableFields.Any() ? availableFields.Min(f => f.VeldNummer) : 101;
-                int aantalOpStandaard = bezettingen.Count(b => b.VeldNummer == defaultVeld);
+                var opStandaard = bezettingen.Where(b => b.VeldNummer == defaultVeld).ToList();
+                int aantalOpStandaard = opStandaard.Count;
                 int totaal = bezettingen.Count;
-                string testmelding = aantalOpStandaard > 0
-                    ? $"Testmodus — {aantalOpStandaard} van {totaal} wedstrijden staan op het standaard veld (Kunstgras 1) omdat nog geen veld is ingesteld. Wijs velden toe via Test data → Wedstrijden."
-                    : $"Testmodus — alle {totaal} wedstrijden hebben een veld toegewezen.";
+                string testmelding;
+                if (aantalOpStandaard > 0)
+                {
+                    var defaultVeldNaam = velden.FirstOrDefault(f => f.VeldNummer == defaultVeld)?.VeldNaam ?? "Kunstgras 1";
+                    var teamNamen = opStandaard
+                        .Select(b => b.TeamNaam ?? b.Wedstrijd ?? "?")
+                        .Distinct()
+                        .OrderBy(n => n);
+                    testmelding = $"Testmodus — {aantalOpStandaard} van {totaal} wedstrijden staan op {defaultVeldNaam} (geen veld ingesteld): "
+                        + string.Join(", ", teamNamen)
+                        + ". Wijs velden toe via Test data → Wedstrijden.";
+                }
+                else
+                {
+                    testmelding = $"Testmodus — alle {totaal} wedstrijden hebben een veld toegewezen.";
+                }
                 response.VoldoendeRuimte = true;
                 response.VoldoendeRuimteMelding = testmelding;
                 response.HtmlPlanner = PlannerHtmlGenerator.GenereerHtml(

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.8.0.1</Version>
-    <AssemblyVersion>2.8.0.1</AssemblyVersion>
-    <FileVersion>2.8.0.1</FileVersion>
+    <Version>2.11.0.0</Version>
+    <AssemblyVersion>2.11.0.0</AssemblyVersion>
+    <FileVersion>2.11.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.8.0.0</Version>
-    <AssemblyVersion>2.8.0.0</AssemblyVersion>
-    <FileVersion>2.8.0.0</FileVersion>
+    <Version>2.8.0.1</Version>
+    <AssemblyVersion>2.8.0.1</AssemblyVersion>
+    <FileVersion>2.8.0.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.7.0.0</Version>
-    <AssemblyVersion>2.7.0.0</AssemblyVersion>
-    <FileVersion>2.7.0.0</FileVersion>
+    <Version>2.8.0.0</Version>
+    <AssemblyVersion>2.8.0.0</AssemblyVersion>
+    <FileVersion>2.8.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.11.0.0</Version>
-    <AssemblyVersion>2.11.0.0</AssemblyVersion>
-    <FileVersion>2.11.0.0</FileVersion>
+    <Version>2.6.0.15</Version>
+    <AssemblyVersion>2.6.0.15</AssemblyVersion>
+    <FileVersion>2.6.0.15</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.6.0.1</Version>
-    <AssemblyVersion>2.6.0.1</AssemblyVersion>
-    <FileVersion>2.6.0.1</FileVersion>
+    <Version>2.7.0.0</Version>
+    <AssemblyVersion>2.7.0.0</AssemblyVersion>
+    <FileVersion>2.7.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Alle documentatie staat in de [`docs/`](docs/) map, georganiseerd op doelgroep.
 
 | Categorie | Documenten |
 |---|---|
-| **Beheerders** | [Admin handleiding](docs/v2-admin-handleiding.md) · [Teambegeleiding export](docs/HANDLEIDING-TEAMBEGELEIDING-EXPORT.md) |
+| **Beheerders** | [Admin handleiding](docs/v2-admin-handleiding.md) · [Testmodus ALLSTARS](docs/TESTMODUS-ALLSTARS.md) · [Teambegeleiding export](docs/HANDLEIDING-TEAMBEGELEIDING-EXPORT.md) |
 | **Developers — opzet** | [Setup](docs/SETUP.md) · [Setup checklist](docs/SETUP-CHECKLIST.md) · [Lokaal debuggen](docs/LOKAAL-DEBUGGEN.md) · [Quick reference](docs/QUICK-REFERENCE.md) |
 | **Developers — architectuur** | [API referentie](docs/API.md) · [Planner architectuur](docs/ARCHITECTURE-PLANNER.md) · [E-mailverwerking](docs/EMAIL-VERWERKING.md) |
 | **Azure & auth** | [Azure Entra setup](docs/AZURE-ENTRA-SETUP.md) · [Versiebeheer](docs/VERSIONING.md) |

--- a/docs/API.md
+++ b/docs/API.md
@@ -44,7 +44,7 @@ Zonder geldige sleutel → 401 Unauthorized (kost niets, geen verwerking).
 | `GET` | `/beheer/testdata/teams` | **Admin** | Echte clubteams ophalen voor testdata-dropdown (filtert `ClubCode!='ALLSTARS'`) |
 | `POST` | `/beheer/testdata/wedstrijden` | **Admin** | Test-wedstrijd aanmaken of bijwerken (upsert op `bk_matches`) — forceert `ClubCode='ALLSTARS'` |
 | `DELETE` | `/beheer/testdata/wedstrijden/{bk}` | **Admin** | Één test-wedstrijd verwijderen op `bk_matches` |
-| `DELETE` | `/beheer/testdata/wedstrijden` | **Admin** | Alle test-wedstrijden verwijderen (`WHERE ClubCode='ALLSTARS'`) |
+| `DELETE` | `/beheer/testdata/wedstrijden?van=YYYY-MM-DD&tot=YYYY-MM-DD` | **Admin** | Test-wedstrijden verwijderen voor datumbereik (beide params optioneel; zonder params: alles verwijderen) |
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,6 +39,12 @@ Zonder geldige sleutel → 401 Unauthorized (kost niets, geen verwerking).
 | `PUT` | `/beheer/theme` | **Admin** | Club-thema opslaan (`{ primary, secondary, accent, textOnPrimary, clubWebsiteUrl }`) — gefilterd op `X-Club-Code` header |
 | `POST` | `/beheer/theme/extract?url=` | **Admin** | Kleuren extraheren uit club-website (SSRF-beschermd) |
 | `GET` | `/beheer/clubs` | **Admin** | Lijst van beschikbare clubs (`[{ clubCode, clubName }]`) voor de GUI-selector |
+| `GET` | `/beheer/velden` | **Admin** | Velden ophalen voor de actieve club (`[{ veldNummer, veldNaam }]`) |
+| `GET` | `/beheer/testdata/wedstrijden` | **Admin** | Test-wedstrijden ophalen (`ClubCode='ALLSTARS'`) — altijd leeg voor echte clubs |
+| `GET` | `/beheer/testdata/teams` | **Admin** | Echte clubteams ophalen voor testdata-dropdown (filtert `ClubCode!='ALLSTARS'`) |
+| `POST` | `/beheer/testdata/wedstrijden` | **Admin** | Test-wedstrijd aanmaken of bijwerken (upsert op `bk_matches`) — forceert `ClubCode='ALLSTARS'` |
+| `DELETE` | `/beheer/testdata/wedstrijden/{bk}` | **Admin** | Één test-wedstrijd verwijderen op `bk_matches` |
+| `DELETE` | `/beheer/testdata/wedstrijden` | **Admin** | Alle test-wedstrijden verwijderen (`WHERE ClubCode='ALLSTARS'`) |
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -9,6 +9,7 @@ Alle documentatie staat in deze map (`docs/`). Gebruik de categorieën hieronder
 | Document | Inhoud |
 |---|---|
 | [Admin handleiding v2](v2-admin-handleiding.md) | Stap-voor-stap handleiding voor de Admin GUI: instellingen, templates, veldplanner, e-maillog |
+| [Testmodus — ALLSTARS fictieve wedstrijden](TESTMODUS-ALLSTARS.md) | Hoe de ALLSTARS-testmodus werkt: activeren, fictieve wedstrijden invoeren, planner testen zonder echte data |
 | [Handleiding teambegeleiding export](HANDLEIDING-TEAMBEGELEIDING-EXPORT.md) | AVG-veilig exporteren van teambegeleidersgegevens uit Sportlink naar SQL |
 | [KNVB speeldagenkalenders](knvb-speeldagenkalenders/README.md) | Importeren van KNVB-speeldagenkalenders |
 

--- a/docs/TESTMODUS-ALLSTARS.md
+++ b/docs/TESTMODUS-ALLSTARS.md
@@ -1,0 +1,148 @@
+# Testmodus — ALLSTARS fictieve wedstrijden
+
+De ALLSTARS-testmodus maakt het mogelijk om de dagplanning en planner-logica te testen met volledig fictieve wedstrijden, zonder de echte Sportlink-data van de club te beïnvloeden.
+
+---
+
+## Wat is de ALLSTARS-testmodus?
+
+In normale modus haalt de planner zijn data uit de Sportlink Club API (live) of de gesynchroniseerde database (`his.matches` met `ClubCode = '<jouwclub>'`). In ALLSTARS-modus wordt dezelfde plannerlogica uitgevoerd op testdata die opgeslagen staat in `his.matches WHERE ClubCode = 'ALLSTARS'`.
+
+**Er is geen echte ALLSTARS-club.** De ClubCode `ALLSTARS` is een speciale sleutelwaarde die aangeeft dat het om fictieve testdata gaat. Er is geen rij in `dbo.AppSettings` voor ALLSTARS — dit is bewust: de testmodus heeft geen eigen e-mail, API-verbinding of synchronisatieschema.
+
+---
+
+## Wat werkt in ALLSTARS-modus?
+
+| Functionaliteit | Werkt | Toelichting |
+|---|---|---|
+| Dagplanning | ✅ | Laadt fictieve wedstrijden uit `his.matches WHERE ClubCode='ALLSTARS'` |
+| Planner-optimalisatie | ✅ | Volledige grasveld-logica, teamtijden en veldconflicten |
+| Testdata beheer (wedstrijden) | ✅ | Invoergrid op `/testdata/wedstrijden` |
+| Velden & veldbeschikbaarheid | ✅ | Deelt `dbo.Velden` met de echte club |
+| Speeltijden | ✅ | Deelt `dbo.Speeltijden` met de echte club |
+| Leermomenten | ✅ | Deelt tabel met echte club |
+| Instellingen | ❌ | Geen `AppSettings`-rij voor ALLSTARS — pagina toont testmodus-melding |
+| Synchronisatie | ❌ | Niet van toepassing — testdata wordt handmatig beheerd |
+| E-mailverwerking | ❌ | Niet van toepassing — testdata genereert geen echte e-mails |
+| E-mailtester | ⚠️ | Werkt technisch, maar stuurt e-mails via de echte club-account |
+| Teambegeleiding | ✅ | Leest `avg.Teambegeleiding WHERE ClubCode='ALLSTARS'` |
+
+---
+
+## Testdata beheren
+
+### Wedstrijden invoeren
+
+Navigeer naar **Testdata → Wedstrijden** in de zijbalk (alleen zichtbaar in ALLSTARS-modus).
+
+Op die pagina voer je fictieve wedstrijden in met:
+- Datum
+- Aanvangstijd
+- Teamnaam (bijv. `JO9-1`, `JO11-3`)
+- Veld (uit de bestaande `dbo.Velden`-tabel)
+- Competitiesoort
+
+De wedstrijden worden opgeslagen in `his.matches` met `ClubCode = 'ALLSTARS'`.
+
+### Teams in ALLSTARS-modus
+
+De planner-logica zoekt teamdata op via `avg.Teambegeleiding WHERE ClubCode = 'ALLSTARS'`. Voeg fictieve teambegeleiders toe via het CSV-importscript of direct in SQL.
+
+### Speeltijden voor testdata
+
+De testmodus deelt de `dbo.Speeltijden`-tabel met de echte club. De koppeling in de planner werkt op teamnaam-prefix: `JO9-2` matcht op `JO9`. Voeg speeltijden toe via **Instellingen → Speeltijden** (in normale modus).
+
+---
+
+## Testmodus activeren en verlaten
+
+### Activeren
+
+Klik op de knop **Testmodus** onderaan de zijbalk (onder de gebruikersnaam). Dit:
+1. Slaat `ALLSTARS` op als geselecteerde club in `localStorage`
+2. Navigeert naar `/testdata/wedstrijden`
+3. Toont "ALLSTARS (testmodus)" als clubnaam in de header
+
+### Verlaten
+
+Klik op **Testmodus — verlaten** (gele knop, verschijnt in plaats van de normale Testmodus-knop). Dit:
+1. Verwijdert de ALLSTARS-selectie uit `localStorage`
+2. Schakelt terug naar de primaire club (eerste club met `SyncEnabled = true` in `dbo.AppSettings`)
+3. Navigeert naar het dashboard
+
+### X-Club-Code header
+
+Elke API-aanroep in ALLSTARS-modus stuurt `X-Club-Code: ALLSTARS` mee. De FunctionApp leest deze header in `EasyAuthHelper.GetClubCodeFromRequest()` en stuurt de ALLSTARS-specifieke datapath in (bijv. `GetAllstarsOccupationsAsync` in de planner).
+
+---
+
+## Datamodel
+
+### `his.matches` — ALLSTARS-rijen
+
+```sql
+SELECT *
+FROM [his].[matches]
+WHERE [ClubCode] = 'ALLSTARS'
+ORDER BY [kaledatum], [aanvangstijd];
+```
+
+Verplichte velden voor planner-werking:
+| Veld | Voorbeeld | Reden |
+|---|---|---|
+| `ClubCode` | `ALLSTARS` | Discriminator |
+| `kaledatum` | `2026-05-30` | Datum voor dagplanning |
+| `aanvangstijd` | `10:00` | Startuur (null = niet meegenomen) |
+| `teamnaam` | `JO9-1` | Prefix-match met Speeltijden |
+| `veld` | `veld 2` | Naam-match met `dbo.Velden.VeldNaam` |
+| `thuisteam` | `Team A` | Weergave in planner-HTML |
+| `uitteam` | `Team B` | Weergave in planner-HTML |
+
+### `dbo.Velden` — gedeeld met echte club
+
+Velden zijn niet per club gesplitst — ze vertegenwoordigen de fysieke accommodatie. `VeldType = 'gras'` bepaalt of de grasveld-ontlastlogica op een veld van toepassing is.
+
+---
+
+## Technische werking
+
+### Planner-routing
+
+In `PlannerFunction.cs` wordt de `X-Club-Code` header uitgelezen:
+
+```csharp
+var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
+var response = await PlannerService.OptimaliseerAsync(request, log, clubCode);
+```
+
+In `PlannerService.OptimaliseerAsync`:
+
+```csharp
+var occupations = string.Equals(clubCode, "ALLSTARS", StringComparison.OrdinalIgnoreCase)
+    ? await PlannerDataAccess.GetAllstarsOccupationsAsync(date)
+    : await SportlinkApiClient.GetFieldOccupationsWithApiAsync(date, log);
+```
+
+### ClubSelectorService
+
+`ClubSelectorService` slaat de geselecteerde clubcode op in `localStorage`. De waarde `ALLSTARS` wordt **niet** teruggezet naar de primaire club bij paginawissel — `MainLayout.LaadClubsAsync` bevat een expliciete uitzondering hiervoor:
+
+```csharp
+if (ClubSelector.SelectedClubCode == null ||
+    (!_clubs.Any(c => c.ClubCode == ClubSelector.SelectedClubCode) &&
+     ClubSelector.SelectedClubCode != "ALLSTARS"))
+{
+    // alleen resetten als het geen ALLSTARS is
+    await ClubSelector.SelectClubAsync(primary);
+}
+```
+
+---
+
+## AVG en security
+
+- De ALLSTARS-testdata bevat **geen echte persoonsgegevens** — alle namen en tijden zijn fictief.
+- De teamnamen (bijv. `Jan de Vries`, `trainer@voorbeeld.nl`) volgen het [John Doe-principe](../CLAUDE.md): bewust niet-identificeerbaar.
+- De testdata staat in dezelfde database als de echte data, maar is volledig geïsoleerd via de `ClubCode = 'ALLSTARS'` discriminator.
+- Productie-API's (Sportlink, Microsoft Graph) worden in testmodus **niet** aangesproken.

--- a/docs/v2-admin-handleiding.md
+++ b/docs/v2-admin-handleiding.md
@@ -33,7 +33,11 @@ eigen venster in de juiste volgorde:
 # Poorten: Azurite :10000, FunctionApp :7094, BlazorAdmin :5242
 ```
 
-Wacht ~15 seconden en controleer dan met:
+Wacht ~15 seconden. Zolang de FunctionApp nog opstart verschijnt bovenaan elk scherm een gele
+**"Backend start op…"**-banner. Zodra de backend bereikbaar is verdwijnt de banner automatisch.
+Bij een 5xx-fout of verbindingsprobleem verschijnt een rode foutbanner met details.
+
+Controleer daarna met:
 
 ```powershell
 .\scripts\dev\Test-App.ps1          # verificatie: schema + build + endpoints + Blazor-pagina's
@@ -514,6 +518,7 @@ De pagina `/testdata/wedstrijden` toont een invoergrid voor het aanmaken van fic
 | Tegenstander | Vrij tekstveld voor de naam van de tegenstander |
 | Starttijd | Aanvangstijd (↓ fill-down beschikbaar) |
 | Veld | Veldnaam selecteren uit de dropdown |
+| Velddeel | Deelveld-dropdown — verschijnt alleen als het team op een deelveld speelt. JO7-JO10 (¼ veld): A1/A2/B1/B2; JO11-JO12 (½ veld): A/B. De beschikbare opties worden automatisch bepaald op basis van de speeltijden-tabel. |
 | Soort | Competitie / Beker / Oefenwedstrijd / Vriendschappelijk |
 
 **Globale invoerbalk** (boven de tabel): Stel datum, soort, tegenstander en starttijd in vóór het toevoegen van rijen — deze waarden worden als default voor nieuwe rijen gebruikt.

--- a/docs/v2-admin-handleiding.md
+++ b/docs/v2-admin-handleiding.md
@@ -542,3 +542,54 @@ De pagina `/testdata/wedstrijden` toont een invoergrid voor het aanmaken van fic
 | `POST /api/beheer/testdata/wedstrijden` | Test-wedstrijd aanmaken of bijwerken (upsert) |
 | `DELETE /api/beheer/testdata/wedstrijden/{bk}` | Één test-wedstrijd verwijderen |
 | `DELETE /api/beheer/testdata/wedstrijden` | Alle test-wedstrijden verwijderen |
+
+---
+
+## 14. Voorkeurstijden & Teamregels (`/voorkeurstijden`)
+
+De pagina `/voorkeurstijden` beheert twee soorten plannerregels per team.
+
+### Team voorkeurstijden
+
+Geef per team de gewenste aanvangstijden op voor een bepaalde dag van de week. De planner gebruikt deze tijden als richtpunt bij het inplannen.
+
+| Veld | Uitleg |
+|---|---|
+| **Team** | Teamnaam, dezelfde waarden als in het wedstrijdprogramma |
+| **Dag** | Dag van de week (1 = maandag … 7 = zondag) |
+| **Tijd** | Gewenste aanvangstijd in HH:mm (bijv. `14:30`). Typ ook `1430` — de applicatie normaliseert dit automatisch |
+| **Prioriteit** | Getal 1–10. **1 = hoogste prioriteit** (sterkste voorkeur), 10 = laagste. Gebruik 1 voor de primaire speeltijd van het team en hogere nummers voor alternatieven. Als een team meerdere tijden heeft, gebruikt de planner de laagste prioriteitswaarde als eerste keus |
+| **Actief** | Aangevinkt = de regel telt mee. Uitgevinkt = tijdelijk uitschakelen zonder verwijderen |
+
+### Teamregels
+
+Fijnere regels per team: buffers vóór/na wedstrijden en een vaste veldvoorkeur. Teamregels worden in aflopende prioriteitsvolgorde toegepast — de regel met het hoogste getal wint bij een conflict.
+
+| Regeltype | Waarde | Uitleg |
+|---|---|---|
+| **Buffer vóór** | Aantal minuten (0–240) | Reserveert extra tijd vóór de wedstrijd op het veld (bijv. 60 min = opslagveld vrijhouden voor warming-up) |
+| **Buffer na** | Aantal minuten (0–240) | Reserveert extra tijd ná de wedstrijd op het veld (bijv. 30 min = uitlooptijd) |
+| **Voorkeursveld** | Veldnummer + optionele aanvangstijd | Wijst een voorkeursveld toe aan het team, optioneel alleen op een bepaald tijdstip |
+
+#### Prioriteit bij Teamregels
+
+| Prioriteit | Effect |
+|---|---|
+| 0 | Laagste prioriteit — wordt als laatste toegepast |
+| 1–98 | Normale volgorde: hoger = eerder toegepast door de planner |
+| 99 | Hoogste prioriteit — overschrijft alle andere regels voor dit team |
+
+**Tip:** Gebruik hogere prioriteiten voor regels die absoluut gelden (bijv. "eerste elftal altijd op veld 1") en lagere voor richtlijnen.
+
+### API-endpoints
+
+| Endpoint | Beschrijving |
+|---|---|
+| `GET /api/beheer/voorkeurstijden` | Alle voorkeurstijden voor de club |
+| `POST /api/beheer/voorkeurstijden` | Nieuwe voorkeurstijd aanmaken |
+| `PUT /api/beheer/voorkeurstijden/{id}` | Voorkeurstijd bijwerken |
+| `DELETE /api/beheer/voorkeurstijden/{id}` | Voorkeurstijd verwijderen (soft-delete) |
+| `GET /api/beheer/teamregels` | Alle teamregels voor de club |
+| `POST /api/beheer/teamregels` | Nieuwe teamregel aanmaken |
+| `PUT /api/beheer/teamregels/{id}` | Teamregel bijwerken |
+| `DELETE /api/beheer/teamregels/{id}` | Teamregel verwijderen (soft-delete) |

--- a/docs/v2-admin-handleiding.md
+++ b/docs/v2-admin-handleiding.md
@@ -45,7 +45,24 @@ In lokale omgeving is `WEBSITE_SITE_NAME` niet aanwezig, waardoor `EasyAuthHelpe
 
 ---
 
-## 2. Way of working
+## 2. Testmodus — ALLSTARS fictieve wedstrijden
+
+De Admin GUI heeft een ingebouwde testmodus waarmee de dagplanning volledig op fictieve data kan worden getest, zonder de echte Sportlink-wedstrijden te beïnvloeden.
+
+**Activeren:** Klik op **Testmodus** onderaan de zijbalk (onder de gebruikersnaam).  
+**Verlaten:** Klik op **Testmodus — verlaten** (gele knop, verschijnt in de zijbalk).
+
+In testmodus:
+- Toont de zijbalk **"ALLSTARS (testmodus)"** als clubnaam
+- Laadt de dagplanning fictieve wedstrijden uit `his.matches WHERE ClubCode='ALLSTARS'`
+- Is het submenu **Testdata → Wedstrijden** zichtbaar voor het invoeren van fictieve wedstrijden
+- Zijn synchronisatie en e-mailverwerking op de Instellingen-pagina verborgen (niet van toepassing)
+
+Volledige documentatie: [docs/TESTMODUS-ALLSTARS.md](TESTMODUS-ALLSTARS.md)
+
+---
+
+## 3. Way of working
 
 ### Branches
 

--- a/docs/v2-admin-handleiding.md
+++ b/docs/v2-admin-handleiding.md
@@ -468,3 +468,60 @@ Bij een API-fout (time-out, netwerk, service onbeschikbaar) schakelt de planner 
 - Testomgeving zonder geldige Sportlink API-credentials
 - Lokale ontwikkelomgeving zonder internet
 - Problematische API-respons tijdelijk omzeilen tijdens een incident
+
+---
+
+## 13. Test data modus (ALLSTARS) — `/testdata/wedstrijden`
+
+De **Testmodus** maakt het mogelijk fictieve wedstrijden aan te maken die worden gebruikt voor lokale tests van de dagplanning en optimalisatie, zonder productiewedstrijden te raken.
+
+### Activeren
+
+Klik op **"Testmodus"** in de zijbalk (onderaan bij de ingelogde gebruiker). De knop activeert de ALLSTARS-modus:
+- Alle API-aanroepen sturen voortaan `X-Club-Code: ALLSTARS` mee
+- Het menu **"Test data"** verschijnt in de zijbalk
+- De actieve club-indicator in de topbalk toont "ALLSTARS"
+
+### Deactiveren
+
+Klik op **"Testmodus — verlaten"** (oranje knop) om terug te keren naar de normale clubmodus.
+
+### Test data → Wedstrijden
+
+De pagina `/testdata/wedstrijden` toont een invoergrid voor het aanmaken van fictieve wedstrijden:
+
+| Kolom | Beschrijving |
+|---|---|
+| Datum | Datum van de wedstrijd (↓ fill-down beschikbaar) |
+| Team (thuis) | Selecteer een echt clubteam uit de dropdown |
+| Tegenstander | Vrij tekstveld voor de naam van de tegenstander |
+| Starttijd | Aanvangstijd (↓ fill-down beschikbaar) |
+| Veld | Veldnaam selecteren uit de dropdown |
+| Soort | Competitie / Beker / Oefenwedstrijd / Vriendschappelijk |
+
+**Globale invoerbalk** (boven de tabel): Stel datum, soort, tegenstander en starttijd in vóór het toevoegen van rijen — deze waarden worden als default voor nieuwe rijen gebruikt.
+
+**Knoppen:**
+- **Alle teams** — voegt één rij per huidig clubteam toe en slaat alles op
+- **+ Lege rij** — voegt één lege rij toe
+- **↓** in een kolomkop — kopieert de eerste ingevulde waarde naar alle lege cellen in die kolom
+- **Verwijder alles** — verwijdert alle testdata-wedstrijden (`WHERE ClubCode='ALLSTARS'`)
+
+**Auto-save:** Elke celwijziging triggert direct een opslaan naar de database. Een ✅ of ⚠️ achter de rij geeft de opslagstatus aan.
+
+### Technische details
+
+- Alle testdata gebruikt `ClubCode = 'ALLSTARS'` — echte wedstrijden (`ClubCode = '<clubcode>'`) blijven onaangetast
+- `bk_matches` wordt synthetisch gegenereerd als `ALLSTARS-{guid}` (28 tekens)
+- Testdata staat in `his.matches` — hetzelfde schema als productiewedstrijden, klaar voor gebruik door de dagplanning
+- De ALLSTARS-modus is persistent in de browser (localStorage via `ClubSelectorService`) en wordt hersteld bij herstart van de browser
+
+### API-endpoints
+
+| Endpoint | Beschrijving |
+|---|---|
+| `GET /api/beheer/testdata/wedstrijden` | Alle test-wedstrijden ophalen |
+| `GET /api/beheer/testdata/teams` | Echte clubteams ophalen voor dropdown |
+| `POST /api/beheer/testdata/wedstrijden` | Test-wedstrijd aanmaken of bijwerken (upsert) |
+| `DELETE /api/beheer/testdata/wedstrijden/{bk}` | Één test-wedstrijd verwijderen |
+| `DELETE /api/beheer/testdata/wedstrijden` | Alle test-wedstrijden verwijderen |

--- a/scripts/dev/Start-Debug.ps1
+++ b/scripts/dev/Start-Debug.ps1
@@ -57,7 +57,7 @@ foreach ($port in @(7094, 5242, 4280)) {
     }
 }
 
-Start-Sleep -Seconds 2
+Start-Sleep -Seconds 4   # extra tijd zodat file handles (runtimeconfig.json) vrijgegeven zijn
 
 $debugPids = [System.Collections.Generic.List[int]]::new()
 
@@ -97,7 +97,7 @@ if ($NoWatch) {
     Write-Host "BlazorAdmin starten op http://localhost:5242 (hot reload actief) ..." -ForegroundColor Cyan
     $blazorProc = Start-Process powershell -ArgumentList @(
         '-NoExit', '-Command',
-        "Set-Location '$root\BlazorAdmin'; Write-Host 'BlazorAdmin — poort 5242  (hot reload: wijzigingen in .razor/.cs/.css herladen automatisch)' -ForegroundColor Green; dotnet watch run --launch-profile http --non-interactive"
+        "Set-Location '$root\BlazorAdmin'; `$env:MSBUILDDISABLENODEREUSE = '1'; Write-Host 'BlazorAdmin — poort 5242  (hot reload: wijzigingen in .razor/.cs/.css herladen automatisch)' -ForegroundColor Green; dotnet watch run --launch-profile http --non-interactive"
     ) -WindowStyle Normal -PassThru
 }
 $debugPids.Add($blazorProc.Id)

--- a/scripts/dev/Start-Debug.ps1
+++ b/scripts/dev/Start-Debug.ps1
@@ -97,7 +97,7 @@ if ($NoWatch) {
     Write-Host "BlazorAdmin starten op http://localhost:5242 (hot reload actief) ..." -ForegroundColor Cyan
     $blazorProc = Start-Process powershell -ArgumentList @(
         '-NoExit', '-Command',
-        "Set-Location '$root\BlazorAdmin'; Write-Host 'BlazorAdmin — poort 5242  (hot reload: wijzigingen in .razor/.cs/.css herladen automatisch)' -ForegroundColor Green; dotnet watch run --launch-profile http"
+        "Set-Location '$root\BlazorAdmin'; Write-Host 'BlazorAdmin — poort 5242  (hot reload: wijzigingen in .razor/.cs/.css herladen automatisch)' -ForegroundColor Green; dotnet watch run --launch-profile http --non-interactive"
     ) -WindowStyle Normal -PassThru
 }
 $debugPids.Add($blazorProc.Id)

--- a/scripts/dev/Start-Debug.ps1
+++ b/scripts/dev/Start-Debug.ps1
@@ -27,10 +27,25 @@ param(
 )
 
 $root = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+$pidFile = Join-Path $env:TEMP 'sportlink-debug-pids.txt'
 
-# --- Stop eventueel draaiende apps (op de bekende poorten) ---
+# --- Sluit vorige debug-vensters via opgeslagen PIDs ---
 Write-Host "Controleer op draaiende services..." -ForegroundColor DarkGray
 
+if (Test-Path $pidFile) {
+    Get-Content $pidFile | ForEach-Object {
+        $savedPid = [int]$_
+        $proc = Get-Process -Id $savedPid -ErrorAction SilentlyContinue
+        if ($proc) {
+            Write-Host "  Sluiten vorig venster: $($proc.ProcessName) (PID $savedPid)" -ForegroundColor DarkGray
+            Stop-Process -Id $savedPid -Force -ErrorAction SilentlyContinue
+        }
+    }
+    Remove-Item $pidFile -Force
+    Start-Sleep -Seconds 1
+}
+
+# --- Fallback: stop op poort als PID-bestand ontbreekt (bijv. eerste keer) ---
 foreach ($port in @(7094, 5242, 4280)) {
     $conn = Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue | Select-Object -First 1
     if ($conn) {
@@ -44,6 +59,8 @@ foreach ($port in @(7094, 5242, 4280)) {
 
 Start-Sleep -Seconds 2
 
+$debugPids = [System.Collections.Generic.List[int]]::new()
+
 # --- Azurite ---
 $azuriteRunning = [bool](Get-NetTCPConnection -LocalPort 10000 -State Listen -ErrorAction SilentlyContinue)
 if ($azuriteRunning) {
@@ -52,35 +69,38 @@ if ($azuriteRunning) {
     Write-Host "Azurite niet gevonden — starten..." -ForegroundColor Yellow
     $azuriteDir = Join-Path $env:TEMP 'azurite'
     if (-not (Test-Path $azuriteDir)) { New-Item -ItemType Directory -Path $azuriteDir | Out-Null }
-    Start-Process powershell -ArgumentList @(
+    $azuriteProc = Start-Process powershell -ArgumentList @(
         '-NoExit', '-Command',
         "azurite --location '$azuriteDir' --debug '$azuriteDir\debug.log'"
-    ) -WindowStyle Minimized
+    ) -WindowStyle Minimized -PassThru
+    $debugPids.Add($azuriteProc.Id)
     Start-Sleep -Seconds 2
 }
 
 # --- FunctionApp ---
 Write-Host "FunctionApp starten op http://localhost:7094 ..." -ForegroundColor Cyan
 Write-Host "  ⚠  FunctionApp heeft GEEN hot reload. Na codewijzigingen: venster sluiten + Start-Debug.ps1 opnieuw." -ForegroundColor DarkYellow
-Start-Process powershell -ArgumentList @(
+$funcProc = Start-Process powershell -ArgumentList @(
     '-NoExit', '-Command',
     "Set-Location '$root\FunctionApp'; Write-Host 'FunctionApp — poort 7094  (geen hot reload — herstart vereist na codewijziging)' -ForegroundColor Cyan; func start --port 7094"
-) -WindowStyle Normal
+) -WindowStyle Normal -PassThru
+$debugPids.Add($funcProc.Id)
 
 # --- BlazorAdmin ---
 if ($NoWatch) {
     Write-Host "BlazorAdmin starten op http://localhost:5242 (geen hot reload) ..." -ForegroundColor Cyan
-    Start-Process powershell -ArgumentList @(
+    $blazorProc = Start-Process powershell -ArgumentList @(
         '-NoExit', '-Command',
         "Set-Location '$root\BlazorAdmin'; Write-Host 'BlazorAdmin — poort 5242  (geen hot reload)' -ForegroundColor Cyan; dotnet run --launch-profile http"
-    ) -WindowStyle Normal
+    ) -WindowStyle Normal -PassThru
 } else {
     Write-Host "BlazorAdmin starten op http://localhost:5242 (hot reload actief) ..." -ForegroundColor Cyan
-    Start-Process powershell -ArgumentList @(
+    $blazorProc = Start-Process powershell -ArgumentList @(
         '-NoExit', '-Command',
         "Set-Location '$root\BlazorAdmin'; Write-Host 'BlazorAdmin — poort 5242  (hot reload: wijzigingen in .razor/.cs/.css herladen automatisch)' -ForegroundColor Green; dotnet watch run --launch-profile http"
-    ) -WindowStyle Normal
+    ) -WindowStyle Normal -PassThru
 }
+$debugPids.Add($blazorProc.Id)
 
 # --- SWA emulator (optioneel) ---
 if ($Swa) {
@@ -92,12 +112,17 @@ if ($Swa) {
         Write-Host "SWA emulator wordt overgeslagen." -ForegroundColor Yellow
     } else {
         Write-Host "SWA emulator starten op http://localhost:4280 ..." -ForegroundColor Cyan
-        Start-Process powershell -ArgumentList @(
+        $swaProc = Start-Process powershell -ArgumentList @(
             '-NoExit', '-Command',
             "Set-Location '$root'; Write-Host 'SWA emulator — poort 4280' -ForegroundColor Cyan; swa start sportlink-admin"
-        ) -WindowStyle Normal
+        ) -WindowStyle Normal -PassThru
+        $debugPids.Add($swaProc.Id)
     }
 }
+
+# --- PIDs opslaan voor volgende herstart ---
+$debugPids | Set-Content $pidFile
+Write-Host "  Debug-venster PIDs opgeslagen: $($debugPids -join ', ')" -ForegroundColor DarkGray
 
 # --- Samenvatting ---
 Write-Host ""


### PR DESCRIPTION
## Samenvatting

- Nieuwe **test data modus (ALLSTARS)** waarmee beheerders snel fictieve wedstrijden kunnen aanmaken voor lokaal testen
- Alle testdata gebruikt `ClubCode = ALLSTARS` — geen impact op echte Sportlink-data
- Activeren via de knop "Testmodus" onderin de zijbalk; bij activatie verschijnt conditioneel "Test data"-menu

## Wijzigingen

- `FunctionApp/Admin/AdminTestDataFunction.cs` — 5 endpoints: GET wedstrijden, GET teams (cross-club), POST upsert, DELETE één, DELETE alle
- `BlazorAdmin/Pages/TestData/Wedstrijden.razor` — invoergrid met auto-save per cel, fill-down per kolom, bulk "Alle teams", globale datum/soort/tegenstander/starttijd
- `BlazorAdmin/Layout/NavMenu.razor` — Testmodus-toggle + conditioneel Test data submenu
- `BlazorAdmin/Models/AdminModels.cs` — `AllstarsWedstrijdDto` + `VeldDto`
- `BlazorAdmin/Services/AdminApiClient.cs` — testdata- en velden-methoden

## Test plan

- [ ] Klik "Testmodus" in de zijbalk — "Test data"-menu verschijnt
- [ ] Navigeer naar "Test data → Wedstrijden"
- [ ] Klik "Alle teams" — grid vult met alle teams
- [ ] Verlaat een cel — auto-save spinner + groen vinkje
- [ ] Klik "↓" op Datum of Starttijd — waarde kopieert naar lege cellen
- [ ] Klik "✕" op een rij — rij verdwijnt
- [ ] Klik "Verwijder alles" — alle rijen weg
- [ ] Klik "Verlaat testmodus" — menu verdwijnt, redirect naar dashboard
- [ ] Echte wedstrijden in dagplanning onaangetast

Fixes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)