### PR TITLE
chore(#419,#430,#431,#435): CI smoke tests, pipeline volgorde, Dependabot, VRC-defaults

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,23 @@ updates:
       - "dependencies"
     commit-message:
       prefix: "NuGet"
+
+  - package-ecosystem: "nuget"
+    directory: "/BlazorAdmin"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "NuGet"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "Actions"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,6 +72,24 @@ jobs:
             --configuration Release \
             --output ./output
 
+      - name: Artefact uploaden
+        uses: actions/upload-artifact@v4
+        with:
+          name: functionapp
+          path: ./output
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build, db-migrate]
+    # Deploy pas na succesvolle migratie — als db-migrate overgeslagen is (geen SQL-vars) mag deploy doorgaan. (#430)
+    if: always() && needs.build.result == 'success' && (needs.db-migrate.result == 'success' || needs.db-migrate.result == 'skipped')
+    steps:
+      - name: Artefact downloaden
+        uses: actions/download-artifact@v4
+        with:
+          name: functionapp
+          path: ./output
+
       - name: Azure inloggen
         uses: azure/login@v2
         with:
@@ -128,9 +146,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    needs: [build, db-migrate]
-    # db-migrate wordt overgeslagen als server niet geconfigureerd — test mag altijd doorgaan
-    if: always() && needs.build.result == 'success'
+    needs: [deploy]
+    # Deploy wordt overgeslagen als server niet geconfigureerd — test mag altijd doorgaan als deploy slaagt
+    if: always() && needs.deploy.result == 'success'
     steps:
       - name: "Smoke test: function app bereikbaar (health → 200)"
         run: |
@@ -160,6 +178,31 @@ jobs:
               echo "FOUT: verwacht 401, kreeg $STATUS"; exit 1
             fi
           done
+
+      - name: "Smoke test: anonymous admin endpoint beveiligd zonder token (→ 401)"
+        run: |
+          URL="https://${{ vars.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/beheer/settings"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 "$URL" || true)
+          echo "GET /api/beheer/settings zonder token: $STATUS"
+          if [ "$STATUS" != "401" ]; then
+            echo "FOUT: verwacht 401, kreeg $STATUS — EasyAuthHelper werkt niet correct"
+            exit 1
+          fi
+
+      - name: "Smoke test: gefakete X-MS-CLIENT-PRINCIPAL wordt niet vertrouwd (→ 401)"
+        run: |
+          # Simuleert een aanvaller die admin-header meestuurt zonder geldig Entra-token.
+          # Als Easy Auth actief is, strip Azure deze header vóór de Function.
+          FAKE_PRINCIPAL=$(echo '{"auth_typ":"aad","claims":[{"typ":"roles","val":"admin"}],"name_typ":"","role_typ":"roles"}' | base64 -w 0)
+          URL="https://${{ vars.AZURE_FUNCTIONAPP_NAME }}.azurewebsites.net/api/beheer/settings"
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 30 \
+            -H "X-MS-CLIENT-PRINCIPAL: $FAKE_PRINCIPAL" \
+            "$URL" || true)
+          echo "GET /api/beheer/settings met gefakete principal: $STATUS"
+          if [ "$STATUS" != "401" ]; then
+            echo "FOUT: verwacht 401, kreeg $STATUS — Easy Auth mogelijk uitgeschakeld of niet geconfigureerd"
+            exit 1
+          fi
 
       - name: "Info: planner endpoint database-check"
         continue-on-error: true

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -246,7 +246,8 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: HIGH,CRITICAL
-          exit-code: 0
+          exit-code: 1
+          ignore-unfixed: true
 
       - name: Upload Trivy results naar GitHub Security
         uses: github/codeql-action/upload-sarif@v3
@@ -259,17 +260,18 @@ jobs:
   security-gate:
     name: "Security Gate — blokkeert merge bij fout"
     runs-on: ubuntu-latest
-    needs: [gitleaks, pii-files, pii-patterns, pii-docs, infra-patterns]
+    needs: [gitleaks, pii-files, pii-patterns, pii-docs, infra-patterns, dependency-scan]
     if: always()
     steps:
       - name: Controleer alle verplichte security checks
         run: |
           FAILED=""
