### PR TITLE
security(#433): planner-endpoints naar Easy Auth + RequireAdmin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - `Function1.cs` logt geen volledige Sportlink API-URLs meer — `clientId=` queryparameter verdwijnt uit Application Insights logs. (#436)
 - `GitHubIssueReporter.SanitizeForPublic` redigeert nu ook URL query-parameters (`clientId`, `code`, `token`, `key`, `secret`). (#436)
 - `deploy.yml`: `cat appsettings.Production.json` verwijderd — tenant/client IDs verschijnen niet meer in workflow-logs. (#437)
+- 7 planner-endpoints gemigreerd van `AuthorizationLevel.Function` naar `Anonymous` + `EasyAuthHelper.RequireAdmin()`: CheckAvailability, DoordeweeksBeschikbaar, BevestigWedstrijd, ZoekWedstrijd, HerplanCheck, HerplanBevestig, GetTeamSchedule. (#433)
 
 ### Changed
 - `docs/DEVELOPER-SETUP.md`: volledig herschreven voor v2.7 — Visual Studio/F5-workflow vervangen door `Start-Debug.ps1` + `Test-App.ps1`, BlazorAdmin-setup toegevoegd (poort 5242, `dotnet watch`), .NET 9 runtime als vereiste gedocumenteerd, fingerprint-veiligheidsregel toegevoegd, oplossing-naam gecorrigeerd naar `sportlink-wedstrijdzaken.sln`. Sluit issue #394.

--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -17,10 +17,12 @@ namespace SportlinkFunction.Planner
     {
         [Function("CheckAvailability")]
         public static async Task<IActionResult> CheckAvailability(
-            [HttpTrigger(AuthorizationLevel.Function, "post", Route = "planner/check-availability")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "planner/check-availability")] HttpRequest req,
             FunctionContext context)
         {
             var log = context.GetLogger("CheckAvailability");
+            var authResult = EasyAuthHelper.RequireAdmin(req);
+            if (authResult != null) return authResult;
             try
             {
                 await SystemUtilities.WaitForDatabaseAsync(log);
@@ -46,10 +48,12 @@ namespace SportlinkFunction.Planner
 
         [Function("DoordeweeksBeschikbaar")]
         public static async Task<IActionResult> DoordeweeksBeschikbaar(
-            [HttpTrigger(AuthorizationLevel.Function, "post", Route = "planner/doordeweeks-beschikbaar")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "planner/doordeweeks-beschikbaar")] HttpRequest req,
             FunctionContext context)
         {
             var log = context.GetLogger("DoordeweeksBeschikbaar");
+            var authResult = EasyAuthHelper.RequireAdmin(req);
+            if (authResult != null) return authResult;
             try
             {
                 await SystemUtilities.WaitForDatabaseAsync(log);
@@ -74,10 +78,12 @@ namespace SportlinkFunction.Planner
 
         [Function("BevestigWedstrijd")]
         public static async Task<IActionResult> BevestigWedstrijd(
-            [HttpTrigger(AuthorizationLevel.Function, "post", Route = "planner/bevestig")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "planner/bevestig")] HttpRequest req,
             FunctionContext context)
         {
             var log = context.GetLogger("BevestigWedstrijd");
+            var authResult = EasyAuthHelper.RequireAdmin(req);
+            if (authResult != null) return authResult;
             try
             {
                 await SystemUtilities.WaitForDatabaseAsync(log);
@@ -220,10 +226,12 @@ namespace SportlinkFunction.Planner
 
         [Function("ZoekWedstrijd")]
         public static async Task<IActionResult> ZoekWedstrijd(
-            [HttpTrigger(AuthorizationLevel.Function, "post", Route = "planner/zoek-wedstrijd")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "planner/zoek-wedstrijd")] HttpRequest req,
             FunctionContext context)
         {
             var log = context.GetLogger("ZoekWedstrijd");
+            var authResult = EasyAuthHelper.RequireAdmin(req);
+            if (authResult != null) return authResult;
             try
             {
                 await SystemUtilities.WaitForDatabaseAsync(log);
@@ -253,10 +261,12 @@ namespace SportlinkFunction.Planner
 
         [Function("HerplanCheck")]
         public static async Task<IActionResult> HerplanCheck(
-            [HttpTrigger(AuthorizationLevel.Function, "post", Route = "planner/herplan-check")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "planner/herplan-check")] HttpRequest req,
             FunctionContext context)
         {
             var log = context.GetLogger("HerplanCheck");
+            var authResult = EasyAuthHelper.RequireAdmin(req);
+            if (authResult != null) return authResult;
             try
             {
                 await SystemUtilities.WaitForDatabaseAsync(log);
@@ -331,10 +341,12 @@ namespace SportlinkFunction.Planner
 
         [Function("HerplanBevestig")]
         public static async Task<IActionResult> HerplanBevestig(
-            [HttpTrigger(AuthorizationLevel.Function, "post", Route = "planner/herplan-bevestig")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "planner/herplan-bevestig")] HttpRequest req,
             FunctionContext context)
         {
             var log = context.GetLogger("HerplanBevestig");
+            var authResult = EasyAuthHelper.RequireAdmin(req);
+            if (authResult != null) return authResult;
             try
             {
                 await SystemUtilities.WaitForDatabaseAsync(log);
@@ -458,10 +470,12 @@ namespace SportlinkFunction.Planner
 
         [Function("GetTeamSchedule")]
         public static async Task<IActionResult> GetTeamSchedule(
-            [HttpTrigger(AuthorizationLevel.Function, "get", Route = "planner/team-schedule")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "planner/team-schedule")] HttpRequest req,
             FunctionContext context)
         {
             var log = context.GetLogger("GetTeamSchedule");
+            var authResult = EasyAuthHelper.RequireAdmin(req);
+            if (authResult != null) return authResult;
             try
             {
                 var team = req.Query["team"].ToString();


### PR DESCRIPTION
## Samenvatting
7 planner-endpoints gemigreerd van `AuthorizationLevel.Function` naar `AuthorizationLevel.Anonymous` + `EasyAuthHelper.RequireAdmin()`:
- CheckAvailability, DoordeweeksBeschikbaar, BevestigWedstrijd
- ZoekWedstrijd, HerplanCheck, HerplanBevestig, GetTeamSchedule

Conform het patroon dat al gebruikt wordt bij Optimaliseer, AutoPlan en alle admin-endpoints.
Lokale bypass via `WEBSITE_SITE_NAME` werkt ongewijzigd.

## Closes
- Closes #433

🤖 Generated with [Claude Code](https://claude.ai/claude-code)