### PR TITLE
security(#427): PII-gate feedbackwidget

### DIFF
--- a/BlazorAdmin/Shared/FeedbackWidget.razor
+++ b/BlazorAdmin/Shared/FeedbackWidget.razor
@@ -77,6 +77,9 @@
                         <button type="button" class="btn-close" @onclick="Sluit"></button>
                     </div>
                     <div class="modal-body">
+                        <div class="alert alert-warning py-2 small mb-3">
+                            ⚠️ Voeg geen persoonsgegevens toe (e-mailadressen, telefoonnummers). Feedback wordt gepubliceerd als GitHub issue.
+                        </div>
                         <p class="text-muted small mb-3">
                             Dit wordt als melding doorgestuurd naar de ontwikkelaar als GitHub issue.
                         </p>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Noodmails (database + OpenAI quota) bevatten geen ruwe `ex.Message` meer — worden vervangen door privacy-safe foutcategorie via `CategorizeerFout()`. (#425)
 - Nieuwe `sp_CleanupClassificatieCorrectie`: anonimiseert samenvattingen na 30 dagen, verwijdert na 90 dagen. Lost FK-blokkade op die de EmailVerwerking-cleanup kon laten falen. Aanroepvolgorde geborgd: correcties vóór email-verwerking. (#424)
 - Nieuwe `sp_CleanupImportLog`: anonimiseert `ImporterendeDoor` + `CsvBestand` na 90 dagen, verwijdert rijen na 1 jaar. Opgenomen in de maandelijkse teambegeleiding-cleanup. (#426)
+- Feedbackwidget blokkeert nu submissions met e-mailadressen of telefoonnummers (HTTP 422) vóór GitHub-publicatie. Overzichtsstap toont waarschuwing over publieke GitHub-publicatie. (#427)
 
 ### Changed
 - `docs/DEVELOPER-SETUP.md`: volledig herschreven voor v2.7 — Visual Studio/F5-workflow vervangen door `Start-Debug.ps1` + `Test-App.ps1`, BlazorAdmin-setup toegevoegd (poort 5242, `dotnet watch`), .NET 9 runtime als vereiste gedocumenteerd, fingerprint-veiligheidsregel toegevoegd, oplossing-naam gecorrigeerd naar `sportlink-wedstrijdzaken.sln`. Sluit issue #394.

--- a/FunctionApp/Feedback/FeedbackFunction.cs
+++ b/FunctionApp/Feedback/FeedbackFunction.cs
@@ -108,6 +108,17 @@ public static class FeedbackFunction
             var labels = KiesLabels(dto.Type);
             var title = Sanitize(structured.Title, 80);
 
+            // PII-gate: blokkeer publicatie als beschrijving of antwoorden persoonsgegevens bevatten. (#427)
+            var teChecken = dto.Beschrijving + " " + string.Join(" ",
+                dto.VragenAntwoorden?.Select(qa => qa.Antwoord ?? "") ?? []);
+            if (BevatPii(teChecken))
+            {
+                log.LogWarning("Feedback geblokkeerd: PII gedetecteerd in submission");
+                return new ObjectResult(new {
+                    error = "Feedback bevat mogelijk persoonsgegevens. Verwijder e-mailadressen en telefoonnummers en probeer opnieuw."
+                }) { StatusCode = 422 };
+            }
+
             var (issueNummer, issueUrl) = await MaakGitHubIssueAsync(pat, owner, repo, title, issueBody, labels, log);
 
             return new OkObjectResult(new { issueNummer, issueUrl });
@@ -366,6 +377,20 @@ public static class FeedbackFunction
         foreach (var qa in qaList)
             sb.AppendLine($"- {Sanitize(qa.Vraag, 200)}: {Sanitize(qa.Antwoord, 500)}");
         return sb.ToString();
+    }
+
+    // PII-gate: detecteert e-mailadressen en Nederlandse telefoonnummers. (#427)
+    // Blokkeert publicatie naar GitHub als mogelijke persoonsgegevens aanwezig zijn.
+    private static bool BevatPii(string tekst)
+    {
+        if (string.IsNullOrWhiteSpace(tekst)) return false;
+        if (System.Text.RegularExpressions.Regex.IsMatch(tekst,
+            @"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}"))
+            return true;
+        if (System.Text.RegularExpressions.Regex.IsMatch(tekst,
+            @"(\+31|0031|06)[\s\-]?\d{2}[\s\-]?\d{6,8}|0\d{1,2}[\s\-]\d{6,8}"))
+            return true;
+        return false;
     }
 
     private static string Sanitize(string? input, int maxLen)


### PR DESCRIPTION
## Samenvatting
- `BevatPii()` helper: detecteert e-mailadressen + NL-telefoonnummers via regex
- `FeedbackSubmit`: blokkeert bij PII-detectie vóór `MaakGitHubIssueAsync` (HTTP 422)
- `FeedbackWidget.razor`: waarschuwingsbanner op Overzicht-stap

## Opmerking
IChatClient-refactor (directe `OpenAI.Chat.ChatClient` → `Microsoft.Extensions.AI.IChatClient`) is apart ondergebracht in #429.

## Closes
- Closes #427

🤖 Generated with [Claude Code](https://claude.ai/claude-code)