### PR TITLE
feat(db-status): database offline detectie + deployment guard (v2.7.0.1)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(dotnet *)",
+      "Bash(func *)",
+      "Bash(pwsh scripts/*)",
+      "Bash(git status)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git branch*)",
+      "Bash(git checkout*)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git push*)",
+      "Bash(git fetch*)",
+      "Bash(git pull*)",
+      "Bash(git stash*)",
+      "Bash(git restore*)",
+      "Bash(git mv *)",
+      "Bash(git rm *)",
+      "Bash(git tag*)",
+      "Bash(gh issue*)",
+      "Bash(gh pr*)",
+      "Bash(gh repo*)",
+      "Bash(gh run*)",
+      "Bash(gh release*)",
+      "Bash(gh api*)"
+    ]
+  }
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,46 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  # ──────────────────────────────────────────────────────────────────────────
+  # db-check: controleert de Azure SQL Free-tier database-status VÓÓR alles.
+  # Als de DB niet Online is wordt de volledige pipeline geblokkeerd:
+  #   build → db-migrate, blazor-deploy en test worden allemaal overgeslagen.
+  # Vereist variabele AZURE_SQL_DATABASE_NAME (naast de al bestaande server/rg-vars).
+  # Wordt overgeslagen als AZURE_SQL_SERVER_NAME of AZURE_SQL_DATABASE_NAME niet
+  # geconfigureerd is (fork / nieuw project zonder SQL-vars) — dan loopt build gewoon door.
+  # ──────────────────────────────────────────────────────────────────────────
+  db-check:
+    runs-on: ubuntu-latest
+    if: vars.AZURE_SQL_SERVER_NAME != '' && vars.AZURE_SQL_DATABASE_NAME != ''
+    steps:
+      - name: Azure inloggen
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: "⛔ Database status controleren (ARM API — vóór migratie en deploy)"
+        run: |
+          STATUS=$(az sql db show \
+            --name "${{ vars.AZURE_SQL_DATABASE_NAME }}" \
+            --resource-group "${{ vars.AZURE_SQL_RESOURCE_GROUP }}" \
+            --server "${{ vars.AZURE_SQL_SERVER_NAME }}" \
+            --query 'status' --output tsv 2>/dev/null || echo "unknown")
+          echo "Database status: $STATUS"
+          if [ "$STATUS" != "Online" ]; then
+            echo "::error::⛔ Database is '$STATUS' — volledige deployment geblokkeerd."
+            echo "::error::Breng de database online vóór deployment:"
+            echo "::error::  Azure Portal → SQL Database → Overzicht → Resume"
+            echo "::error::Of wacht tot de maandlimiet vernieuwd is (begin volgende kalendermaand)."
+            exit 1
+          fi
+          echo "✓ Database Online — deployment mag doorgaan"
+
   build:
     runs-on: ubuntu-latest
+    # Wacht op db-check. Als db-check FAILED → build wordt overgeslagen (en alles daarna ook).
+    # Als db-check SKIPPED (vars niet ingesteld) → build loopt gewoon door (backward compatible).
+    needs: db-check
+    if: always() && (needs.db-check.result == 'success' || needs.db-check.result == 'skipped')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -79,9 +79,11 @@ sp_create_current.txt
 sp_merge_current.txt
 
 # ── Claude Code local settings en memory ─────────────────────────────────────
-# settings.local.json bevat machine-specifieke permissies.
-# memory/ bevat conversatiecontext die persoonlijke info kan bevatten.
-.claude/
+# settings.local.json bevat machine-specifieke permissies (paden, etc.) — nooit committen.
+# memory/ bevat AI-conversatiecontext die persoonlijke info kan bevatten — nooit committen.
+# settings.json is gecommit (gedeeld) en bevat project-brede permissies voor alle developers.
+.claude/settings.local.json
+.claude/memory/
 
 # ── Build artifacts ───────────────────────────────────────────────────────────
 *.lscache

--- a/BlazorAdmin/App.razor
+++ b/BlazorAdmin/App.razor
@@ -1,7 +1,9 @@
 @using BlazorAdmin.Pages
+@using BlazorAdmin.Services
 @inject AuthenticationStateProvider AuthStateProvider
 @inject NavigationManager NavManager
-@inject BlazorAdmin.Services.ThemeService ThemeService
+@inject ThemeService ThemeService
+@inject DatabaseStatusService DbStatusService
 @implements IDisposable
 
 @*
