### PR TITLE
fix(#438): sync deelsuccessen zichtbaar + LastSyncTimestamp semantiek

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 ### Fixed
 - `EmailGraphService.SendReplyAsync` slikt verzendfouten niet meer stilzwijgend weg — exception wordt opnieuw gegooid zodat de aanroeper de status correct kan bijwerken. (#432)
 - `VerwerkEmailAsync`: status `AntwoordVerstuurd` en `MarkAsRead` worden pas bijgewerkt na bevestigde Graph-send. Bij mislukking: `VerzendFout`, mail blijft ongelezen voor herverwerking. (#432)
+- Sportlink-sync: deelfouten (teams, programma, uitslagen) worden expliciet bijgehouden — `LastSyncTimestamp` wordt alleen bijgewerkt als de sync volledig geslaagd is. `AdminSyncTrigger` response bevat melding over asynchrone aard. (#438)
 
 ### Changed
 - `docs/DEVELOPER-SETUP.md`: volledig herschreven voor v2.7 — Visual Studio/F5-workflow vervangen door `Start-Debug.ps1` + `Test-App.ps1`, BlazorAdmin-setup toegevoegd (poort 5242, `dotnet watch`), .NET 9 runtime als vereiste gedocumenteerd, fingerprint-veiligheidsregel toegevoegd, oplossing-naam gecorrigeerd naar `sportlink-wedstrijdzaken.sln`. Sluit issue #394.

--- a/FunctionApp/Admin/AdminSyncFunction.cs
+++ b/FunctionApp/Admin/AdminSyncFunction.cs
@@ -101,7 +101,10 @@ public static class AdminSyncFunction
                 status = "gestart",
                 weekOffsetFrom = -1,
                 weekOffsetTo = toWeekOffset,
-                tijdstip = DateTime.UtcNow
+                tijdstip = DateTime.UtcNow,
+                // Sync draait op de achtergrond (~3-5 min). LastSyncTimestamp in /status
+                // wordt bijgewerkt zodra de sync volledig geslaagd is. (#438)
+                melding = "Sync gestart op achtergrond. Controleer LastSyncTimestamp via /beheer/sync/status voor resultaat."
             }) { StatusCode = 202 };
         }
         catch (Exception ex)

--- a/FunctionApp/Function1.cs
+++ b/FunctionApp/Function1.cs
@@ -116,11 +116,22 @@ namespace SportlinkFunction
             string ApiUrl;
 
             // Drop and create staging table
+            // partialFailure: als één stap faalt, slaan we LastSyncTimestamp NIET op. (#438)
+            var partialFailure = false;
+
             await CreateStagingTable.ExecuteAsync("teams");
             // Fetch and store Teams data
             ApiUrl = $"{sportlinkApiUrl}/teams?{sportlinkClientId}";
-            await FetchAndStoreTeamsData(ApiUrl, log);
-            log.LogInformation("TEAMS - GET endpoint=/teams");
+            try
+            {
+                await FetchAndStoreTeamsData(ApiUrl, log);
+                log.LogInformation("TEAMS - GET endpoint=/teams");
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "TEAMS - fetch mislukt");
+                partialFailure = true;
+            }
 
             // Drop and create staging table
             await CreateStagingTable.ExecuteAsync("matches");
@@ -131,8 +142,16 @@ namespace SportlinkFunction
             for (int weekOffset = fromWeekOffset; weekOffset <= toWeekOffset; weekOffset++)
             {
                 ApiUrl = $"{sportlinkApiUrl}/programma?{sportlinkClientId}&weekoffset={weekOffset}";
-                await FetchAndStoreProgrammaMatches(ApiUrl, log);
-                log.LogInformation("MATCHES/PROGRAMMA - GET endpoint=/programma weekOffset={WeekOffset}", weekOffset);
+                try
+                {
+                    await FetchAndStoreProgrammaMatches(ApiUrl, log);
+                    log.LogInformation("MATCHES/PROGRAMMA - GET endpoint=/programma weekOffset={WeekOffset}", weekOffset);
+                }
+                catch (Exception ex)
+                {
+                    log.LogError(ex, "MATCHES/PROGRAMMA - fetch mislukt weekOffset={WeekOffset}", weekOffset);
+                    partialFailure = true;
+                }
             }
 
             // Step 2: /uitslagen — fetch past weeks only for scores (uitslag, uitslag-regulier, etc.)
@@ -142,8 +161,16 @@ namespace SportlinkFunction
             for (int weekOffset = scoreFromOffset; weekOffset <= 0; weekOffset++)
             {
                 ApiUrl = $"{sportlinkApiUrl}/uitslagen?{sportlinkClientId}&weekoffset={weekOffset}";
-                await FetchAndStoreUitslagenScores(ApiUrl, log);
-                log.LogInformation("MATCHES/UITSLAGEN - GET endpoint=/uitslagen weekOffset={WeekOffset}", weekOffset);
+                try
+                {
+                    await FetchAndStoreUitslagenScores(ApiUrl, log);
+                    log.LogInformation("MATCHES/UITSLAGEN - GET endpoint=/uitslagen weekOffset={WeekOffset}", weekOffset);
+                }
+                catch (Exception ex)
+                {
+                    log.LogError(ex, "MATCHES/UITSLAGEN - fetch mislukt weekOffset={WeekOffset}", weekOffset);
+                    partialFailure = true;
+                }
             }
             // Drop and create staging table
             await CreateStagingTable.ExecuteAsync("matchdetails");
@@ -161,7 +188,12 @@ namespace SportlinkFunction
             await new MergeStgToHis("stg", "matchdetails", "his", "matchdetails").ExecuteAsync(log);
 
             await SportlinkFunction.Planner.PlannerDataAccess.MarkeerVervallenGeplandeWedstrijdenAsync(log);
-            await SystemUtilities.AppSettings.SaveLastSyncTimestampAsync(log);
+
+            // LastSyncTimestamp = laatste volledig succesvolle sync, niet laatste poging. (#438)
+            if (!partialFailure)
+                await SystemUtilities.AppSettings.SaveLastSyncTimestampAsync(log);
+            else
+                log.LogWarning("Sync gedeeltelijk mislukt — LastSyncTimestamp NIET bijgewerkt");
         }
 
         private static async Task FetchAndStoreMatchDetails(string apiUrl, ILogger log)
@@ -252,6 +284,7 @@ namespace SportlinkFunction
             catch (Exception ex)
             {
                 log.LogError($"TEAMS - Error fetching or deserializing: {ex.Message}");
+                throw;
             }
         }
 
@@ -273,6 +306,7 @@ namespace SportlinkFunction
             catch (Exception ex)
             {
                 log.LogError($"MATCHES/PROGRAMMA - Error fetching or deserializing: {ex.Message}");
+                throw;
             }
         }
 
@@ -294,6 +328,7 @@ namespace SportlinkFunction
             catch (Exception ex)
             {
                 log.LogError($"MATCHES/UITSLAGEN - Error fetching or deserializing: {ex.Message}");
+                throw;
             }
         }
 


### PR DESCRIPTION
## Samenvatting
- `partialFailure` vlag per fetch-stap in `RunSyncAsync`
- `LastSyncTimestamp` = alleen bij volledig succesvolle sync
- `FetchAndStore*` methoden gooien exceptions nu opnieuw (throw; in catch)
- `AdminSyncTrigger` response: melding dat sync asynchroon is

## Closes
- Closes #438

🤖 Generated with [Claude Code](https://claude.ai/claude-code)