### PR TITLE
infra(#418): Easy Auth authsettingsV2 declaratief in Bicep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - `VerwerkEmailAsync`: status `AntwoordVerstuurd` en `MarkAsRead` worden pas bijgewerkt na bevestigde Graph-send. Bij mislukking: `VerzendFout`, mail blijft ongelezen voor herverwerking. (#432)
 - Sportlink-sync: deelfouten (teams, programma, uitslagen) worden expliciet bijgehouden — `LastSyncTimestamp` wordt alleen bijgewerkt als de sync volledig geslaagd is. `AdminSyncTrigger` response bevat melding over asynchrone aard. (#438)
 - `BerichtAiService` en `FeedbackFunction` gebruiken nu `IChatClient` (Microsoft.Extensions.AI) i.p.v. directe `OpenAI.Chat.ChatClient`. DI-registratie in `Program.cs`. README gecorrigeerd: OpenAI direct (gpt-4o-mini), niet Azure OpenAI. (#429)
+- `infrastructure/modules/function-app.bicep`: `authsettingsV2` resource toegevoegd — Easy Auth declaratief vastgelegd (AllowAnonymous + Entra ID single-tenant). Wordt overgeslagen als tenantId/clientId niet geconfigureerd zijn. (#418)
+- `infrastructure/main.bicep`: `tenantId` en `clientId` parameters toegevoegd, doorgegeven aan function-app module via GitHub Variables. (#418)
 
 ### Changed
 - `docs/DEVELOPER-SETUP.md`: volledig herschreven voor v2.7 — Visual Studio/F5-workflow vervangen door `Start-Debug.ps1` + `Test-App.ps1`, BlazorAdmin-setup toegevoegd (poort 5242, `dotnet watch`), .NET 9 runtime als vereiste gedocumenteerd, fingerprint-veiligheidsregel toegevoegd, oplossing-naam gecorrigeerd naar `sportlink-wedstrijdzaken.sln`. Sluit issue #394.

--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -50,6 +50,12 @@ param azureWebJobsStorage string = ''
 @description('Monitoring deployen? Alleen instellen op true na expliciete kostengoedkeuring eigenaar.')
 param deployMonitoring bool = false
 
+@description('Entra ID tenant ID voor Easy Auth — via GitHub Variable AZURE_AD_TENANT_ID. Leeg = Easy Auth niet declaratief geconfigureerd.')
+param tenantId string = ''
+
+@description('Entra ID client ID van de App Registration — via GitHub Variable AZURE_AD_CLIENT_ID. Leeg = Easy Auth niet declaratief geconfigureerd.')
+param clientId string = ''
+
 // ── Modules ──────────────────────────────────────────────────────────────────
 
 module functionApp 'modules/function-app.bicep' = {
@@ -62,6 +68,8 @@ module functionApp 'modules/function-app.bicep' = {
     appInsightsConnectionString: appInsightsConnectionString
     sqlConnectionString: sqlConnectionString
     azureWebJobsStorage: azureWebJobsStorage
+    tenantId: tenantId
+    clientId: clientId
   }
 }
 

--- a/infrastructure/modules/function-app.bicep
+++ b/infrastructure/modules/function-app.bicep
@@ -29,6 +29,12 @@ param sqlConnectionString string = ''
 @secure()
 param azureWebJobsStorage string = ''
 
+@description('Entra ID tenant ID voor Easy Auth (single-tenant) — via GitHub Variable AZURE_AD_TENANT_ID')
+param tenantId string = ''
+
+@description('Entra ID client ID van de App Registration — via GitHub Variable AZURE_AD_CLIENT_ID')
+param clientId string = ''
+
 // ── Bestaande resources ophalen ──────────────────────────────────────────────
 
 resource appServicePlan 'Microsoft.Web/serverFarms@2023-01-01' = {
@@ -101,6 +107,47 @@ resource functionApp 'Microsoft.Web/sites@2023-01-01' = {
       ]
     }
     httpsOnly: true
+  }
+}
+
+// ── Easy Auth (authsettingsV2) ────────────────────────────────────────────────
+// AllowAnonymous: unauthenticated requests mogen door; EasyAuthHelper doet
+// endpoint-level role-checks. Niet Return401 — dat breekt health + timer endpoints.
+// tenantId/clientId zijn leeg als vars niet geconfigureerd zijn — resource wordt
+// dan overgeslagen (Bicep condition). (#418)
+
+resource functionAppAuthSettings 'Microsoft.Web/sites/config@2023-01-01' = if (!empty(tenantId) && !empty(clientId)) {
+  name: 'authsettingsV2'
+  parent: functionApp
+  properties: {
+    globalValidation: {
+      requireAuthentication: false
+      unauthenticatedClientAction: 'AllowAnonymous'
+    }
+    identityProviders: {
+      azureActiveDirectory: {
+        enabled: true
+        registration: {
+          clientId: clientId
+          openIdIssuer: 'https://sts.windows.net/${tenantId}/v2.0'
+        }
+        validation: {
+          allowedAudiences: [
+            'api://${clientId}'
+          ]
+        }
+        isAutoProvisioned: false
+      }
+    }
+    login: {
+      tokenStore: {
+        enabled: false
+      }
+    }
+    platform: {
+      enabled: true
+      runtimeVersion: '~1'
+    }
   }
 }
 


### PR DESCRIPTION
## Samenvatting
- `function-app.bicep`: `authsettingsV2` resource toegevoegd
  - `unauthenticatedClientAction: AllowAnonymous` (bestaande architectuur behouden)
  - Entra ID als identity provider (single-tenant via openIdIssuer)
  - Conditional: alleen uitgerold als `tenantId` + `clientId` niet leeg zijn
- `main.bicep`: `tenantId` + `clientId` parameters, doorgegeven aan function-app module

## Backward compatible
Forks/installaties zonder `AZURE_AD_TENANT_ID`/`AZURE_AD_CLIENT_ID` GitHub Variables krijgen de resource overgeslagen — geen bestaande deployments gebroken.

## Closes
- Closes #418

🤖 Generated with [Claude Code](https://claude.ai/claude-code)