### PR TITLE
security(#372): PII-sanitisering in GitHubIssueReporter

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.6.1.8</Version>
-    <AssemblyVersion>2.6.1.8</AssemblyVersion>
-    <FileVersion>2.6.1.8</FileVersion>
+    <Version>2.6.1.9</Version>
+    <AssemblyVersion>2.6.1.9</AssemblyVersion>
+    <FileVersion>2.6.1.9</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Security
+- GitHubIssueReporter sanitiseert nu `ex.Message` en stacktraces vóór publicatie in GitHub Issues (#372): e-mailadressen, GUIDs, SQL-connectiestring-fragmenten en grote getallen worden vervangen door placeholders (`<email>`, `<guid>`, `<redacted>`, `<n>`). Voorheen kon PII uit exception-berichten ongesanitiseerd in publieke GitHub Issues terechtkomen.
+
 ### Fixed
 - Email-planner: "heel veld" uit email wordt nu correct doorgegeven aan de beschikbaarheidscheck. Voorheen werd voor teams als JO12 altijd de speeltijd-veldafmeting (0.50) gebruikt, ook als de afzender expliciet "heel veld" vroeg. Nu overschrijft het `heelVeld`-veld (gevuld door AI en doorgegeven via BerichtPipeline → CheckAvailabilityRequest) de veldafmeting naar 1.00m, en ontvangt de coördinator een waarschuwing dat dit team normaal op een halftijdsspeelveld speelt.
 - Auto-planner: voorkeurstijden zijn nu zachte richtlijnen in plaats van harde doelen. Compactheid heeft prioriteit — als de vroegst mogelijke start meer dan de teamspecifieke buffer vóór de voorkeurstijd ligt, wordt compact ingepland zodat er geen onnodig gat in het schema ontstaat. Teams met een expliciete BufferVoor-teamregel (bijv. Heren 1 met 60 min voor) behouden hun gerechtvaardigd gat.

--- a/FunctionApp/Infrastructure/GitHubIssueReporter.cs
+++ b/FunctionApp/Infrastructure/GitHubIssueReporter.cs
@@ -118,8 +118,8 @@ public static class GitHubIssueReporter
         var nlTijd = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, nlZone);
 
         var body = $"🔁 Opnieuw opgetreden op {nlTijd:dd-MM-yyyy HH:mm} in functie `{functionName}`\n\n"
-                 + $"**Exception:** `{ex.GetType().FullName}: {ex.Message}`\n\n"
-                 + $"**Stacktrace:**\n```\n{TruncateStackTrace(ex.StackTrace)}\n```";
+                 + $"**Exception:** `{ex.GetType().FullName}: {SanitizeForPublic(ex.Message)}`\n\n"
+                 + $"**Stacktrace:**\n```\n{TruncateStackTrace(SanitizeForPublic(ex.StackTrace))}\n```";
 
         var payload = JsonConvert.SerializeObject(new { body });
         var url = $"https://api.github.com/repos/{owner}/{repo}/issues/{issueNumber}/comments";
@@ -138,14 +138,15 @@ public static class GitHubIssueReporter
         var nlZone = TimeZoneInfo.FindSystemTimeZoneById("W. Europe Standard Time");
         var nlTijd = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, nlZone);
 
-        var title = $"[bug][fp:{fp}] {ex.GetType().Name}: {TruncateMessage(ex.Message)}";
+        var sanitizedMessage = SanitizeForPublic(ex.Message);
+        var title = $"[bug][fp:{fp}] {ex.GetType().Name}: {TruncateMessage(sanitizedMessage)}";
         var body = $"## Automatisch gerapporteerde exception\n\n"
                  + $"**Tijdstip:** {nlTijd:dd-MM-yyyy HH:mm} (Europe/Amsterdam)\n"
                  + $"**Functie:** `{functionName}`\n"
                  + $"**Fingerprint:** `{fp}`\n\n"
                  + $"**Exception:** `{ex.GetType().FullName}`\n"
-                 + $"**Bericht:** {ex.Message}\n\n"
-                 + $"**Stacktrace:**\n```\n{TruncateStackTrace(ex.StackTrace)}\n```\n\n"
+                 + $"**Bericht:** {sanitizedMessage}\n\n"
+                 + $"**Stacktrace:**\n```\n{TruncateStackTrace(SanitizeForPublic(ex.StackTrace))}\n```\n\n"
                  + $"*Automatisch aangemaakt door GitHubIssueReporter (v2.1 zelfherstellend systeem)*";
 
         var payload = JsonConvert.SerializeObject(new
@@ -182,5 +183,33 @@ public static class GitHubIssueReporter
     {
         if (message.Length <= 120) return message;
         return message[..117] + "...";
+    }
+
+    // Verwijdert PII en club-specifieke gegevens voordat tekst in publieke GitHub issues terechtkomt.
+    // Sanitiseert: e-mailadressen, GUIDs, SQL-connectiestring-fragmenten, datums, getallen.
+    private static string SanitizeForPublic(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return "";
+        var s = text;
+        // E-mailadressen
+        s = System.Text.RegularExpressions.Regex.Replace(s,
+            @"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}", "<email>");
+        // GUIDs / client IDs
+        s = System.Text.RegularExpressions.Regex.Replace(s,
+            @"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b", "<guid>");
+        // SQL-connectiestring-fragmenten (key=value paren die credentials kunnen bevatten)
+        s = System.Text.RegularExpressions.Regex.Replace(s,
+            @"(?i)\b(Server|Database|User Id|Data Source|Initial Catalog|Pwd|Uid)\s*=\s*[^\s;,'""<>]+",
+            "$1=<redacted>");
+        // Afzonderlijke credentials (pwd, pass, secret varianten)
+        s = System.Text.RegularExpressions.Regex.Replace(s,
+            @"(?i)\b(pass\w*|secret\w*|token\w*|key\w*)\s*[=:]\s*\S{4,}",
+            "$1=<redacted>");
+        // Datums
+        s = System.Text.RegularExpressions.Regex.Replace(s,
+            @"\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?)?", "<date>");
+        // Losse getallen
+        s = System.Text.RegularExpressions.Regex.Replace(s, @"\b\d{5,}\b", "<n>");
+        return s.Trim();
     }
 }

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.6.1.8</Version>
-    <AssemblyVersion>2.6.1.8</AssemblyVersion>
-    <FileVersion>2.6.1.8</FileVersion>
+    <Version>2.6.1.9</Version>
+    <AssemblyVersion>2.6.1.9</AssemblyVersion>
+    <FileVersion>2.6.1.9</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
## Samenvatting

`GitHubIssueReporter` plaatste `ex.Message` en stacktraces ongesanitiseerd in publieke GitHub Issues. Bij SQL-fouten of API-fouten kon PII (e-mailadressen, credentials) uitlekken.

## Fix

Nieuwe `SanitizeForPublic()` methode die e-mailadressen, GUIDs, SQL-connectiestring key=value paren, credential-sleutels en grote getallen vervangt door placeholders voordat tekst in een publiek issue terechtkomt.

Closes #372

🤖 Generated with [Claude Code](https://claude.ai/claude-code)