### PR TITLE
fix(#432): markeer e-mail pas als verstuurd na bevestigde Graph-send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - `.github/workflows/security-scan.yml`: Trivy blokkeert nu bij HIGH/CRITICAL findings (was: exit-code 0). Dependency-scan opgenomen in security-gate. (#431)
 - `Database`: `DEFAULT 'VRC'` verwijderd uit `Speeltijden`, `VeldBeschikbaarheid`, `TeamRegels`; DROP CONSTRAINT-migraties toegevoegd voor bestaande installaties. PostDeployment scalar subquery gefixet. `PlannerAfzenderNaam` default `VRC Veldplanner` → `Veldplanner`. (#435)
 
+### Fixed
+- `EmailGraphService.SendReplyAsync` slikt verzendfouten niet meer stilzwijgend weg — exception wordt opnieuw gegooid zodat de aanroeper de status correct kan bijwerken. (#432)
+- `VerwerkEmailAsync`: status `AntwoordVerstuurd` en `MarkAsRead` worden pas bijgewerkt na bevestigde Graph-send. Bij mislukking: `VerzendFout`, mail blijft ongelezen voor herverwerking. (#432)
+
 ### Changed
 - `docs/DEVELOPER-SETUP.md`: volledig herschreven voor v2.7 — Visual Studio/F5-workflow vervangen door `Start-Debug.ps1` + `Test-App.ps1`, BlazorAdmin-setup toegevoegd (poort 5242, `dotnet watch`), .NET 9 runtime als vereiste gedocumenteerd, fingerprint-veiligheidsregel toegevoegd, oplossing-naam gecorrigeerd naar `sportlink-wedstrijdzaken.sln`. Sluit issue #394.
 - `docs/SETUP-CHECKLIST.md`: herschreven voor v2.7 — verwijzingen naar niet-bestaande scripts en Visual Studio verwijderd; `Start-Debug.ps1`, `Test-App.ps1` en .NET 9 runtime-eis toegevoegd. Sluit issue #394.

--- a/FunctionApp/Email/EmailGraphService.cs
+++ b/FunctionApp/Email/EmailGraphService.cs
@@ -217,6 +217,7 @@ public partial class EmailGraphService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Fout bij versturen van antwoord (ontvanger en onderwerp niet gelogd — AVG #210)");
+            throw; // aanroeper bepaalt over status — niet stil doorgaan (#432)
         }
     }
 

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -324,7 +324,18 @@ public class EmailProcessorFunction
             ? Environment.GetEnvironmentVariable("EmailReviewRecipient") ?? email.Afzender
             : email.Afzender;
 
-        await graphService.SendReplyAsync(ontvanger, onderwerp, antwoordBody, email.ConversationId);
+        // Fail-explicit: alleen AntwoordVerstuurd en MarkAsRead als Graph-send slaagt. (#432)
+        try
+        {
+            await graphService.SendReplyAsync(ontvanger, onderwerp, antwoordBody, email.ConversationId);
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "Graph-send mislukt voor verwerking {Id} — VerzendFout, mail blijft ongelezen", verwerkingId);
+            try { await UpdateFoutAsync(email.MessageId, SanitizeFoutMelding(ex.Message)); } catch { }
+            return; // mail NIET als gelezen markeren — wordt bij volgende poll opnieuw opgepikt
+        }
+
         await UpdateAntwoordVerstuurdAsync(verwerkingId, ontvanger, antwoordBody);
         await graphService.MarkAsReadAsync(email.MessageId);
 


### PR DESCRIPTION
## Samenvatting
- `EmailGraphService.SendReplyAsync`: `throw;` toegevoegd in catch — exception bubbles up naar aanroeper
- `VerwerkEmailAsync`: try/catch rond SendReplyAsync
  - Bij succes: UpdateAntwoordVerstuurdAsync + MarkAsReadAsync
  - Bij mislukking: UpdateFoutAsync (VerzendFout) + return (mail blijft ongelezen)

## Closes
- Closes #432

🤖 Generated with [Claude Code](https://claude.ai/claude-code)