### PR TITLE
fix(#370): GitHubIssueReporter deduplicatie over koude starts

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.6.1.9</Version>
-    <AssemblyVersion>2.6.1.9</AssemblyVersion>
-    <FileVersion>2.6.1.9</FileVersion>
+    <Version>2.6.2.0</Version>
+    <AssemblyVersion>2.6.2.0</AssemblyVersion>
+    <FileVersion>2.6.2.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- GitHubIssueReporter maakte dagelijks een nieuw GitHub Issue aan voor dezelfde fout (#370): de in-memory deduplicatie werkte niet na een koude start (Azure Functions). Zoekopdracht uitgebreid naar open én gesloten issues — bij een bestaand issue (open of gesloten) wordt nu commentaar toegevoegd, en een gesloten issue wordt automatisch heropend.
+
 ### Security
 - GitHubIssueReporter sanitiseert nu `ex.Message` en stacktraces vóór publicatie in GitHub Issues (#372): e-mailadressen, GUIDs, SQL-connectiestring-fragmenten en grote getallen worden vervangen door placeholders (`<email>`, `<guid>`, `<redacted>`, `<n>`). Voorheen kon PII uit exception-berichten ongesanitiseerd in publieke GitHub Issues terechtkomen.
 

--- a/FunctionApp/Infrastructure/GitHubIssueReporter.cs
+++ b/FunctionApp/Infrastructure/GitHubIssueReporter.cs
@@ -66,7 +66,11 @@ public static class GitHubIssueReporter
             var existing = await SearchIssueAsync(http, owner, repo, fp, log);
 
             if (existing.HasValue)
-                await AddCommentAsync(http, owner, repo, existing.Value, ex, functionName, log);
+            {
+                if (existing.Value.isClosed)
+                    await ReopenIssueAsync(http, owner, repo, existing.Value.number, log);
+                await AddCommentAsync(http, owner, repo, existing.Value.number, ex, functionName, log);
+            }
             else
                 await CreateIssueAsync(http, owner, repo, fp, ex, functionName, log);
         }
@@ -86,11 +90,13 @@ public static class GitHubIssueReporter
         return http;
     }
 
-    private static async Task<int?> SearchIssueAsync(
+    private static async Task<(int number, bool isClosed)?> SearchIssueAsync(
         HttpClient http, string owner, string repo, string fp, ILogger log)
     {
-        var query = Uri.EscapeDataString($"[fp:{fp}] in:title repo:{owner}/{repo} is:open");
-        var url = $"https://api.github.com/search/issues?q={query}&per_page=1";
+        // Zoek in open én gesloten issues — zo wordt nooit een duplicaat aangemaakt
+        // ook niet na een cold start of nadat een issue eerder gesloten werd.
+        var query = Uri.EscapeDataString($"[fp:{fp}] in:title repo:{owner}/{repo}");
+        var url = $"https://api.github.com/search/issues?q={query}&per_page=1&sort=created&order=desc";
         var resp = await http.GetAsync(url);
         if (!resp.IsSuccessStatusCode)
         {
@@ -104,10 +110,24 @@ public static class GitHubIssueReporter
         if (count > 0)
         {
             int number = (int)result.items[0].number;
-            log.LogInformation("Bestaand GitHub issue #{Nr} gevonden voor fp:{Fp}", number, fp);
-            return number;
+            string state = (string)result.items[0].state;
+            bool isClosed = state == "closed";
+            log.LogInformation("Bestaand GitHub issue #{Nr} ({State}) gevonden voor fp:{Fp}", number, state, fp);
+            return (number, isClosed);
         }
         return null;
+    }
+
+    private static async Task ReopenIssueAsync(
+        HttpClient http, string owner, string repo, int issueNumber, ILogger log)
+    {
+        var payload = JsonConvert.SerializeObject(new { state = "open" });
+        var url = $"https://api.github.com/repos/{owner}/{repo}/issues/{issueNumber}";
+        var resp = await http.PatchAsync(url, new StringContent(payload, Encoding.UTF8, "application/json"));
+        if (resp.IsSuccessStatusCode)
+            log.LogInformation("GitHub issue #{Nr} heropend (opnieuw opgetreden)", issueNumber);
+        else
+            log.LogWarning("GitHub issue heropenen mislukt: HTTP {Status}", (int)resp.StatusCode);
     }
 
     private static async Task AddCommentAsync(

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.6.1.9</Version>
-    <AssemblyVersion>2.6.1.9</AssemblyVersion>
-    <FileVersion>2.6.1.9</FileVersion>
+    <Version>2.6.2.0</Version>
+    <AssemblyVersion>2.6.2.0</AssemblyVersion>
+    <FileVersion>2.6.2.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
## Probleem

`GitHubIssueReporter` maakte dagelijks een nieuw GitHub issue aan voor dezelfde fout (zelfde fingerprint). De in-memory deduplicatie (`_recentlyReported` dict) werkte niet na een koude start — Azure Functions timer-functies starten elke nacht vers op.

## Fix

`SearchIssueAsync` zoekt nu in open én gesloten issues. Als een bestaand issue gevonden wordt: voeg comment toe (en heropen als gesloten). Nieuw issue alleen als fingerprint werkelijk nog niet bestaat.

Closes #370

🤖 Generated with [Claude Code](https://claude.ai/claude-code)