-          [ "${{ needs.gitleaks.result }}"    != "success" ] && FAILED="${FAILED}\n  ❌ Secret Detection (gitleaks): ${{ needs.gitleaks.result }}"
-          [ "${{ needs.pii-files.result }}"   != "success" ] && FAILED="${FAILED}\n  ❌ PII File Detection:           ${{ needs.pii-files.result }}"
-          [ "${{ needs.pii-patterns.result }}" != "success" ] && FAILED="${FAILED}\n  ❌ PII Pattern Scan:             ${{ needs.pii-patterns.result }}"
-          [ "${{ needs.pii-docs.result }}" != "success" ] && FAILED="${FAILED}\n  ❌ PII in Documentatie:          ${{ needs.pii-docs.result }}"
-          [ "${{ needs.infra-patterns.result }}" != "success" ] && FAILED="${FAILED}\n  ❌ Club-infrastructuur patronen:  ${{ needs.infra-patterns.result }}"
+          [ "${{ needs.gitleaks.result }}"         != "success" ] && FAILED="${FAILED}\n  ❌ Secret Detection (gitleaks): ${{ needs.gitleaks.result }}"
+          [ "${{ needs.pii-files.result }}"         != "success" ] && FAILED="${FAILED}\n  ❌ PII File Detection:           ${{ needs.pii-files.result }}"
+          [ "${{ needs.pii-patterns.result }}"      != "success" ] && FAILED="${FAILED}\n  ❌ PII Pattern Scan:             ${{ needs.pii-patterns.result }}"
+          [ "${{ needs.pii-docs.result }}"          != "success" ] && FAILED="${FAILED}\n  ❌ PII in Documentatie:          ${{ needs.pii-docs.result }}"
+          [ "${{ needs.infra-patterns.result }}"    != "success" ] && FAILED="${FAILED}\n  ❌ Club-infrastructuur patronen: ${{ needs.infra-patterns.result }}"
+          [ "${{ needs.dependency-scan.result }}"   != "success" ] && FAILED="${FAILED}\n  ❌ Dependency Vulnerability Scan: ${{ needs.dependency-scan.result }}"
 
           if [ -n "$FAILED" ]; then
             echo "::error::════════════════════════════════════════════════════"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - 7 planner-endpoints gemigreerd van `AuthorizationLevel.Function` naar `Anonymous` + `EasyAuthHelper.RequireAdmin()`: CheckAvailability, DoordeweeksBeschikbaar, BevestigWedstrijd, ZoekWedstrijd, HerplanCheck, HerplanBevestig, GetTeamSchedule. (#433)
 - Bootstrap Icons gehost vanuit `lib/bootstrap-icons/` — externe CDN (cdn.jsdelivr.net) verwijderd uit index.html. (#434)
 - `staticwebapp.config.json`: Content-Security-Policy, Referrer-Policy, X-Content-Type-Options en Permissions-Policy toegevoegd als globale headers. Clickjacking geblokkeerd via `frame-ancestors 'none'`. (#434)
+- `deploy.yml`: Function App deploy verplaatst naar aparte `deploy` job die `needs: [build, db-migrate]` — nieuwe code bereikt productie pas na succesvolle DB-migratie. (#430)
+- `deploy.yml`: twee nieuwe smoke tests voor anonymous admin endpoint (zonder token → 401) en header-spoofing (gefakete X-MS-CLIENT-PRINCIPAL → 401). (#419)
+- `.github/dependabot.yml`: Dependabot bewaakt nu ook `/BlazorAdmin` NuGet-packages en GitHub Actions. (#431)
+- `.github/workflows/security-scan.yml`: Trivy blokkeert nu bij HIGH/CRITICAL findings (was: exit-code 0). Dependency-scan opgenomen in security-gate. (#431)
+- `Database`: `DEFAULT 'VRC'` verwijderd uit `Speeltijden`, `VeldBeschikbaarheid`, `TeamRegels`; DROP CONSTRAINT-migraties toegevoegd voor bestaande installaties. PostDeployment scalar subquery gefixet. `PlannerAfzenderNaam` default `VRC Veldplanner` → `Veldplanner`. (#435)
 
 ### Changed
 - `docs/DEVELOPER-SETUP.md`: volledig herschreven voor v2.7 — Visual Studio/F5-workflow vervangen door `Start-Debug.ps1` + `Test-App.ps1`, BlazorAdmin-setup toegevoegd (poort 5242, `dotnet watch`), .NET 9 runtime als vereiste gedocumenteerd, fingerprint-veiligheidsregel toegevoegd, oplossing-naam gecorrigeerd naar `sportlink-wedstrijdzaken.sln`. Sluit issue #394.

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -9,8 +9,8 @@ Post-Deployment Script Template
                SELECT * FROM [$(TableName)]					
 --------------------------------------------------------------------------------------
 */
--- New setup needed for the first time
-IF (SELECT [ClubName] FROM [dbo].[AppSettings]) IS NULL
+-- New setup needed for the first time (#435: gebruik IF NOT EXISTS i.p.v. scalar subquery die faalt bij >1 rij)
+IF NOT EXISTS (SELECT 1 FROM [dbo].[AppSettings])
 BEGIN
 	INSERT INTO [dbo].[AppSettings]
 		([ClubName]
@@ -139,7 +139,7 @@ GO
 IF EXISTS (SELECT 1 FROM [dbo].[AppSettings] WHERE [PlannerAfzenderNaam] IS NULL)
 BEGIN
     UPDATE [dbo].[AppSettings]
-    SET [PlannerAfzenderNaam] = 'VRC Veldplanner',
+    SET [PlannerAfzenderNaam] = 'Veldplanner',
         [CoordinatorFunctie] = N'Coördinator thuiswedstrijden'
     WHERE [PlannerAfzenderNaam] IS NULL
 END
@@ -314,6 +314,20 @@ IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.TeamRe
 GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.VeldBeschikbaarheid') AND name = 'ClubCode')
     ALTER TABLE [dbo].[VeldBeschikbaarheid] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_VeldBeschikbaarheid_ClubCode] DEFAULT 'VRC'; -- migratie-backwards-compat
+GO
+
+-- #435: verwijder VRC-default constraints — clubnaam heeft geen plek als DB-default
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_Speeltijden_ClubCode')
+    ALTER TABLE [dbo].[Speeltijden] DROP CONSTRAINT [DF_Speeltijden_ClubCode];
+GO
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_TeamRegels_ClubCode')
+    ALTER TABLE [dbo].[TeamRegels] DROP CONSTRAINT [DF_TeamRegels_ClubCode];
+GO
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_VeldBeschikbaarheid_ClubCode')
+    ALTER TABLE [dbo].[VeldBeschikbaarheid] DROP CONSTRAINT [DF_VeldBeschikbaarheid_ClubCode];
+GO
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_Velden_ClubCode')
+    ALTER TABLE [dbo].[Velden] DROP CONSTRAINT [DF_Velden_ClubCode];
 GO
 
 -- ============================================================

--- a/Database/dbo/Tables/Speeltijden.sql
+++ b/Database/dbo/Tables/Speeltijden.sql
@@ -4,6 +4,6 @@ CREATE TABLE [dbo].[Speeltijden] (
     [WedstrijdTotaal] INT          NOT NULL,
     [WedstrijdHelft]  INT          NOT NULL,
     [WedstrijdRust]   INT          NOT NULL,
-    [ClubCode]        NVARCHAR(20)  NOT NULL CONSTRAINT [DF_Speeltijden_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
+    [ClubCode]        NVARCHAR(20)  NOT NULL,
     CONSTRAINT [PK_Speeltijden] PRIMARY KEY CLUSTERED ([Leeftijd] ASC, [ClubCode] ASC)
 ) ON [PRIMARY]

--- a/Database/dbo/Tables/TeamRegels.sql
+++ b/Database/dbo/Tables/TeamRegels.sql
@@ -8,6 +8,6 @@ CREATE TABLE [dbo].[TeamRegels] (
     [Prioriteit]        INT            NOT NULL CONSTRAINT [DF_TeamRegels_Prioriteit] DEFAULT 0,
     [Actief]            BIT            NOT NULL CONSTRAINT [DF_TeamRegels_Actief] DEFAULT 1,
     [Opmerking]         NVARCHAR(500)  NULL,
-    [ClubCode]          NVARCHAR(20)   NOT NULL CONSTRAINT [DF_TeamRegels_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
+    [ClubCode]          NVARCHAR(20)   NOT NULL,
     CONSTRAINT [PK_TeamRegels] PRIMARY KEY CLUSTERED ([Id] ASC)
 );

--- a/Database/dbo/Tables/VeldBeschikbaarheid.sql
+++ b/Database/dbo/Tables/VeldBeschikbaarheid.sql
@@ -5,7 +5,7 @@ CREATE TABLE [dbo].[VeldBeschikbaarheid] (
     [BeschikbaarVanaf]     TIME               NOT NULL,
     [BeschikbaarTot]       TIME               NOT NULL,
     [GebruikZonsondergang] BIT                NOT NULL CONSTRAINT [DF_VeldBeschikbaarheid_Zon] DEFAULT 0,
-    [ClubCode]             NVARCHAR(20)       NOT NULL CONSTRAINT [DF_VeldBeschikbaarheid_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
+    [ClubCode]             NVARCHAR(20)       NOT NULL,
     CONSTRAINT [PK_VeldBeschikbaarheid] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [FK_VeldBeschikbaarheid_Velden] FOREIGN KEY ([VeldNummer]) REFERENCES [dbo].[Velden]([VeldNummer])
 );


### PR DESCRIPTION
## Samenvatting

**#430 — Pipeline volgorde:**
- `build` job maakt artefact + upload (geen deploy meer)
- Nieuwe `deploy` job `needs: [build, db-migrate]` — deploy pas na migratie
- `test` job `needs: [deploy]`

**#419 — Smoke tests:**
- Nieuwe test: `GET /api/beheer/settings` zonder token → 401
- Nieuwe test: `GET /api/beheer/settings` met gefakete `X-MS-CLIENT-PRINCIPAL` → 401

**#431 — Dependabot + Trivy:**
- Dependabot bewaakt `/BlazorAdmin` en `github-actions`
- Trivy: `exit-code: 1`, `ignore-unfixed: true`, `dependency-scan` in security-gate `needs`

**#435 — VRC-defaults:**
- `DEFAULT 'VRC'` verwijderd uit `Speeltijden`, `VeldBeschikbaarheid`, `TeamRegels` schema's
- DROP CONSTRAINT migraties in PostDeployment (bestaande installaties)
- Scalar subquery `IF (SELECT [ClubName]...) IS NULL` → `IF NOT EXISTS (...)`
- `PlannerAfzenderNaam` default `'VRC Veldplanner'` → `'Veldplanner'`

## Closes
- Closes #430 — Closes #419 — Closes #431 — Closes #435

🤖 Generated with [Claude Code](https://claude.ai/claude-code)