### PR TITLE
security(#420,#423,#425): AVG-fixes EmailProcessor — FoutMelding, cold-start, fout-sanitizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ### Security
 - SSRF-bescherming `POST /api/beheer/theme/extract` vervangen door domein-allowlist op basis van `ThemeClubWebsiteUrl` uit AppSettings. Elimineert TOCTOU/DNS-rebinding volledig — geen DNS-lookup meer nodig. (#422, sluit ook #421)
+- `sp_CleanupEmailVerwerking` fase-1 anonimisering uitgebreid met `[FoutMelding] = NULL` — voorkomt dat exception-tekst (mogelijk met PII) langer dan 30 dagen bewaard blijft. (#420)
+- `UpdateFoutAsync` slaat foutmeldingen nu op via `SanitizeFoutMelding()` — verwijdert e-mailadressen en knipt af op 200 tekens vóór DB-opslag. (#420)
+- Uitsluitingslijst wordt nu geladen vóór eerste AI-classificatie (fail-closed). Op cold start wordt de database gewekt en de lijst opgehaald; lukt dat niet, dan worden mails niet naar AI gestuurd. (#423)
+- Noodmails (database + OpenAI quota) bevatten geen ruwe `ex.Message` meer — worden vervangen door privacy-safe foutcategorie via `CategorizeerFout()`. (#425)
 
 ### Changed
 - `docs/DEVELOPER-SETUP.md`: volledig herschreven voor v2.7 — Visual Studio/F5-workflow vervangen door `Start-Debug.ps1` + `Test-App.ps1`, BlazorAdmin-setup toegevoegd (poort 5242, `dotnet watch`), .NET 9 runtime als vereiste gedocumenteerd, fingerprint-veiligheidsregel toegevoegd, oplossing-naam gecorrigeerd naar `sportlink-wedstrijdzaken.sln`. Sluit issue #394.

--- a/Database/planner/System Stored Procedures/sp_CleanupEmailVerwerking.sql
+++ b/Database/planner/System Stored Procedures/sp_CleanupEmailVerwerking.sql
@@ -5,7 +5,7 @@ BEGIN
 
     -- Fase 1: anonimiseer PII in rijen van 30-90 dagen oud
     -- Afzender en Onderwerp zijn NOT NULL → vervangen door placeholder.
-    -- Nullbare velden worden op NULL gezet.
+    -- Nullbare velden worden op NULL gezet, inclusief FoutMelding (#420).
     UPDATE [planner].[EmailVerwerking]
     SET [Afzender]          = '[geanonimiseerd]',
         [Onderwerp]         = '[geanonimiseerd]',
@@ -14,6 +14,7 @@ BEGIN
         [AntwoordEmail]     = NULL,
         [PlannerResponse]   = NULL,
         [GeextraheerdeData] = NULL,
+        [FoutMelding]       = NULL,
         [mta_modified]      = GETUTCDATE()
     WHERE [mta_inserted] < DATEADD(DAY, -30, GETUTCDATE())
       AND [mta_inserted] >= DATEADD(DAY, -90, GETUTCDATE())
@@ -21,7 +22,8 @@ BEGIN
            OR [EmailBody] IS NOT NULL
            OR [AntwoordEmail] IS NOT NULL
            OR [PlannerResponse] IS NOT NULL
-           OR [GeextraheerdeData] IS NOT NULL);
+           OR [GeextraheerdeData] IS NOT NULL
+           OR [FoutMelding] IS NOT NULL);
 
     -- Fase 2: verwijder rijen ouder dan 90 dagen
     DELETE FROM [planner].[EmailVerwerking]

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -12,9 +12,9 @@ public class EmailProcessorFunction
 {
     private static bool _databaseNoodmailVerstuurd;
     private static DateTime? _openAiQuotaNoodmailVerstuurdenOp;
-    // Uitsluitingslijst-cache: geladen in fase 2, hergebruikt in fase 1 van volgende polls.
-    // Leeg bij koude start — eerste poll classificeert alles via AI (acceptabel).
+    // Uitsluitingslijst-cache: geladen vóór eerste AI-classificatie (fail-closed bij cold start). (#423)
     private static HashSet<string> _uitgeslotenCache = new(StringComparer.OrdinalIgnoreCase);
+    private static bool _uitgeslotenCacheGeladen;
 
     [Function("ProcessIncomingEmails")]
     public async Task Run(
@@ -77,7 +77,37 @@ public class EmailProcessorFunction
             return;
         }
 
-        // AI-classificatie voor alle resterende emails — database wordt nog niet gewekt
+        // Fail-closed: uitsluitingslijst moet geladen zijn vóór AI-classificatie. (#423)
+        // Op cold start: probeer DB te wekken en lijst te laden. Lukt dat niet → return.
+        if (!_uitgeslotenCacheGeladen)
+        {
+            log.LogInformation("Uitsluitingslijst nog niet geladen (cold start) — laden vóór AI-classificatie");
+            try
+            {
+                await SystemUtilities.WaitForDatabaseAsync(log);
+                await SystemUtilities.AppSettings.LoadSettingsAsync(log);
+                _uitgeslotenCache = await LaadUitgeslotenAdressenAsync(log);
+                _uitgeslotenCacheGeladen = true;
+                // Re-filter met de nu geladen lijst — verwijder eerder doorgelaten uitgesloten adressen
+                teClassificeren = teClassificeren
+                    .Where(e => !_uitgeslotenCache.Contains(e.Afzender))
+                    .ToList();
+                log.LogInformation("Uitsluitingslijst geladen op cold start: {Aantal} adressen", _uitgeslotenCache.Count);
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "Uitsluitingslijst niet beschikbaar — AI-verwerking uitgesteld (fail-closed)");
+                return;
+            }
+        }
+
+        if (teClassificeren.Count == 0)
+        {
+            log.LogInformation("Alle emails gefilterd na uitsluitingslijst-check");
+            return;
+        }
+
+        // AI-classificatie voor alle resterende emails — database wordt niet nogmaals gewekt
         var aiService = new BerichtAiService(loggerFactory.CreateLogger<BerichtAiService>());
         var classificaties = new List<(InkomendBericht Email, BerichtClassificatie Classificatie)>();
         var aiAborted = false;
@@ -97,7 +127,7 @@ public class EmailProcessorFunction
                 if (_openAiQuotaNoodmailVerstuurdenOp == null
                     || (DateTime.UtcNow - _openAiQuotaNoodmailVerstuurdenOp.Value).TotalHours >= 24)
                 {
-                    await StuurOpenAiNoodmailAsync(graphService, ex.Message, log);
+                    await StuurOpenAiNoodmailAsync(graphService, CategorizeerFout(ex), log);
                 }
                 else
                 {
@@ -159,7 +189,7 @@ public class EmailProcessorFunction
             if (!_databaseNoodmailVerstuurd)
             {
                 log.LogError(dbEx, "Database niet beschikbaar — stuur noodmail");
-                await StuurDatabaseNoodmailAsync(graphService, teVerwerken.Count, dbEx.Message, log);
+                await StuurDatabaseNoodmailAsync(graphService, teVerwerken.Count, CategorizeerFout(dbEx), log);
             }
             else
             {
@@ -170,6 +200,7 @@ public class EmailProcessorFunction
 
         // Refresh uitsluitingslijst nu DB wakker is — cache bijwerken voor volgende polls
         _uitgeslotenCache = await LaadUitgeslotenAdressenAsync(log);
+        _uitgeslotenCacheGeladen = true;
 
         int verwerkt = 0, fouten = 0;
 
@@ -185,7 +216,7 @@ public class EmailProcessorFunction
                 fouten++;
                 log.LogError(ex, "Fout bij verwerken van email {MessageId} (onderwerp niet gelogd — AVG #210)",
                     email.MessageId);
-                try { await UpdateFoutAsync(email.MessageId, ex.Message); }
+                try { await UpdateFoutAsync(email.MessageId, SanitizeFoutMelding(ex.Message)); }
                 catch { /* fout bij fout-logging mag niet cascaderen */ }
             }
         }
@@ -443,6 +474,36 @@ public class EmailProcessorFunction
         var msg = ex.Message + (ex.InnerException?.Message ?? "");
         return msg.Contains("insufficient_quota", StringComparison.OrdinalIgnoreCase)
             || msg.Contains("429", StringComparison.Ordinal);
+    }
+
+    // Categoriseert een exception naar een privacy-safe foutomschrijving. (#425)
+    // Nooit ruwe ex.Message in noodmails of externe output — kan PII bevatten.
+    private static string CategorizeerFout(Exception ex)
+    {
+        var msg = (ex.Message + (ex.InnerException?.Message ?? "")).ToLowerInvariant();
+        if (msg.Contains("insufficient_quota") || msg.Contains("429"))
+            return "OpenAI quota overschreden";
+        if (msg.Contains("login failed") || msg.Contains("cannot open database") || msg.Contains("connection"))
+            return "Database niet beschikbaar";
+        if (msg.Contains("404") || msg.Contains("resourcenotfound") || msg.Contains("not found"))
+            return "Graph API: bericht niet gevonden";
+        if (msg.Contains("401") || msg.Contains("unauthorized") || msg.Contains("403") || msg.Contains("forbidden"))
+            return "Graph API: autorisatiefout";
+        if (msg.Contains("timeout") || msg.Contains("timed out"))
+            return "Time-out bij externe service";
+        return "Onverwachte verwerkingsfout";
+    }
+
+    // Sanitiseert een foutmelding voor opslag in de DB — verwijdert e-mailadressen en knipt af. (#420)
+    private static string SanitizeFoutMelding(string message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+            return "Onbekende fout";
+        var gesaneerd = System.Text.RegularExpressions.Regex.Replace(
+            message,
+            @"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}",
+            "[e-mail]");
+        return gesaneerd.Length > 200 ? gesaneerd[..200] + "…" : gesaneerd;
     }
 
     private static async Task StuurOpenAiNoodmailAsync(


### PR DESCRIPTION
## Samenvatting

Drie gerelateerde AVG/security-fixes in de email-processor en cleanup-stored-procedure.

**#420 — FoutMelding anonimisering + ex.Message sanitize:**
- `sp_CleanupEmailVerwerking` fase-1: `[FoutMelding] = NULL` toegevoegd
- `SanitizeFoutMelding()` helper: verwijdert e-mailadressen, knipt af op 200 tekens
- `UpdateFoutAsync` gebruikt nu `SanitizeFoutMelding(ex.Message)` i.p.v. ruwe `ex.Message`

**#423 — Uitsluitingslijst vóór AI (fail-closed):**
- `_uitgeslotenCacheGeladen` flag toegevoegd
- Op cold start: DB wekken + AppSettings laden + uitsluitingslijst ophalen vóór AI
- Als dat mislukt: return (mails blijven ongelezen voor volgende poll)
- Comment "Leeg bij koude start — eerste poll classificeert alles via AI" verwijderd

**#425 — Noodmails zonder ruwe ex.Message:**
- `CategorizeerFout()` helper: categoriseert exceptions naar privacy-safe strings
- `StuurOpenAiNoodmailAsync` en `StuurDatabaseNoodmailAsync` gebruiken `CategorizeerFout(ex)`

## Closes
- Closes #420
- Closes #423
- Closes #425

🤖 Generated with [Claude Code](https://claude.ai/claude-code)