### PR TITLE
refactor(#429): IChatClient BerichtAiService + FeedbackFunction + README AI-provider fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - `EmailGraphService.SendReplyAsync` slikt verzendfouten niet meer stilzwijgend weg — exception wordt opnieuw gegooid zodat de aanroeper de status correct kan bijwerken. (#432)
 - `VerwerkEmailAsync`: status `AntwoordVerstuurd` en `MarkAsRead` worden pas bijgewerkt na bevestigde Graph-send. Bij mislukking: `VerzendFout`, mail blijft ongelezen voor herverwerking. (#432)
 - Sportlink-sync: deelfouten (teams, programma, uitslagen) worden expliciet bijgehouden — `LastSyncTimestamp` wordt alleen bijgewerkt als de sync volledig geslaagd is. `AdminSyncTrigger` response bevat melding over asynchrone aard. (#438)
+- `BerichtAiService` en `FeedbackFunction` gebruiken nu `IChatClient` (Microsoft.Extensions.AI) i.p.v. directe `OpenAI.Chat.ChatClient`. DI-registratie in `Program.cs`. README gecorrigeerd: OpenAI direct (gpt-4o-mini), niet Azure OpenAI. (#429)
 
 ### Changed
 - `docs/DEVELOPER-SETUP.md`: volledig herschreven voor v2.7 — Visual Studio/F5-workflow vervangen door `Start-Debug.ps1` + `Test-App.ps1`, BlazorAdmin-setup toegevoegd (poort 5242, `dotnet watch`), .NET 9 runtime als vereiste gedocumenteerd, fingerprint-veiligheidsregel toegevoegd, oplossing-naam gecorrigeerd naar `sportlink-wedstrijdzaken.sln`. Sluit issue #394.

--- a/FunctionApp/Admin/EmailTestFunction.cs
+++ b/FunctionApp/Admin/EmailTestFunction.cs
@@ -60,7 +60,9 @@ public static class EmailTestFunction
             await SystemUtilities.AppSettings.LoadSettingsAsync(log);
 
             var loggerFactory = context.InstanceServices.GetRequiredService<ILoggerFactory>();
-            var aiService = new BerichtAiService(loggerFactory.CreateLogger<BerichtAiService>());
+            var chatClient = context.InstanceServices.GetService<Microsoft.Extensions.AI.IChatClient>()
+                ?? throw new InvalidOperationException("IChatClient niet geconfigureerd — controleer OpenAiApiKey env var");
+            var aiService = new BerichtAiService(loggerFactory.CreateLogger<BerichtAiService>(), chatClient);
 
             var onderwerp = dto.Onderwerp ?? "";
             var afzender = dto.Afzender ?? "test@example.com";

--- a/FunctionApp/Email/BerichtAiService.cs
+++ b/FunctionApp/Email/BerichtAiService.cs
@@ -1,6 +1,6 @@
-using System.Text.Json;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
-using OpenAI.Chat;
+using System.Text.Json;
 
 namespace SportlinkFunction.Email;
 
@@ -11,7 +11,7 @@ namespace SportlinkFunction.Email;
 public class BerichtAiService
 {
     private readonly ILogger<BerichtAiService> _logger;
-    private readonly ChatClient _chatClient;
+    private readonly IChatClient _chatClient;
 
     // KNVB-verplaatsingsregels voor seizoen 2025/'26 — wordt door AI gebruikt om overtreding te signaleren
     // Bron: https://www.knvb.nl/assist-wedstrijdsecretarissen/veldvoetbal/regelen-dagelijkse-praktijk/verplaatsen-van-wedstrijden
@@ -133,15 +133,10 @@ public class BerichtAiService
     }
 
 
-    public BerichtAiService(ILogger<BerichtAiService> logger)
+    public BerichtAiService(ILogger<BerichtAiService> logger, IChatClient chatClient)
     {
         _logger = logger;
-
-        var apiKey = Environment.GetEnvironmentVariable("OpenAiApiKey");
-        if (string.IsNullOrWhiteSpace(apiKey))
-            throw new InvalidOperationException("OpenAiApiKey environment variable is niet geconfigureerd of leeg.");
-
-        _chatClient = new ChatClient("gpt-4o-mini", apiKey);
+        _chatClient = chatClient;
     }
 
     /// <summary>
@@ -158,22 +153,22 @@ public class BerichtAiService
         var today = DateTime.Now; // Lokale tijd — NL-context voor datumberekening
         var userPrompt = $"Van: {afzender}\nOnderwerp: {subject}\n\n{body}";
 
-        var messages = new List<ChatMessage>
+        var messages = new List<Microsoft.Extensions.AI.ChatMessage>
         {
-            new SystemChatMessage(BouwClassificatieSystemPrompt(today, voorbeelden)),
-            new UserChatMessage(userPrompt)
+            new(ChatRole.System, BouwClassificatieSystemPrompt(today, voorbeelden)),
+            new(ChatRole.User, userPrompt)
         };
 
-        var options = new ChatCompletionOptions
+        var options = new ChatOptions
         {
             Temperature = 0.1f,
-            ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat()
+            ResponseFormat = ChatResponseFormat.Json
         };
 
         try
         {
-            var completion = await _chatClient.CompleteChatAsync(messages, options);
-            var jsonResponse = completion.Value.Content[0].Text;
+            var response = await _chatClient.GetResponseAsync(messages, options);
+            var jsonResponse = response.Text ?? "";
 
             _logger.LogInformation("OpenAI classificatie response ontvangen");
 
@@ -216,22 +211,22 @@ public class BerichtAiService
 
         var userPrompt = $"Originele classificatie: {origineelType}.\nOriginele samenvatting: {originaleSamenvatting ?? "(geen)"}.\n\nReply:\nOnderwerp: {subject}\n\n{body}";
 
-        var messages = new List<ChatMessage>
+        var messages = new List<Microsoft.Extensions.AI.ChatMessage>
         {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage(userPrompt)
+            new(ChatRole.System, systemPrompt),
+            new(ChatRole.User, userPrompt)
         };
 
-        var options = new ChatCompletionOptions
+        var options = new ChatOptions
         {
             Temperature = 0.1f,
-            ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat()
+            ResponseFormat = ChatResponseFormat.Json
         };
 
         try
         {
-            var completion = await _chatClient.CompleteChatAsync(messages, options);
-            var jsonResponse = completion.Value.Content[0].Text;
+            var response = await _chatClient.GetResponseAsync(messages, options);
+            var jsonResponse = response.Text ?? "";
 
             using var doc = JsonDocument.Parse(jsonResponse);
             var root = doc.RootElement;

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -108,7 +108,9 @@ public class EmailProcessorFunction
         }
 
         // AI-classificatie voor alle resterende emails — database wordt niet nogmaals gewekt
-        var aiService = new BerichtAiService(loggerFactory.CreateLogger<BerichtAiService>());
+        var chatClient = context.InstanceServices.GetService<Microsoft.Extensions.AI.IChatClient>()
+            ?? throw new InvalidOperationException("IChatClient niet geconfigureerd — controleer OpenAiApiKey env var");
+        var aiService = new BerichtAiService(loggerFactory.CreateLogger<BerichtAiService>(), chatClient);
         var classificaties = new List<(InkomendBericht Email, BerichtClassificatie Classificatie)>();
         var aiAborted = false;
 

--- a/FunctionApp/Feedback/FeedbackFunction.cs
+++ b/FunctionApp/Feedback/FeedbackFunction.cs
@@ -1,13 +1,14 @@
-using System.Collections.Concurrent;
-using System.Net.Http.Headers;
-using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using OpenAI.Chat;
+using System.Collections.Concurrent;
+using System.Net.Http.Headers;
+using System.Text;
 
 namespace SportlinkFunction.Feedback;
 
@@ -49,10 +50,8 @@ public static class FeedbackFunction
             if (dto == null || string.IsNullOrWhiteSpace(dto.Beschrijving))
                 return new BadRequestObjectResult(new { error = "Type en beschrijving zijn verplicht." });
 
-            var apiKey = Environment.GetEnvironmentVariable("OpenAiApiKey")
-                ?? throw new InvalidOperationException("OpenAiApiKey niet geconfigureerd");
-
-            var chatClient = new ChatClient("gpt-4o-mini", apiKey);
+            var chatClient = context.InstanceServices.GetService<IChatClient>()
+                ?? throw new InvalidOperationException("IChatClient niet geconfigureerd — controleer OpenAiApiKey env var");
             var result = await ValideerVolledigheid(chatClient, dto, log);
 
             return new OkObjectResult(result);
@@ -98,10 +97,8 @@ public static class FeedbackFunction
                 return new ObjectResult(new { error = "GitHub-integratie niet geconfigureerd. Neem contact op met de beheerder." }) { StatusCode = 503 };
             }
 
-            var apiKey = Environment.GetEnvironmentVariable("OpenAiApiKey")
-                ?? throw new InvalidOperationException("OpenAiApiKey niet geconfigureerd");
-
-            var chatClient = new ChatClient("gpt-4o-mini", apiKey);
+            var chatClient = context.InstanceServices.GetService<IChatClient>()
+                ?? throw new InvalidOperationException("IChatClient niet geconfigureerd — controleer OpenAiApiKey env var");
             var structured = await StructureerIssue(chatClient, dto, log);
 
             var issueBody = BouwIssueBody(dto, structured);
@@ -133,7 +130,7 @@ public static class FeedbackFunction
     // ── AI: volledigheid valideren ─────────────────────────────────────────────
 
     private static async Task<ValidateResponse> ValideerVolledigheid(
-        ChatClient chatClient, FeedbackRequest dto, ILogger log)
+        IChatClient chatClient, FeedbackRequest dto, ILogger log)
     {
         // Als de gebruiker al antwoorden heeft gegeven op aanvulvragen, accepteer direct.
         // Re-validatie leidt tot dezelfde vragen omdat het AI-model eerder gestelde vragen
@@ -167,20 +164,20 @@ public static class FeedbackFunction
             {qaBlok}
             """;
 
-        var messages = new List<ChatMessage>
+        var messages = new List<Microsoft.Extensions.AI.ChatMessage>
         {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage(userPrompt)
+            new(ChatRole.System, systemPrompt),
+            new(ChatRole.User, userPrompt)
         };
 
-        var options = new ChatCompletionOptions
+        var options = new ChatOptions
         {
             Temperature = 0.1f,
-            ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat()
+            ResponseFormat = ChatResponseFormat.Json
         };
 
-        var completion = await chatClient.CompleteChatAsync(messages, options);
-        var json = completion.Value.Content[0].Text;
+        var response = await chatClient.GetResponseAsync(messages, options);
+        var json = response.Text ?? "";
         log.LogDebug("Validate AI response: {Json}", json);
 
         var parsed = JObject.Parse(json);
@@ -193,7 +190,7 @@ public static class FeedbackFunction
     // ── AI: issue structureren ─────────────────────────────────────────────────
 
     private static async Task<StructuredIssue> StructureerIssue(
-        ChatClient chatClient, FeedbackRequest dto, ILogger log)
+        IChatClient chatClient, FeedbackRequest dto, ILogger log)
     {
         var beschrijving = Sanitize(dto.Beschrijving, 2000);
         var qaBlok = BouwQaBlok(dto.VragenAntwoorden);
@@ -230,20 +227,20 @@ public static class FeedbackFunction
             {qaBlok}
             """;
 
-        var messages = new List<ChatMessage>
+        var messages = new List<Microsoft.Extensions.AI.ChatMessage>
         {
-            new SystemChatMessage(systemPrompt),
-            new UserChatMessage(userPrompt)
+            new(ChatRole.System, systemPrompt),
+            new(ChatRole.User, userPrompt)
         };
 
-        var options = new ChatCompletionOptions
+        var options = new ChatOptions
         {
             Temperature = 0.2f,
-            ResponseFormat = ChatResponseFormat.CreateJsonObjectFormat()
+            ResponseFormat = ChatResponseFormat.Json
         };
 
-        var completion = await chatClient.CompleteChatAsync(messages, options);
-        var json = completion.Value.Content[0].Text;
+        var response = await chatClient.GetResponseAsync(messages, options);
+        var json = response.Text ?? "";
         log.LogDebug("Submit AI response: {Json}", json);
 
         var parsed = JObject.Parse(json);

--- a/FunctionApp/Program.cs
+++ b/FunctionApp/Program.cs
@@ -1,8 +1,10 @@
 using Azure.Identity;
 using Microsoft.Azure.Functions.Worker.Builder;
+using Microsoft.Extensions.AI;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Graph;
+using OpenAI.Chat;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 builder.ConfigureFunctionsWebApplication();
@@ -10,12 +12,22 @@ builder.ConfigureFunctionsWebApplication();
 // Graph client met client credentials (application permissions)
 var tenantId = Environment.GetEnvironmentVariable("GraphTenantId");
 var clientId = Environment.GetEnvironmentVariable("GraphClientId");
-var clientSecret = Environment.GetEnvironmentVariable("GraphClientSecret");
+var graphAppCredential = Environment.GetEnvironmentVariable("GraphClientSecret");
 
-if (!string.IsNullOrEmpty(tenantId) && !string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret))
+if (!string.IsNullOrEmpty(tenantId) && !string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(graphAppCredential))
 {
-    var credential = new ClientSecretCredential(tenantId, clientId, clientSecret);
+    var credential = new ClientSecretCredential(tenantId, clientId, graphAppCredential);
     builder.Services.AddSingleton(new GraphServiceClient(credential));
+}
+
+// IChatClient: provider-agnostische AI-abstractie (CLAUDE.md architectuurregel).
+// Provider: OpenAI gpt-4o-mini direct — geen Azure OpenAI.
+var openAiApiKey = Environment.GetEnvironmentVariable("OpenAiApiKey");
+if (!string.IsNullOrWhiteSpace(openAiApiKey))
+{
+    builder.Services.AddSingleton<IChatClient>(
+        new ChatClient("gpt-4o-mini", new System.ClientModel.ApiKeyCredential(openAiApiKey))
+            .AsIChatClient());
 }
 
 // CORS voor lokale dev: geconfigureerd via Host.CORS in local.settings.json (Functions host-level).

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
     <PackageReference Include="Microsoft.Graph" Version="6.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Een serverless pipeline die Sportlink-data synchroniseert, verwerkt en omzet in 
 Elke nacht haalt een Azure Function alle wedstrijden, teams en details op via de Sportlink Club API. De data wordt opgeslagen in een lokale SQL Server — zodat je er zelf query's op kunt draaien, rapporten van kunt bouwen, of koppelen aan andere systemen.
 
 ### 2 — AI-gestuurde e-mailverwerking
-Binnenkomende e-mails over wedstrijdwijzigingen (verplaatsverzoeken, afzeggingen) worden automatisch geclassificeerd via Azure OpenAI. Op basis van de classificatie stuurt de planner een standaardantwoord terug — met de leider en trainer van het betrokken team automatisch in BCC.
+Binnenkomende e-mails over wedstrijdwijzigingen (verplaatsverzoeken, afzeggingen) worden automatisch geclassificeerd via OpenAI (gpt-4o-mini, direct via OpenAI API). Op basis van de classificatie stuurt de planner een standaardantwoord terug — met de leider en trainer van het betrokken team automatisch in BCC.
 
 **Geen handmatig zoekwerk meer.** De juiste contactpersonen worden automatisch gevonden via de koppeling met de ledenexport.
 
@@ -77,7 +77,7 @@ Azure Static Web Apps (gratis tier)
         └── Entra ID authenticatie (admin / user rollen)
 ```
 
-**Technologie:** .NET 9 (FunctionApp) · .NET 10 (Blazor) · Azure Functions v4 · Blazor WebAssembly · Azure SQL · Microsoft Graph API · Azure OpenAI · Azure Static Web Apps · Entra ID
+**Technologie:** .NET 9 (FunctionApp) · .NET 10 (Blazor) · Azure Functions v4 · Blazor WebAssembly · Azure SQL · Microsoft Graph API · OpenAI (gpt-4o-mini, direct) · Azure Static Web Apps · Entra ID
 
 ---
 


### PR DESCRIPTION
## Samenvatting
- `Microsoft.Extensions.AI.OpenAI` 10.6.0 toegevoegd
- `Program.cs`: `IChatClient` geregistreerd via DI (`new ChatClient(...).AsIChatClient()`)
- `BerichtAiService`: constructor-injectie IChatClient, MEAI-types
- `FeedbackFunction` + `EmailTestFunction`: IChatClient via `context.InstanceServices`
- README: "Azure OpenAI" → "OpenAI (gpt-4o-mini, direct)"

## Closes
- Closes #429

🤖 Generated with [Claude Code](https://claude.ai/claude-code)