@@ -34,13 +36,43 @@
     }
     else if (_state == AppState.Authenticated)
     {
-        @* Ingelogd MET admin- of user-rol: volledige app met MainLayout. *@
-        <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
-            <Found Context="routeData">
-                <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
-                <FocusOnNavigate RouteData="@routeData" Selector="h1" />
-            </Found>
-        </Router>
+        @* DB-overlay: blokkeert de volledige app als de Azure SQL Free-tier database
+           niet online is. Overlay verdwijnt zodra DB hersteld is (polling elke 15s). *@
+        @if (DbStatusService.State == DbState.Starting || DbStatusService.State == DbState.LimietBereikt)
+        {
+            <div class="api-startup">
+                <div class="startup-card">
+                    @if (DbStatusService.State == DbState.Starting)
+                    {
+                        <div class="startup-spinner"><div class="spinner-ring"></div></div>
+                        <p class="startup-label">Database wordt opgestart&hellip;</p>
+                        <p class="startup-sub">Dit duurt gemiddeld 1&nbsp;minuut. Even geduld.</p>
+                    }
+                    else
+                    {
+                        <p class="startup-icon">&#9888;&#65039;</p>
+                        <p class="startup-label startup-label-error">Database niet beschikbaar</p>
+                        <p class="startup-sub">
+                            De maandlimiet van de gratis database is bereikt.<br />
+                            De database is automatisch hervat aan het begin van de volgende maand.
+                        </p>
+                        <p class="startup-sub startup-sub-muted">
+                            Neem contact op met de beheerder als dit onverwacht is.
+                        </p>
+                    }
+                </div>
+            </div>
+        }
+        else
+        {
+            @* Ingelogd MET admin- of user-rol: volledige app met MainLayout. *@
+            <Router AppAssembly="@typeof(App).Assembly" NotFoundPage="typeof(Pages.NotFound)">
+                <Found Context="routeData">
+                    <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+                    <FocusOnNavigate RouteData="@routeData" Selector="h1" />
+                </Found>
+            </Router>
+        }
     }
     else if (_state == AppState.AccessDenied)
     {
@@ -53,6 +85,7 @@
 
 @code {
     private AppState _state = AppState.Initializing;
+    private bool _dbPollingStarted;
 
     protected override async Task OnInitializedAsync()
     {
@@ -90,7 +123,18 @@
         StateHasChanged();
 
         if (_state == AppState.Authenticated)
+        {
             await ThemeService.LoadAndApplyAsync();
+
+            // Start DB-polling eenmalig na succesvolle authenticatie.
+            // Overlay in de Authenticated-branch bewaakt de database-status.
+            if (!_dbPollingStarted)
+            {
+                _dbPollingStarted = true;
+                DbStatusService.OnStateChanged += HandleDbStateChanged;
+                DbStatusService.StartPolling();
+            }
+        }
     }
 
     private void HandleLocationChange(object? sender, LocationChangedEventArgs e)
@@ -98,9 +142,12 @@
         InvokeAsync(EvaluateStateAsync);
     }
 
+    private void HandleDbStateChanged() => InvokeAsync(StateHasChanged);
+
     public void Dispose()
     {
         NavManager.LocationChanged -= HandleLocationChange;
+        DbStatusService.OnStateChanged -= HandleDbStateChanged;
     }
 
     private enum AppState { Initializing, OnAuthRoute, Authenticated, AccessDenied, RedirectingToLogin }

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.7.0.0</Version>
-    <AssemblyVersion>2.7.0.0</AssemblyVersion>
-    <FileVersion>2.7.0.0</FileVersion>
+    <Version>2.7.0.1</Version>
+    <AssemblyVersion>2.7.0.1</AssemblyVersion>
+    <FileVersion>2.7.0.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/Program.cs
+++ b/BlazorAdmin/Program.cs
@@ -94,5 +94,6 @@ else
 builder.Services.AddScoped<ClubSelectorService>();
 builder.Services.AddScoped<ThemeService>();
 builder.Services.AddScoped<ApiStatusService>();
+builder.Services.AddScoped<DatabaseStatusService>();
 
 await builder.Build().RunAsync();

--- a/BlazorAdmin/Services/DatabaseStatusService.cs
+++ b/BlazorAdmin/Services/DatabaseStatusService.cs
@@ -1,0 +1,97 @@
+using System.Net.Http.Json;
+
+namespace BlazorAdmin.Services;
+
+public enum DbState { Unknown, Starting, Online, LimietBereikt }
+
+/// <summary>
+/// Pollt /api/health en bewaakt de Azure SQL Free-tier database-status.
+/// Start bij authenticatie; blokkeert de app-UI als de DB niet online komt.
+///
+/// State machine:
+///   Unknown    → (eerste poll) → Online  (succes binnen 2 min)
+///                              → Starting (mislukking, bezig met resumeren)
+///                                → ... → Online  (hersteld)
+///                                      → LimietBereikt (na 2 min geen succes)
+///   LimietBereikt → elke 5 min opnieuw checken (volgende maand of handmatig herstart)
+///   Online        → elke 5 min alive-check; bij mislukking terug naar Starting
+/// </summary>
+public sealed class DatabaseStatusService : IDisposable
+{
+    public DbState State { get; private set; } = DbState.Unknown;
+    public event Action? OnStateChanged;
+
+    private readonly HttpClient _http;
+    private CancellationTokenSource? _cts;
+    private bool _polling;
+
+    public DatabaseStatusService(HttpClient http) => _http = http;
+
+    public void StartPolling()
+    {
+        if (_polling) return;
+        _polling = true;
+        _ = PollLoopAsync();
+    }
+
+    private async Task PollLoopAsync()
+    {
+        _cts?.Cancel();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+        var startedAt = DateTime.UtcNow;
+
+        while (!token.IsCancellationRequested)
+        {
+            try
+            {
+                var resp = await _http.GetFromJsonAsync<HealthResponse>("api/health", token);
+                var dbOnline = resp?.database == "online";
+
+                if (dbOnline)
+                {
+                    SetState(DbState.Online);
+                    startedAt = DateTime.UtcNow; // reset: volgende storing krijgt weer 2 min
+                    await Task.Delay(TimeSpan.FromMinutes(5), token);
+                    continue;
+                }
+
+                // DB niet online — bepaal hoe lang we al wachten
+                var elapsed = DateTime.UtcNow - startedAt;
+                if (elapsed > TimeSpan.FromMinutes(2))
+                {
+                    SetState(DbState.LimietBereikt);
+                    // Blijf elke 5 min checken: bij maandwisseling of handmatige herstart
+                    await Task.Delay(TimeSpan.FromMinutes(5), token);
+                    startedAt = DateTime.UtcNow; // reset window voor volgende cyclus
+                    continue;
+                }
+
+                SetState(DbState.Starting);
+            }
+            catch (OperationCanceledException) { break; }
+            catch { /* netwerk/parse-fout — opnieuw proberen */ }
+
+            await Task.Delay(TimeSpan.FromSeconds(15), token).ConfigureAwait(false);
+        }
+    }
+
+    private void SetState(DbState next)
+    {
+        if (State == next) return;
+        State = next;
+        OnStateChanged?.Invoke();
+    }
+
+    public void Dispose()
+    {
+        _cts?.Cancel();
+        _cts?.Dispose();
+    }
+
+    private sealed class HealthResponse
+    {
+        public string? status { get; set; }
+        public string? database { get; set; }
+    }
+}

--- a/BlazorAdmin/wwwroot/css/app.css
+++ b/BlazorAdmin/wwwroot/css/app.css
@@ -176,6 +176,29 @@ code {
     to { transform: rotate(360deg); }
 }
 
+.startup-sub {
+    margin: 0;
+    font-size: .85rem;
+    color: #6c757d;
+    line-height: 1.5;
+    text-align: center;
+}
+
+.startup-sub-muted {
+    font-size: .78rem;
+    color: #adb5bd;
+}
+
+.startup-icon {
+    margin: 0;
+    font-size: 2.5rem;
+    line-height: 1;
+}
+
+.startup-label-error {
+    color: #dc3545;
+}
+
 /* ── Dashboard quick-access cards (#344) ─────────────────────── */
 
 .dashboard-card {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+## [2.7.0.1] — 2026-05-31
+
+### Added
+- Blazor toont een blokkerende overlay als de Azure SQL Free-tier database niet online is: "Database wordt opgestart..." (eerste 2 min) of "Database niet beschikbaar — maandlimiet bereikt" (daarna). Voorkomen dat beheerders eindeloos op "Laden..." kijken zonder uitleg.
+- `/api/health` geeft nu ook de database-status terug (`database: "online" | "paused" | "timeout" | "unavailable"`). Status `paused` triggert automatisch de Azure SQL auto-resume.
+- `db-check` job in `deploy.yml` controleert de database-status via Azure ARM API als allereerste stap — vóór build, migratie én Blazor-deploy. Hele pipeline wordt geblokkeerd als de database niet `Online` is.
+- `scripts/azure/Setup-SqlAlerts.ps1`: eenmalig uit te voeren script dat een gratis Resource Health Alert aanmaakt (e-mail bij database Unavailable/Resolved).
+
+### Fixed
+- `blazor-deploy` werd eerder uitgevoerd zelfs als de database offline was (had alleen `needs: build`). Nu geblokkeerd via `db-check → build` dependency-keten.
+
 ## [2.7.0.0] — 2026-05-31
 
 ### Fixed

--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using SportlinkFunction.Admin;
@@ -279,12 +281,52 @@ namespace SportlinkFunction.Planner
         }
 
         [Function("Health")]
-        public static IActionResult Health(
+        public static async Task<IActionResult> Health(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "health")] HttpRequest req,
             FunctionContext context)
         {
             var version = typeof(PlannerFunction).Assembly.GetName().Version?.ToString(4) ?? "?";
-            return new OkObjectResult(new { status = "ok", version, timestamp = DateTime.UtcNow });
+            var dbStatus = await GetDatabaseStatusAsync();
+            return new OkObjectResult(new
+            {
+                status = dbStatus == "online" ? "ok" : "degraded",
+                version,
+                timestamp = DateTime.UtcNow,
+                database = dbStatus
+            });
+        }
+
+        // Geeft "online", "paused", "timeout" of "unavailable" terug.
+        // Error 40613 = Azure SQL serverless auto-paused; verbinding triggert automatisch resume.
+        private static async Task<string> GetDatabaseStatusAsync()
+        {
+            string connStr;
+            try { connStr = SystemUtilities.DatabaseConfig.ConnectionString; }
+            catch { return "unconfigured"; }
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            try
+            {
+                using var conn = new SqlConnection(connStr);
+                await conn.OpenAsync(cts.Token);
+                using var cmd = new SqlCommand("SELECT 1", conn) { CommandTimeout = 5 };
+                await cmd.ExecuteScalarAsync(cts.Token);
+                return "online";
+            }
+            catch (SqlException ex) when (ex.Number == 40613)
+            {
+                // Database is paused (free tier limiet of normale auto-pause).
+                // Azure begint automatisch te resumeren zodra we verbinding proberen.
+                return "paused";
+            }
+            catch (OperationCanceledException)
+            {
+                return "timeout";
+            }
+            catch
+            {
+                return "unavailable";
+            }
         }
 
         [Function("HerplanBevestig")]

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.7.0.0</Version>
-    <AssemblyVersion>2.7.0.0</AssemblyVersion>
-    <FileVersion>2.7.0.0</FileVersion>
+    <Version>2.7.0.1</Version>
+    <AssemblyVersion>2.7.0.1</AssemblyVersion>
+    <FileVersion>2.7.0.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/docs/MONITORING.md
+++ b/docs/MONITORING.md
@@ -98,6 +98,77 @@ Bron: [Azure Monitor cost — alerts](https://learn.microsoft.com/azure/azure-mo
 | p95 response time | > 1 s | > 2 s |
 | Health endpoint DOWN | — | 3 achtereenvolgende fouten |
 
+---
+
+## Azure SQL Free-tier bescherming
+
+De gratis Azure SQL database heeft een maandlimiet van **100.000 vCore-seconden**. Bij uitputting
+wordt de database gepauzeerd tot het begin van de volgende kalendermaand. Dit heeft impact op drie lagen.
+
+### Laag 1 — Deployment guard (CI/CD)
+
+De `db-check` job in `deploy.yml` controleert de database-status via de Azure ARM API **vóór** elke
+build, migratie of Blazor-deploy. Als de database niet `Online` is, wordt de volledige pipeline
+geblokkeerd met een duidelijke foutmelding.
+
+**Vereiste GitHub variabele (eenmalig instellen):**
+```
+Settings → Secrets and variables → Actions → Variables → New repository variable
+  Name:  AZURE_SQL_DATABASE_NAME
+  Value: [database-naam]   (bijv. myFreeDB)
+```
+
+Zonder deze variabele wordt de `db-check` job overgeslagen (backward compatible voor forks
+zonder SQL-configuratie). De variabele is naast de al bestaande `AZURE_SQL_SERVER_NAME` en
+`AZURE_SQL_RESOURCE_GROUP`.
+
+**Pipeline-volgorde:**
+```
+db-check → build → db-migrate
+                 → test
+                 → blazor-deploy
+```
+Als `db-check` faalt → `build` wordt overgeslagen → alle downstream jobs worden overgeslagen.
+
+### Laag 2 — In-app overlay (Blazor)
+
+De `DatabaseStatusService` pollt `/api/health` na authenticatie (elke 15 seconden, max 2 minuten).
+Het `/api/health` endpoint probeert een `SELECT 1` met 5 seconden timeout en retourneert:
+
+| `database` waarde | Betekenis |
+|---|---|
+| `online` | Database bereikbaar |
+| `paused` | Auto-paused (fout 40613); Azure begint automatisch te resumeren |
+| `timeout` | Verbinding time-out na 5 seconden |
+| `unavailable` | Andere SQL-fout |
+| `unconfigured` | Geen connection string (lokale dev zonder SQL) |
+
+**UI-gedrag:**
+- `Starting` (0–2 min): spinner-overlay "Database wordt opgestart..."
+- `LimietBereikt` (> 2 min): blokkerende overlay met uitleg + contactadvies
+- `Online`: normale app-weergave; alive-check elke 5 minuten
+
+### Laag 3 — E-mail alert (eenmalig instellen)
+
+Voer eenmalig het script uit om een gratis Resource Health Alert te maken:
+
+```powershell
+.\scripts\azure\Setup-SqlAlerts.ps1 `
+    -ResourceGroup "[sql-resource-group]" `
+    -SqlServerName "[sql-servernaam]" `
+    -DatabaseName "[database-naam]" `
+    -NotificationEmail "beheerder@[club-domein]"
+```
+
+Dit maakt aan:
+- **Action Group** met e-mailnotificatie (gratis)
+- **Resource Health Alert** voor de SQL database (gratis) — e-mail bij `Unavailable` én bij `Resolved`
+
+**Vroege waarschuwing (Metric Alert — controleer kosten eerst):**
+Azure Portal → SQL Database → Monitoring → Metrics → Metric: `Free amount remaining`
+→ New alert rule → Threshold: `10.000` (= 10% van maandlimiet).
+Controleer actuele kosten via het kostenbeleid in `CLAUDE.md` vóór aanmaken.
+
 ### Activity Log Alert aanmaken (gratis)
 
 Alert bij deploy-fout (Function App restart mislukt):

--- a/scripts/azure/Setup-SqlAlerts.ps1
+++ b/scripts/azure/Setup-SqlAlerts.ps1
@@ -11,30 +11,8 @@
     Bron: https://learn.microsoft.com/azure/azure-monitor/fundamentals/best-practices-cost#alerts
 
     TIP: Metric Alert "Free amount remaining < 10.000 vCore-seconden" (vroege waarschuwing)
-    is beschikbaar via Azure Portal → SQL Database → Metrics → New alert rule.
-    Controleer de actuele kosten in CLAUDE.md (kostenbeleid) vóór aanmaken.
-
-.PARAMETER ResourceGroup
-    Resource group van de SQL Server (bijv. "myResourceGroup").
-
-.PARAMETER SqlServerName
-    Naam van de Azure SQL Server (zonder .database.windows.net).
-
-.PARAMETER DatabaseName
-    Naam van de Azure SQL Database.
-
-.PARAMETER NotificationEmail
-    E-mailadres dat alerts ontvangt.
-
-.PARAMETER ActionGroupName
-    Naam voor de Action Group (default: "ag-sql-db-alerts").
-
-.EXAMPLE
-    .\Setup-SqlAlerts.ps1 `
-        -ResourceGroup "myResourceGroup" `
-        -SqlServerName "myserver" `
-        -DatabaseName "mydb" `
-        -NotificationEmail "beheerder@[club-domein]"
+    is beschikbaar via Azure Portal -> SQL Database -> Metrics -> New alert rule.
+    Controleer de actuele kosten in CLAUDE.md (kostenbeleid) voor aanmaken.
 #>
 param(
     [Parameter(Mandatory)][string]$ResourceGroup,
@@ -52,14 +30,16 @@ Write-Host "=== Setup-SqlAlerts.ps1 ===" -ForegroundColor Cyan
 Write-Host "Gratis Azure Monitor alerts voor Azure SQL Free-tier database"
 Write-Host ""
 
-# Verificeer login
-$account = az account show --query "{sub:id,name:name}" -o json 2>/dev/null | ConvertFrom-Json
-if (-not $account) {
+# Verificeer login — 2>$null is de PowerShell-equivalent van bash 2>/dev/null
+$accountJson = az account show --query "{sub:id,name:name}" -o json 2>$null
+if (-not $accountJson) {
     Write-Error "Niet ingelogd bij Azure CLI. Voer 'az login' uit."
     exit 1
 }
+$account = $accountJson | ConvertFrom-Json
 $SubscriptionId = $account.sub
-Write-Host "Subscription : $($account.name) ($SubscriptionId)"
+
+Write-Host "Subscription  : $($account.name) ($SubscriptionId)"
 Write-Host "Resource group: $ResourceGroup"
 Write-Host "SQL Server    : $SqlServerName"
 Write-Host "Database      : $DatabaseName"
@@ -70,43 +50,54 @@ $dbResourceId = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/pr
 
 # ── STAP 1: Action Group aanmaken (gratis) ────────────────────────────────
 Write-Host "[1/2] Action Group aanmaken..." -ForegroundColor Yellow
-$agExists = az monitor action-group show `
-    --resource-group $ResourceGroup `
-    --name $ActionGroupName `
-    --query id -o tsv 2>/dev/null
 
-if ($agExists) {
-    Write-Host "      Al aanwezig: $agExists" -ForegroundColor Green
-    $ActionGroupId = $agExists
+$agJson = az monitor action-group show --resource-group $ResourceGroup --name $ActionGroupName -o json 2>$null
+if ($agJson) {
+    $ActionGroupId = ($agJson | ConvertFrom-Json).id
+    Write-Host "      Al aanwezig: $ActionGroupId" -ForegroundColor Green
 } else {
-    $ActionGroupId = az monitor action-group create `
+    # az CLI positional syntax: --action email NAME EMAIL_ADDRESS
+    $agResult = az monitor action-group create `
         --resource-group $ResourceGroup `
         --name $ActionGroupName `
         --short-name "sqlDbAlert" `
-        --email-receiver name="Beheerder" email="$NotificationEmail" `
-        --query id -o tsv
+        --action email Beheerder $NotificationEmail `
+        -o json 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Action Group aanmaken mislukt:`n$agResult"
+        exit 1
+    }
+    $ActionGroupId = ($agResult | ConvertFrom-Json).id
     Write-Host "      Aangemaakt: $ActionGroupId" -ForegroundColor Green
+}
+
+if ([string]::IsNullOrEmpty($ActionGroupId)) {
+    Write-Error "Action Group ID is leeg — kan alert niet aanmaken."
+    exit 1
 }
 
 # ── STAP 2: Resource Health Alert voor SQL Database (gratis) ─────────────
 Write-Host "[2/2] Resource Health Alert aanmaken voor SQL Database..." -ForegroundColor Yellow
 $alertName = "sql-db-resource-health"
-$alertExists = az monitor activity-log alert show `
-    --resource-group $ResourceGroup `
-    --name $alertName `
-    --query id -o tsv 2>/dev/null
 
-if ($alertExists) {
-    Write-Host "      Al aanwezig: $alertExists" -ForegroundColor Green
+$alertJson = az monitor activity-log alert show --resource-group $ResourceGroup --name $alertName -o json 2>$null
+if ($alertJson) {
+    $AlertId = ($alertJson | ConvertFrom-Json).id
+    Write-Host "      Al aanwezig: $AlertId" -ForegroundColor Green
 } else {
-    az monitor activity-log alert create `
+    $alertResult = az monitor activity-log alert create `
         --name $alertName `
         --resource-group $ResourceGroup `
         --scope $dbResourceId `
         --condition "category=ResourceHealth" `
         --action-group $ActionGroupId `
-        --description "Waarschuwing als Azure SQL database niet beschikbaar is (incl. Free-tier limiet bereikt)"
-    Write-Host "      Resource Health Alert aangemaakt." -ForegroundColor Green
+        --description "Waarschuwing als Azure SQL database niet beschikbaar is (incl. Free-tier limiet bereikt)" `
+        -o json 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Resource Health Alert aanmaken mislukt:`n$alertResult"
+        exit 1
+    }
+    Write-Host "      Aangemaakt." -ForegroundColor Green
 }
 
 Write-Host ""
@@ -116,11 +107,11 @@ Write-Host "Alerts zijn actief. Je ontvangt een e-mail op '$NotificationEmail' a
 Write-Host "  - De database onbereikbaar wordt (bijv. Free-tier limiet bereikt)"
 Write-Host "  - De database herstelt (Resolved)"
 Write-Host ""
-Write-Host "TIP — Vroege waarschuwing (vóór limiet bereikt):" -ForegroundColor Cyan
-Write-Host "  Azure Portal → SQL Database '$DatabaseName' → Monitoring → Metrics"
-Write-Host "  Metric: 'Free amount remaining' → New alert rule → Threshold: 10.000"
-Write-Host "  Controleer kosten in CLAUDE.md (kostenbeleid) vóór aanmaken."
+Write-Host "TIP: Vroege waarschuwing (voor limiet bereikt):" -ForegroundColor Cyan
+Write-Host "  Azure Portal -> SQL Database '$DatabaseName' -> Monitoring -> Metrics"
+Write-Host "  Metric: 'Free amount remaining' -> New alert rule -> Threshold: 10.000"
+Write-Host "  Controleer kosten in CLAUDE.md (kostenbeleid) voor aanmaken."
 Write-Host ""
-Write-Host "Nieuw instellen? Voeg als GitHub variabele toe:"
+Write-Host "Vergeet niet als GitHub variabele toe te voegen:"
 Write-Host "  AZURE_SQL_DATABASE_NAME = $DatabaseName"
 Write-Host "  (vereist door db-check job in deploy.yml)"

--- a/scripts/azure/Setup-SqlAlerts.ps1
+++ b/scripts/azure/Setup-SqlAlerts.ps1
@@ -1,0 +1,126 @@
+<#
+.SYNOPSIS
+    Maakt gratis Azure Monitor alerts aan voor de Azure SQL Free-tier database.
+
+.DESCRIPTION
+    Eenmalig uitvoeren per club. Maakt aan:
+      1. Action Group met e-mailnotificatie (gratis)
+      2. Resource Health Alert voor de SQL database (gratis)
+
+    Kosten: NIETS — Resource Health Alerts zijn altijd gratis.
+    Bron: https://learn.microsoft.com/azure/azure-monitor/fundamentals/best-practices-cost#alerts
+
+    TIP: Metric Alert "Free amount remaining < 10.000 vCore-seconden" (vroege waarschuwing)
+    is beschikbaar via Azure Portal → SQL Database → Metrics → New alert rule.
+    Controleer de actuele kosten in CLAUDE.md (kostenbeleid) vóór aanmaken.
+
+.PARAMETER ResourceGroup
+    Resource group van de SQL Server (bijv. "myResourceGroup").
+
+.PARAMETER SqlServerName
+    Naam van de Azure SQL Server (zonder .database.windows.net).
+
+.PARAMETER DatabaseName
+    Naam van de Azure SQL Database.
+
+.PARAMETER NotificationEmail
+    E-mailadres dat alerts ontvangt.
+
+.PARAMETER ActionGroupName
+    Naam voor de Action Group (default: "ag-sql-db-alerts").
+
+.EXAMPLE
+    .\Setup-SqlAlerts.ps1 `
+        -ResourceGroup "myResourceGroup" `
+        -SqlServerName "myserver" `
+        -DatabaseName "mydb" `
+        -NotificationEmail "beheerder@[club-domein]"
+#>
+param(
+    [Parameter(Mandatory)][string]$ResourceGroup,
+    [Parameter(Mandatory)][string]$SqlServerName,
+    [Parameter(Mandatory)][string]$DatabaseName,
+    [Parameter(Mandatory)][string]$NotificationEmail,
+    [string]$ActionGroupName = "ag-sql-db-alerts"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+Write-Host ""
+Write-Host "=== Setup-SqlAlerts.ps1 ===" -ForegroundColor Cyan
+Write-Host "Gratis Azure Monitor alerts voor Azure SQL Free-tier database"
+Write-Host ""
+
+# Verificeer login
+$account = az account show --query "{sub:id,name:name}" -o json 2>/dev/null | ConvertFrom-Json
+if (-not $account) {
+    Write-Error "Niet ingelogd bij Azure CLI. Voer 'az login' uit."
+    exit 1
+}
+$SubscriptionId = $account.sub
+Write-Host "Subscription : $($account.name) ($SubscriptionId)"
+Write-Host "Resource group: $ResourceGroup"
+Write-Host "SQL Server    : $SqlServerName"
+Write-Host "Database      : $DatabaseName"
+Write-Host "E-mail        : $NotificationEmail"
+Write-Host ""
+
+$dbResourceId = "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroup/providers/Microsoft.Sql/servers/$SqlServerName/databases/$DatabaseName"
+
+# ── STAP 1: Action Group aanmaken (gratis) ────────────────────────────────
+Write-Host "[1/2] Action Group aanmaken..." -ForegroundColor Yellow
+$agExists = az monitor action-group show `
+    --resource-group $ResourceGroup `
+    --name $ActionGroupName `
+    --query id -o tsv 2>/dev/null
+
+if ($agExists) {
+    Write-Host "      Al aanwezig: $agExists" -ForegroundColor Green
+    $ActionGroupId = $agExists
+} else {
+    $ActionGroupId = az monitor action-group create `
+        --resource-group $ResourceGroup `
+        --name $ActionGroupName `
+        --short-name "sqlDbAlert" `
+        --email-receiver name="Beheerder" email="$NotificationEmail" `
+        --query id -o tsv
+    Write-Host "      Aangemaakt: $ActionGroupId" -ForegroundColor Green
+}
+
+# ── STAP 2: Resource Health Alert voor SQL Database (gratis) ─────────────
+Write-Host "[2/2] Resource Health Alert aanmaken voor SQL Database..." -ForegroundColor Yellow
+$alertName = "sql-db-resource-health"
+$alertExists = az monitor activity-log alert show `
+    --resource-group $ResourceGroup `
+    --name $alertName `
+    --query id -o tsv 2>/dev/null
+
+if ($alertExists) {
+    Write-Host "      Al aanwezig: $alertExists" -ForegroundColor Green
+} else {
+    az monitor activity-log alert create `
+        --name $alertName `
+        --resource-group $ResourceGroup `
+        --scope $dbResourceId `
+        --condition "category=ResourceHealth" `
+        --action-group $ActionGroupId `
+        --description "Waarschuwing als Azure SQL database niet beschikbaar is (incl. Free-tier limiet bereikt)"
+    Write-Host "      Resource Health Alert aangemaakt." -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "=== Klaar ===" -ForegroundColor Green
+Write-Host ""
+Write-Host "Alerts zijn actief. Je ontvangt een e-mail op '$NotificationEmail' als:"
+Write-Host "  - De database onbereikbaar wordt (bijv. Free-tier limiet bereikt)"
+Write-Host "  - De database herstelt (Resolved)"
+Write-Host ""
+Write-Host "TIP — Vroege waarschuwing (vóór limiet bereikt):" -ForegroundColor Cyan
+Write-Host "  Azure Portal → SQL Database '$DatabaseName' → Monitoring → Metrics"
+Write-Host "  Metric: 'Free amount remaining' → New alert rule → Threshold: 10.000"
+Write-Host "  Controleer kosten in CLAUDE.md (kostenbeleid) vóór aanmaken."
+Write-Host ""
+Write-Host "Nieuw instellen? Voeg als GitHub variabele toe:"
+Write-Host "  AZURE_SQL_DATABASE_NAME = $DatabaseName"
+Write-Host "  (vereist door db-check job in deploy.yml)"


### PR DESCRIPTION
## Summary

- `/api/health` retourneert nu ook `database`-status via `SELECT 1` met 5s timeout; error 40613 triggert automatisch Azure SQL auto-resume
- `DatabaseStatusService` pollt het health endpoint na authenticatie (elke 15s, max 2 min) en publiceert DB-state naar `App.razor`
- Blazor toont een blokkerende overlay als de database niet online is: spinner ("wordt opgestart") of foutmelding ("maandlimiet bereikt") — geen eindeloze "Laden..." spinners meer
- **Nieuw: `db-check` job** in `deploy.yml` als allereerste stap — controleert database-status via Azure ARM API vóór build, migratie én Blazor-deploy. Volledige pipeline blokkeert als DB niet `Online` is
- `scripts/azure/Setup-SqlAlerts.ps1`: eenmalig script voor gratis Resource Health Alert (e-mail bij database Unavailable/Resolved)
- `docs/MONITORING.md` bijgewerkt met drie-lagen beschermingsdocumentatie

## Vereiste actie na merge

Voeg als GitHub repository variabele toe (Settings → Secrets and variables → Actions → Variables):
```
AZURE_SQL_DATABASE_NAME = [database-naam]
```
Dit activeert de `db-check` job. Zonder deze variabele wordt de job overgeslagen (backward compatible).

Voer eenmalig het alerts script uit voor e-mail notificaties:
```powershell
.\scripts\azure\Setup-SqlAlerts.ps1 `
    -ResourceGroup "[sql-resource-group]" `
    -SqlServerName "[sql-servernaam]" `
    -DatabaseName "[database-naam]" `
    -NotificationEmail "beheerder@[club-domein]"
```

## Test plan

- [ ] Health endpoint retourneert `database: "online"` als DB bereikbaar is
- [ ] Blazor-overlay verschijnt niet als DB online is (normaal gebruik ongewijzigd)
- [ ] `db-check` job slaagt bij online database; pipeline loopt door
- [ ] Bij handmatig pauzeren van de DB: `db-check` faalt en pipeline stopt (build/blazor niet uitgevoerd)
- [ ] Overlay toont "wordt opgestart" direct na DB-pause; na 2 min "maandlimiet bereikt"

🤖 Generated with [Claude Code](https://claude.com/claude-code)