### PR TITLE
feat(#428): ClubCode doorvoeren in planner-datamodel en data-access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - `BerichtAiService` en `FeedbackFunction` gebruiken nu `IChatClient` (Microsoft.Extensions.AI) i.p.v. directe `OpenAI.Chat.ChatClient`. DI-registratie in `Program.cs`. README gecorrigeerd: OpenAI direct (gpt-4o-mini), niet Azure OpenAI. (#429)
 - `infrastructure/modules/function-app.bicep`: `authsettingsV2` resource toegevoegd — Easy Auth declaratief vastgelegd (AllowAnonymous + Entra ID single-tenant). Wordt overgeslagen als tenantId/clientId niet geconfigureerd zijn. (#418)
 - `infrastructure/main.bicep`: `tenantId` en `clientId` parameters toegevoegd, doorgegeven aan function-app module via GitHub Variables. (#418)
+- `planner.GeplandeWedstrijden`: `ClubCode NOT NULL` kolom toegevoegd aan schema + PostDeployment migratie (backfill → NOT NULL → unique constraint update). (#428)
+- `PlannerDataAccess.GetSpeeltijdAsync` + `SavePlannedMatchAsync`: clubCode parameter toegevoegd (optioneel, valt terug op AppSettings). `BevestigWedstrijd` endpoint geeft clubCode door. (#428)
+- `planner.AlleWedstrijdenOpVeld`: `SELECT TOP 1` subqueries vervangen door `CROSS APPLY` op AppSettings — robuuster bij meerdere AppSettings-rijen + ClubCode-filter op Speeltijden en Velden. (#428)
 
 ### Changed
 - `docs/DEVELOPER-SETUP.md`: volledig herschreven voor v2.7 — Visual Studio/F5-workflow vervangen door `Start-Debug.ps1` + `Test-App.ps1`, BlazorAdmin-setup toegevoegd (poort 5242, `dotnet watch`), .NET 9 runtime als vereiste gedocumenteerd, fingerprint-veiligheidsregel toegevoegd, oplossing-naam gecorrigeerd naar `sportlink-wedstrijdzaken.sln`. Sluit issue #394.

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -684,3 +684,34 @@ GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('his.matches') AND name = 'veld_subpositie')
     ALTER TABLE [his].[matches] ADD [veld_subpositie] NVARCHAR(5) NULL;
 GO
+
+-- ============================================================
+-- #428: ClubCode in planner.GeplandeWedstrijden + unique constraint
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('planner.GeplandeWedstrijden') AND name = 'ClubCode')
+BEGIN
+    ALTER TABLE [planner].[GeplandeWedstrijden] ADD [ClubCode] NVARCHAR(20) NULL;
+    -- Backfill: koppel bestaande rijen aan de primaire club
+    UPDATE [planner].[GeplandeWedstrijden]
+    SET [ClubCode] = (SELECT TOP 1 [ClubCode] FROM [dbo].[AppSettings] WHERE [SyncEnabled] = 1 ORDER BY [Id])
+    WHERE [ClubCode] IS NULL;
+    -- NOT NULL na backfill
+    ALTER TABLE [planner].[GeplandeWedstrijden] ALTER COLUMN [ClubCode] NVARCHAR(20) NOT NULL;
+END
+GO
+
+-- Update unique constraint om ClubCode op te nemen (drop + recreate, idempotent)
+IF EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('planner.GeplandeWedstrijden') AND name = 'UQ_GeplandeWedstrijden_Slot')
+AND NOT EXISTS (
+    SELECT 1 FROM sys.index_columns ic
+    JOIN sys.columns c ON ic.object_id = c.object_id AND ic.column_id = c.column_id
+    WHERE ic.object_id = OBJECT_ID('planner.GeplandeWedstrijden') AND ic.index_id =
+        (SELECT index_id FROM sys.indexes WHERE object_id = OBJECT_ID('planner.GeplandeWedstrijden') AND name = 'UQ_GeplandeWedstrijden_Slot')
+    AND c.name = 'ClubCode'
+)
+BEGIN
+    ALTER TABLE [planner].[GeplandeWedstrijden] DROP CONSTRAINT [UQ_GeplandeWedstrijden_Slot];
+    ALTER TABLE [planner].[GeplandeWedstrijden] ADD CONSTRAINT [UQ_GeplandeWedstrijden_Slot]
+        UNIQUE ([ClubCode], [Datum], [AanvangsTijd], [VeldNummer], [VeldDeelGebruik]);
+END
+GO

--- a/Database/planner/Tables/GeplandeWedstrijden.sql
+++ b/Database/planner/Tables/GeplandeWedstrijden.sql
@@ -14,9 +14,10 @@ CREATE TABLE [planner].[GeplandeWedstrijden] (
     [Opmerking]             NVARCHAR(500)  NULL,
     [IsVervallen]           BIT            NOT NULL CONSTRAINT [DF_GeplandeWedstrijden_IsVervallen] DEFAULT 0,
     [SportlinkWedstrijdCode] BIGINT        NULL,
+    [ClubCode]              NVARCHAR(20)   NOT NULL,
     [mta_inserted]          DATETIME       NOT NULL CONSTRAINT [DF_GeplandeWedstrijden_Ins] DEFAULT GETUTCDATE(),
     [mta_modified]          DATETIME       NOT NULL CONSTRAINT [DF_GeplandeWedstrijden_Mod] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_GeplandeWedstrijden] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [FK_GeplandeWedstrijden_Velden] FOREIGN KEY ([VeldNummer]) REFERENCES [dbo].[Velden]([VeldNummer]),
-    CONSTRAINT [UQ_GeplandeWedstrijden_Slot] UNIQUE ([Datum], [AanvangsTijd], [VeldNummer], [VeldDeelGebruik])
+    CONSTRAINT [UQ_GeplandeWedstrijden_Slot] UNIQUE ([ClubCode], [Datum], [AanvangsTijd], [VeldNummer], [VeldDeelGebruik])
 );

--- a/Database/planner/Views/AlleWedstrijdenOpVeld.sql
+++ b/Database/planner/Views/AlleWedstrijdenOpVeld.sql
@@ -3,6 +3,7 @@ AS
 -- Thuiswedstrijden op eigen accommodatie (gefilterd op Accommodatie uit dbo.AppSettings)
 -- Speelduur exclusief via dbo.Speeltijden (WedstrijdTotaal = speeltijd + rust).
 -- Sportlink [Duration] uit matchdetails wordt niet meer gebruikt — DB is leidend (#291).
+-- ClubCode uit CROSS APPLY ipv SELECT TOP 1 — voorkomt scalar subquery fout bij >1 rij (#428).
 SELECT
     CAST(m.[kaledatum] AS DATE)                                                     AS Datum,
     CAST(m.[aanvangstijd] AS TIME)                                                  AS AanvangsTijd,
@@ -18,16 +19,19 @@ SELECT
     RTRIM(SUBSTRING(m.[veld], 7, 10))                                               AS VeldSubpositie,
     'Competitie'                                                                    AS Bron
 FROM [his].[matches] m
+CROSS APPLY (SELECT TOP 1 [ClubCode], [Accommodatie] FROM [dbo].[AppSettings] WHERE [SyncEnabled] = 1 ORDER BY [Id]) a
 LEFT JOIN [his].[teams] t
     ON t.[teamnaam] = m.[teamnaam] AND t.[leeftijdscategorie] IS NOT NULL AND t.[leeftijdscategorie] <> ''
 LEFT JOIN [dbo].[Speeltijden] s
     ON s.[Leeftijd] = CASE
-        WHEN m.[teamnaam] LIKE (SELECT TOP 1 [ClubCode] FROM [dbo].[AppSettings]) + ' G[0-9]%' THEN 'G'
+        WHEN m.[teamnaam] LIKE a.[ClubCode] + ' G[0-9]%' THEN 'G'
         ELSE REPLACE(REPLACE(REPLACE(t.[leeftijdscategorie], 'Onder ', 'JO'), 'Meisjes ', 'MO'), 'Vrouwen', 'VR')
     END
+   AND s.[ClubCode] = a.[ClubCode]
 LEFT JOIN [dbo].[Velden] v
     ON RTRIM(LEFT(m.[veld], 6)) = v.[VeldNaam]
-WHERE m.[accommodatie] LIKE '%' + (SELECT TOP 1 [Accommodatie] FROM [dbo].[AppSettings]) + '%'
+   AND v.[ClubCode] = a.[ClubCode]
+WHERE m.[accommodatie] LIKE '%' + a.[Accommodatie] + '%'
   AND m.[status] <> 'Afgelast'
   AND m.[aanvangstijd] IS NOT NULL
   AND v.[VeldNummer] IS NOT NULL

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -10,13 +10,16 @@ namespace SportlinkFunction.Planner
     {
         private static string ConnectionString => SystemUtilities.DatabaseConfig.ConnectionString;
 
-        public static async Task<Speeltijd?> GetSpeeltijdAsync(string leeftijdsCategorie)
+        public static async Task<Speeltijd?> GetSpeeltijdAsync(string leeftijdsCategorie, string? clubCode = null)
         {
+            // clubCode is optioneel voor backward compat; valt terug op AppSettings (#428)
+            var cc = clubCode ?? SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
             using var cmd = new SqlCommand(
-                "SELECT [Leeftijd], [Veldafmeting], [WedstrijdTotaal] FROM [dbo].[Speeltijden] WHERE [Leeftijd] = @cat", conn);
+                "SELECT [Leeftijd], [Veldafmeting], [WedstrijdTotaal] FROM [dbo].[Speeltijden] WHERE [Leeftijd] = @cat AND [ClubCode] = @cc", conn);
             cmd.Parameters.AddWithValue("@cat", leeftijdsCategorie);
+            cmd.Parameters.AddWithValue("@cc", cc);
             using var reader = await cmd.ExecuteReaderAsync();
             if (await reader.ReadAsync())
             {
@@ -357,20 +360,22 @@ namespace SportlinkFunction.Planner
         public static async Task<int> SavePlannedMatchAsync(
             DateOnly datum, TimeOnly aanvangsTijd, TimeOnly eindTijd, int veldNummer,
             decimal veldDeelGebruik, string? leeftijdsCategorie, string? teamNaam,
-            string? tegenstander, int wedstrijdDuurMinuten, string? aangevraagdDoor)
+            string? tegenstander, int wedstrijdDuurMinuten, string? aangevraagdDoor,
+            string? clubCode = null)
         {
+            var cc = clubCode ?? SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
             using var cmd = new SqlCommand(@"
                 INSERT INTO [planner].[GeplandeWedstrijden]
                     ([Datum], [AanvangsTijd], [EindTijd], [VeldNummer], [VeldDeelGebruik],
                      [LeeftijdsCategorie], [TeamNaam], [Tegenstander], [WedstrijdDuurMinuten],
-                     [Status], [AangevraagdDoor])
+                     [Status], [AangevraagdDoor], [ClubCode])
                 OUTPUT INSERTED.[Id]
                 VALUES
                     (@datum, @aanvang, @eind, @veld, @deel,
                      @cat, @team, @tegen, @duur,
-                     'Te bevestigen', @door)
+                     'Te bevestigen', @door, @cc)
             ", conn);
             cmd.Parameters.AddWithValue("@datum", datum.ToDateTime(TimeOnly.MinValue));
             cmd.Parameters.AddWithValue("@aanvang", aanvangsTijd.ToTimeSpan());
@@ -382,6 +387,7 @@ namespace SportlinkFunction.Planner
             cmd.Parameters.AddWithValue("@tegen", (object?)tegenstander ?? DBNull.Value);
             cmd.Parameters.AddWithValue("@duur", wedstrijdDuurMinuten);
             cmd.Parameters.AddWithValue("@door", (object?)aangevraagdDoor ?? DBNull.Value);
+            cmd.Parameters.AddWithValue("@cc", cc);
 
             return (int)(await cmd.ExecuteScalarAsync())!;
         }

--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -101,9 +101,10 @@ namespace SportlinkFunction.Planner
 
                 int duurMinuten = request.WedstrijdDuurMinuten ?? 105;
                 decimal veldFractie = 1.00m;
+                var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req);
                 if (!string.IsNullOrEmpty(request.LeeftijdsCategorie))
                 {
-                    var speeltijd = await PlannerDataAccess.GetSpeeltijdAsync(request.LeeftijdsCategorie);
+                    var speeltijd = await PlannerDataAccess.GetSpeeltijdAsync(request.LeeftijdsCategorie, clubCode);
                     if (speeltijd != null)
                     {
                         duurMinuten = request.WedstrijdDuurMinuten ?? speeltijd.WedstrijdTotaal;
@@ -119,7 +120,7 @@ namespace SportlinkFunction.Planner
                 var id = await PlannerDataAccess.SavePlannedMatchAsync(
                     date, tijd, eindTijd, request.VeldNummer, veldFractie,
                     request.LeeftijdsCategorie, request.TeamNaam, request.Tegenstander,
-                    duurMinuten, request.AangevraagdDoor);
+                    duurMinuten, request.AangevraagdDoor, clubCode);
 
                 log.LogInformation("BevestigWedstrijd: saved with id={Id}", id);
 


### PR DESCRIPTION
## Samenvatting
- `planner.GeplandeWedstrijden`: ClubCode NOT NULL kolom
- PostDeployment migratie: backfill + NOT NULL + unique constraint update
- `GetSpeeltijdAsync`: optionele clubCode param, filtert Speeltijden per club
- `SavePlannedMatchAsync`: clubCode in INSERT
- `BevestigWedstrijd`: haalt clubCode op en geeft door aan DataAccess
- `AlleWedstrijdenOpVeld`: SELECT TOP 1 → CROSS APPLY (robuuster + ClubCode-filter)

## Closes
- Closes #428

🤖 Generated with [Claude Code](https://claude.ai/claude-code)