### PR TITLE
security(#424,#426): AVG-cleanup ClassificatieCorrectie + ImportLog retentie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - `UpdateFoutAsync` slaat foutmeldingen nu op via `SanitizeFoutMelding()` — verwijdert e-mailadressen en knipt af op 200 tekens vóór DB-opslag. (#420)
 - Uitsluitingslijst wordt nu geladen vóór eerste AI-classificatie (fail-closed). Op cold start wordt de database gewekt en de lijst opgehaald; lukt dat niet, dan worden mails niet naar AI gestuurd. (#423)
 - Noodmails (database + OpenAI quota) bevatten geen ruwe `ex.Message` meer — worden vervangen door privacy-safe foutcategorie via `CategorizeerFout()`. (#425)
+- Nieuwe `sp_CleanupClassificatieCorrectie`: anonimiseert samenvattingen na 30 dagen, verwijdert na 90 dagen. Lost FK-blokkade op die de EmailVerwerking-cleanup kon laten falen. Aanroepvolgorde geborgd: correcties vóór email-verwerking. (#424)
+- Nieuwe `sp_CleanupImportLog`: anonimiseert `ImporterendeDoor` + `CsvBestand` na 90 dagen, verwijdert rijen na 1 jaar. Opgenomen in de maandelijkse teambegeleiding-cleanup. (#426)
 
 ### Changed
 - `docs/DEVELOPER-SETUP.md`: volledig herschreven voor v2.7 — Visual Studio/F5-workflow vervangen door `Start-Debug.ps1` + `Test-App.ps1`, BlazorAdmin-setup toegevoegd (poort 5242, `dotnet watch`), .NET 9 runtime als vereiste gedocumenteerd, fingerprint-veiligheidsregel toegevoegd, oplossing-naam gecorrigeerd naar `sportlink-wedstrijdzaken.sln`. Sluit issue #394.

--- a/Database/avg/System Stored Procedures/sp_CleanupImportLog.sql
+++ b/Database/avg/System Stored Procedures/sp_CleanupImportLog.sql
@@ -1,0 +1,19 @@
+CREATE PROCEDURE [avg].[sp_CleanupImportLog]
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    -- Fase 1: anonimiseer PII in records ouder dan 90 dagen
+    -- ImporterendeDoor is een persoonsgegeven (Entra display name).
+    -- CsvBestand kan herleidbare info bevatten.
+    UPDATE [avg].[ImportLog]
+    SET [ImporterendeDoor] = NULL,
+        [CsvBestand]       = NULL
+    WHERE [ImportDatum] < DATEADD(DAY, -90, GETUTCDATE())
+      AND ([ImporterendeDoor] IS NOT NULL
+           OR [CsvBestand] IS NOT NULL);
+
+    -- Fase 2: verwijder records ouder dan 1 jaar (gelijk aan avg.Teambegeleiding-retentie)
+    DELETE FROM [avg].[ImportLog]
+    WHERE [ImportDatum] < DATEADD(YEAR, -1, GETUTCDATE());
+END;

--- a/Database/planner/System Stored Procedures/sp_CleanupClassificatieCorrectie.sql
+++ b/Database/planner/System Stored Procedures/sp_CleanupClassificatieCorrectie.sql
@@ -1,0 +1,23 @@
+CREATE PROCEDURE [planner].[sp_CleanupClassificatieCorrectie]
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    -- VEREISTE AANROEPVOLGORDE: deze SP moet worden aangeroepen VÓÓR sp_CleanupEmailVerwerking.
+    -- ClassificatieCorrectie heeft FK naar EmailVerwerking — verwijdering van rijen uit
+    -- EmailVerwerking faalt als refererende correcties nog bestaan.
+
+    -- Fase 1: anonimiseer samenvattingen in records 30-90 dagen oud
+    UPDATE [planner].[ClassificatieCorrectie]
+    SET [OrigineleSamenvatting] = NULL,
+        [CorrectieSamenvatting] = NULL,
+        [mta_modified]          = GETUTCDATE()
+    WHERE [mta_inserted] < DATEADD(DAY, -30, GETUTCDATE())
+      AND [mta_inserted] >= DATEADD(DAY, -90, GETUTCDATE())
+      AND ([OrigineleSamenvatting] IS NOT NULL
+           OR [CorrectieSamenvatting] IS NOT NULL);
+
+    -- Fase 2: verwijder records ouder dan 90 dagen
+    DELETE FROM [planner].[ClassificatieCorrectie]
+    WHERE [mta_inserted] < DATEADD(DAY, -90, GETUTCDATE());
+END;

--- a/FunctionApp/Email/CleanupEmailVerwerkingFunction.cs
+++ b/FunctionApp/Email/CleanupEmailVerwerkingFunction.cs
@@ -12,7 +12,7 @@ public static class CleanupEmailVerwerkingFunction
         FunctionContext context)
     {
         var log = context.GetLogger("CleanupEmailVerwerking");
-        log.LogInformation("AVG-cleanup gestart: planner.EmailVerwerking (30d anonimiseren, 90d verwijderen)");
+        log.LogInformation("AVG-cleanup gestart: ClassificatieCorrectie + EmailVerwerking");
 
         try
         {
@@ -22,16 +22,28 @@ public static class CleanupEmailVerwerkingFunction
             await using var conn = new SqlConnection(connStr);
             await conn.OpenAsync();
 
-            await using var cmd = conn.CreateCommand();
-            cmd.CommandText = "EXEC [planner].[sp_CleanupEmailVerwerking]";
-            cmd.CommandTimeout = 120;
-            await cmd.ExecuteNonQueryAsync();
+            // Volgorde is kritiek: ClassificatieCorrectie heeft FK naar EmailVerwerking.
+            // ClassificatieCorrectie eerst opruimen zodat de DELETE op EmailVerwerking niet
+            // faalt door een referentie-constraint. (#424)
+            await using (var cmd1 = conn.CreateCommand())
+            {
+                cmd1.CommandText = "EXEC [planner].[sp_CleanupClassificatieCorrectie]";
+                cmd1.CommandTimeout = 120;
+                await cmd1.ExecuteNonQueryAsync();
+                log.LogInformation("AVG-cleanup ClassificatieCorrectie geslaagd");
+            }
 
-            log.LogInformation("AVG-cleanup EmailVerwerking geslaagd");
+            await using (var cmd2 = conn.CreateCommand())
+            {
+                cmd2.CommandText = "EXEC [planner].[sp_CleanupEmailVerwerking]";
+                cmd2.CommandTimeout = 120;
+                await cmd2.ExecuteNonQueryAsync();
+                log.LogInformation("AVG-cleanup EmailVerwerking geslaagd");
+            }
         }
         catch (Exception ex)
         {
-            log.LogError(ex, "AVG-cleanup EmailVerwerking mislukt");
+            log.LogError(ex, "AVG-cleanup EmailVerwerking/ClassificatieCorrectie mislukt");
             throw;
         }
     }

--- a/FunctionApp/Email/CleanupTeambegeleidingFunction.cs
+++ b/FunctionApp/Email/CleanupTeambegeleidingFunction.cs
@@ -12,7 +12,7 @@ public static class CleanupTeambegeleidingFunction
         FunctionContext context)
     {
         var log = context.GetLogger("CleanupTeambegeleiding");
-        log.LogInformation("AVG-cleanup gestart: avg.Teambegeleiding (rijen ouder dan 1 jaar verwijderen)");
+        log.LogInformation("AVG-cleanup gestart: avg.Teambegeleiding + avg.ImportLog");
 
         try
         {
@@ -22,16 +22,26 @@ public static class CleanupTeambegeleidingFunction
             await using var conn = new SqlConnection(connStr);
             await conn.OpenAsync();
 
-            await using var cmd = conn.CreateCommand();
-            cmd.CommandText = "EXEC [avg].[sp_CleanupTeambegeleiding]";
-            cmd.CommandTimeout = 120;
-            await cmd.ExecuteNonQueryAsync();
+            await using (var cmd1 = conn.CreateCommand())
+            {
+                cmd1.CommandText = "EXEC [avg].[sp_CleanupTeambegeleiding]";
+                cmd1.CommandTimeout = 120;
+                await cmd1.ExecuteNonQueryAsync();
+                log.LogInformation("AVG-cleanup Teambegeleiding geslaagd");
+            }
 
-            log.LogInformation("AVG-cleanup Teambegeleiding geslaagd");
+            // ImportLog: anonimiseer ImporterendeDoor + CsvBestand na 90d, verwijder na 1 jaar. (#426)
+            await using (var cmd2 = conn.CreateCommand())
+            {
+                cmd2.CommandText = "EXEC [avg].[sp_CleanupImportLog]";
+                cmd2.CommandTimeout = 120;
+                await cmd2.ExecuteNonQueryAsync();
+                log.LogInformation("AVG-cleanup ImportLog geslaagd");
+            }
         }
         catch (Exception ex)
         {
-            log.LogError(ex, "AVG-cleanup Teambegeleiding mislukt");
+            log.LogError(ex, "AVG-cleanup Teambegeleiding/ImportLog mislukt");
             throw;
         }
     }


### PR DESCRIPTION
## Samenvatting

**#424 — ClassificatieCorrectie cleanup + FK-blokkade fix:**
- `sp_CleanupClassificatieCorrectie` aangemaakt: fase-1 anonimisering (30d) + fase-2 verwijdering (90d)
- `CleanupEmailVerwerkingFunction` roept ClassificatieCorrectie-SP nu vóór EmailVerwerking aan — voorkomt FK-constraint-fout
- Aanroepvolgorde geborgd met commentaar

**#426 — ImportLog retentie:**
- `sp_CleanupImportLog` aangemaakt: ImporterendeDoor + CsvBestand anonimiseren na 90d, verwijderen na 1 jaar
- `CleanupTeambegeleidingFunction` uitgebreid met ImportLog-cleanup

## Closes
- Closes #424
- Closes #426

🤖 Generated with [Claude Code](https://claude.ai/claude-code)