### PR TITLE
security(#436,#437): clientId redactie logs + appsettings-log verwijderen

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -217,8 +217,7 @@ jobs:
             -e "s|{{POST_LOGOUT_REDIRECT_URL}}|${POST_LOGOUT_REDIRECT_URL}|g" \
             BlazorAdmin/wwwroot/appsettings.Production.template.json \
             > BlazorAdmin/wwwroot/appsettings.Production.json
-          echo "Gegenereerd:"
-          cat BlazorAdmin/wwwroot/appsettings.Production.json
+          echo "appsettings.Production.json gegenereerd (inhoud niet gelogd — bevat tenant/client IDs)"
 
       - name: Blazor WASM publiceren
         if: steps.check.outputs.skip == 'false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Nieuwe `sp_CleanupClassificatieCorrectie`: anonimiseert samenvattingen na 30 dagen, verwijdert na 90 dagen. Lost FK-blokkade op die de EmailVerwerking-cleanup kon laten falen. Aanroepvolgorde geborgd: correcties vóór email-verwerking. (#424)
 - Nieuwe `sp_CleanupImportLog`: anonimiseert `ImporterendeDoor` + `CsvBestand` na 90 dagen, verwijdert rijen na 1 jaar. Opgenomen in de maandelijkse teambegeleiding-cleanup. (#426)
 - Feedbackwidget blokkeert nu submissions met e-mailadressen of telefoonnummers (HTTP 422) vóór GitHub-publicatie. Overzichtsstap toont waarschuwing over publieke GitHub-publicatie. (#427)
+- `Function1.cs` logt geen volledige Sportlink API-URLs meer — `clientId=` queryparameter verdwijnt uit Application Insights logs. (#436)
+- `GitHubIssueReporter.SanitizeForPublic` redigeert nu ook URL query-parameters (`clientId`, `code`, `token`, `key`, `secret`). (#436)
+- `deploy.yml`: `cat appsettings.Production.json` verwijderd — tenant/client IDs verschijnen niet meer in workflow-logs. (#437)
 
 ### Changed
 - `docs/DEVELOPER-SETUP.md`: volledig herschreven voor v2.7 — Visual Studio/F5-workflow vervangen door `Start-Debug.ps1` + `Test-App.ps1`, BlazorAdmin-setup toegevoegd (poort 5242, `dotnet watch`), .NET 9 runtime als vereiste gedocumenteerd, fingerprint-veiligheidsregel toegevoegd, oplossing-naam gecorrigeerd naar `sportlink-wedstrijdzaken.sln`. Sluit issue #394.

--- a/FunctionApp/Function1.cs
+++ b/FunctionApp/Function1.cs
@@ -120,7 +120,7 @@ namespace SportlinkFunction
             // Fetch and store Teams data
             ApiUrl = $"{sportlinkApiUrl}/teams?{sportlinkClientId}";
             await FetchAndStoreTeamsData(ApiUrl, log);
-            log.LogInformation($"TEAMS - GET: {ApiUrl}");
+            log.LogInformation("TEAMS - GET endpoint=/teams");
 
             // Drop and create staging table
             await CreateStagingTable.ExecuteAsync("matches");
@@ -132,7 +132,7 @@ namespace SportlinkFunction
             {
                 ApiUrl = $"{sportlinkApiUrl}/programma?{sportlinkClientId}&weekoffset={weekOffset}";
                 await FetchAndStoreProgrammaMatches(ApiUrl, log);
-                log.LogInformation($"MATCHES/PROGRAMMA - GET {ApiUrl}");
+                log.LogInformation("MATCHES/PROGRAMMA - GET endpoint=/programma weekOffset={WeekOffset}", weekOffset);
             }
 
             // Step 2: /uitslagen — fetch past weeks only for scores (uitslag, uitslag-regulier, etc.)
@@ -143,7 +143,7 @@ namespace SportlinkFunction
             {
                 ApiUrl = $"{sportlinkApiUrl}/uitslagen?{sportlinkClientId}&weekoffset={weekOffset}";
                 await FetchAndStoreUitslagenScores(ApiUrl, log);
-                log.LogInformation($"MATCHES/UITSLAGEN - GET {ApiUrl}");
+                log.LogInformation("MATCHES/UITSLAGEN - GET endpoint=/uitslagen weekOffset={WeekOffset}", weekOffset);
             }
             // Drop and create staging table
             await CreateStagingTable.ExecuteAsync("matchdetails");
@@ -153,7 +153,7 @@ namespace SportlinkFunction
             {
                 ApiUrl = $"{sportlinkApiUrl}/wedstrijd-informatie?{sportlinkClientId}&wedstrijdcode={wedstrijdcode}";
                 await FetchAndStoreMatchDetails(ApiUrl, log);
-                log.LogInformation($"MATCHDETAILS - GET: {ApiUrl}");
+                log.LogInformation("MATCHDETAILS - GET endpoint=/wedstrijd-informatie wedstrijdcode={Wedstrijdcode}", wedstrijdcode);
             }
             // Merge staging data into history tables
             await new MergeStgToHis("stg", "teams",        "his", "teams").ExecuteAsync(log);

--- a/FunctionApp/Infrastructure/GitHubIssueReporter.cs
+++ b/FunctionApp/Infrastructure/GitHubIssueReporter.cs
@@ -206,11 +206,16 @@ public static class GitHubIssueReporter
     }
 
     // Verwijdert PII en club-specifieke gegevens voordat tekst in publieke GitHub issues terechtkomt.
-    // Sanitiseert: e-mailadressen, GUIDs, SQL-connectiestring-fragmenten, datums, getallen.
+    // Sanitiseert: e-mailadressen, GUIDs, SQL-connectiestring-fragmenten, URL queryparameters, datums, getallen.
     private static string SanitizeForPublic(string? text)
     {
         if (string.IsNullOrEmpty(text)) return "";
         var s = text;
+        // URL query-parameters met gevoelige namen — clientId, code, token, key, secret (#436)
+        s = System.Text.RegularExpressions.Regex.Replace(s,
+            @"([?&](clientId|code|token|key|secret|apikey|client_secret|client_id)=)[^&\s""'<>]+",
+            "$1<redacted>",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
         // E-mailadressen
         s = System.Text.RegularExpressions.Regex.Replace(s,
             @"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}", "<email>");


### PR DESCRIPTION
## Samenvatting

**#436 — clientId redactie uit logs:**
- `Function1.cs`: 4 log-statements vervangen door endpoint-naam zonder queryparameters
- `GitHubIssueReporter.SanitizeForPublic`: URL query-parameters (`clientId`, `code`, `token`, `key`, `secret`) worden nu geredigeerd naar `<redacted>`

**#437 — appsettings-log verwijderd:**
- `cat appsettings.Production.json` verwijderd uit deploy.yml
- tenant/client IDs verschijnen niet meer in workflow-logs

**Opmerking #437 OIDC:** De migratie van `AZURE_CREDENTIALS` naar GitHub OIDC federated credentials vereist Azure Portal-setup door de eigenaar (az ad app federated-credential create). Dit is een handmatige stap die buiten de scope van code-wijzigingen valt. Beschreven in #437.

## Closes
- Closes #436
- Partially closes #437 (appsettings-log gereed; OIDC-migratie wacht op Azure Portal-setup)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)