### PR TITLE
fix(#463,#464,#469): P1 security+reliability bugs

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.9.0.0</Version>
-    <AssemblyVersion>2.9.0.0</AssemblyVersion>
-    <FileVersion>2.9.0.0</FileVersion>
+    <Version>2.9.1.0</Version>
+    <AssemblyVersion>2.9.1.0</AssemblyVersion>
+    <FileVersion>2.9.1.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+## [2.9.1.0] — 2026-05-31
+
+### Fixed
+- `LaadUitgeslotenAdressenAsync` inslikt exceptions niet langer — bij DB-fout op cold start wordt AI-verwerking nu correct uitgesteld (fail-closed garantie hersteld). (#463)
+- Matchdetails-fouten (HTTP-fout of JSON-deserialisatiefout) zetten nu `partialFailure = true` — `LastSyncTimestamp` wordt niet bijgewerkt als matchdetails deels mislukken. Logs tonen succesvol/mislukt-tellingen. (#464)
+- `GetSpeeltijdenLookupAsync`, `GetTeamRulesAsync`, `GetAllTeamBuffersAsync` en `GetTeamLeeftijdLookupAsync` filteren nu op `ClubCode` — ALLSTARS-testdata lekt niet meer door in planner-berekeningen. (#469)
+
 ## [2.9.0.0] — 2026-05-31
 
 ### Added

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -552,30 +552,24 @@ public class EmailProcessorFunction
 
     // --- Database operaties ---
 
+    // Laadt uitsluitingslijst strikt — exception propageren zodat de outer cold-start catch
+    // fail-closed kan garanderen (_uitgeslotenCacheGeladen blijft false bij fout). (#463)
     private static async Task<HashSet<string>> LaadUitgeslotenAdressenAsync(ILogger log)
     {
-        try
-        {
-            var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-                ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
-            using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
-            await connection.OpenAsync();
-            using var command = new SqlCommand(
-                "SELECT [EmailAdres] FROM [dbo].[UitgeslotenEmailAdressen] WHERE [Actief] = 1 AND [ClubCode] = @ClubCode",
-                connection);
-            command.Parameters.AddWithValue("@ClubCode", clubCode);
-            var adressen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            using var reader = await command.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-                adressen.Add(reader.GetString(0));
-            log.LogInformation("Uitsluitingslijst geladen: {Aantal} adressen", adressen.Count);
-            return adressen;
-        }
-        catch (Exception ex)
-        {
-            log.LogWarning(ex, "Uitsluitingslijst kon niet worden geladen — doorgaan zonder");
-            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        }
+        var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
+            ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
+        await connection.OpenAsync();
+        using var command = new SqlCommand(
+            "SELECT [EmailAdres] FROM [dbo].[UitgeslotenEmailAdressen] WHERE [Actief] = 1 AND [ClubCode] = @ClubCode",
+            connection);
+        command.Parameters.AddWithValue("@ClubCode", clubCode);
+        var adressen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        using var reader = await command.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+            adressen.Add(reader.GetString(0));
+        log.LogInformation("Uitsluitingslijst geladen: {Aantal} adressen", adressen.Count);
+        return adressen;
     }
 
     private static async Task<bool> BestaatMessageIdAsync(string messageId)

--- a/FunctionApp/Function1.cs
+++ b/FunctionApp/Function1.cs
@@ -176,12 +176,23 @@ namespace SportlinkFunction
             await CreateStagingTable.ExecuteAsync("matchdetails");
             // Fetch and store match details for each match in the staging table
             var wedstrijdcodes = await FetchWedstrijdcodesFromStagingMatches(log);
+            int matchDetailsOk = 0, matchDetailsFout = 0;
             foreach (var wedstrijdcode in wedstrijdcodes)
             {
                 ApiUrl = $"{sportlinkApiUrl}/wedstrijd-informatie?{sportlinkClientId}&wedstrijdcode={wedstrijdcode}";
-                await FetchAndStoreMatchDetails(ApiUrl, log);
-                log.LogInformation("MATCHDETAILS - GET endpoint=/wedstrijd-informatie wedstrijdcode={Wedstrijdcode}", wedstrijdcode);
+                if (await FetchAndStoreMatchDetails(ApiUrl, log))
+                {
+                    matchDetailsOk++;
+                    log.LogInformation("MATCHDETAILS - GET endpoint=/wedstrijd-informatie wedstrijdcode={Wedstrijdcode}", wedstrijdcode);
+                }
+                else
+                {
+                    matchDetailsFout++;
+                    partialFailure = true;
+                }
             }
+            log.LogInformation("MATCHDETAILS - {Ok} succesvol, {Fout} mislukt van {Totaal} wedstrijdcodes",
+                matchDetailsOk, matchDetailsFout, wedstrijdcodes.Count);
             // Merge staging data into history tables
             await new MergeStgToHis("stg", "teams",        "his", "teams").ExecuteAsync(log);
             await new MergeStgToHis("stg", "matches",      "his", "matches").ExecuteAsync(log);
@@ -196,37 +207,35 @@ namespace SportlinkFunction
                 log.LogWarning("Sync gedeeltelijk mislukt — LastSyncTimestamp NIET bijgewerkt");
         }
 
-        private static async Task FetchAndStoreMatchDetails(string apiUrl, ILogger log)
+        // Retourneert true bij succes, false bij elke fout — zodat de caller partialFailure kan bijhouden. (#464)
+        private static async Task<bool> FetchAndStoreMatchDetails(string apiUrl, ILogger log)
         {
             try
             {
-                using (var client = new HttpClient())
-                {
-                    var response = await client.GetAsync(apiUrl);
-                    response.EnsureSuccessStatusCode();
+                using var client = new HttpClient();
+                var response = await client.GetAsync(apiUrl);
+                response.EnsureSuccessStatusCode();
 
-                    string jsonResponse = await response.Content.ReadAsStringAsync();
-                    try
-                    {
-                        MatchDetails? matchDetails = JsonConvert.DeserializeObject<MatchDetails>(jsonResponse, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-                        if (matchDetails != null)
-                        {
-                            await SaveToDatabaseMatchDetails(matchDetails, log);
-                        }
-                        else
-                        {
-                            log.LogWarning("MATCHDETAILS - No match details found.");
-                        }
-                    }
-                    catch (JsonSerializationException ex)
-                    {
-                        log.LogError($"Error deserializing JSON: {ex.Message}");
-                    }
+                string jsonResponse = await response.Content.ReadAsStringAsync();
+                try
+                {
+                    MatchDetails? matchDetails = JsonConvert.DeserializeObject<MatchDetails>(jsonResponse, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+                    if (matchDetails != null)
+                        await SaveToDatabaseMatchDetails(matchDetails, log);
+                    else
+                        log.LogWarning("MATCHDETAILS - No match details found.");
                 }
+                catch (JsonSerializationException ex)
+                {
+                    log.LogError("MATCHDETAILS - JSON-deserialisatiefout: {Message}", ex.Message);
+                    return false;
+                }
+                return true;
             }
             catch (Exception ex)
             {
-                log.LogError($"Error fetching match details from {apiUrl}: {ex.Message}");
+                log.LogError("MATCHDETAILS - Ophalen mislukt voor {ApiUrl}: {Message}", apiUrl, ex.Message);
+                return false;
             }
         }
         private static async Task<List<string>> FetchWedstrijdcodesFromStagingMatches(ILogger log)

--- a/FunctionApp/Planner/PlannerDataAccess.cs
+++ b/FunctionApp/Planner/PlannerDataAccess.cs
@@ -211,13 +211,15 @@ namespace SportlinkFunction.Planner
         }
 
         // Lookup: Leeftijd → Speeltijd. Gebruikt door SportlinkApiClient.
-        public static async Task<Dictionary<string, Speeltijd>> GetSpeeltijdenLookupAsync()
+        public static async Task<Dictionary<string, Speeltijd>> GetSpeeltijdenLookupAsync(string? clubCode = null)
         {
+            var cc = clubCode ?? SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
             var result = new Dictionary<string, Speeltijd>(StringComparer.OrdinalIgnoreCase);
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
             using var cmd = new SqlCommand(
-                "SELECT [Leeftijd], [Veldafmeting], [WedstrijdTotaal] FROM [dbo].[Speeltijden]", conn);
+                "SELECT [Leeftijd], [Veldafmeting], [WedstrijdTotaal] FROM [dbo].[Speeltijden] WHERE [ClubCode] = @cc", conn);
+            cmd.Parameters.AddWithValue("@cc", cc);
             using var reader = await cmd.ExecuteReaderAsync();
             while (await reader.ReadAsync())
                 result[reader.GetString(0)] = new Speeltijd
@@ -240,7 +242,9 @@ namespace SportlinkFunction.Planner
                 SELECT [teamnaam],
                        REPLACE(REPLACE(REPLACE([leeftijdscategorie], 'Onder ', 'JO'), 'Meisjes ', 'MO'), 'Vrouwen', 'VR')
                 FROM [his].[teams]
-                WHERE [leeftijdscategorie] IS NOT NULL AND [leeftijdscategorie] <> ''", conn);
+                WHERE [leeftijdscategorie] IS NOT NULL AND [leeftijdscategorie] <> ''
+                  AND [ClubCode] = @clubCode", conn);
+            cmd.Parameters.AddWithValue("@clubCode", clubCode);
             using var reader = await cmd.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {
@@ -290,18 +294,20 @@ namespace SportlinkFunction.Planner
             return results;
         }
 
-        public static async Task<List<TeamRegel>> GetTeamRulesAsync(string teamNaam)
+        public static async Task<List<TeamRegel>> GetTeamRulesAsync(string teamNaam, string? clubCode = null)
         {
+            var cc = clubCode ?? SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
             var results = new List<TeamRegel>();
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
             using var cmd = new SqlCommand(@"
                 SELECT [TeamNaam], [RegelType], [WaardeMinuten], [WaardeVeldNummer], [WaardeTijd], [Prioriteit]
                 FROM [dbo].[TeamRegels]
-                WHERE [TeamNaam] = @team AND [Actief] = 1
+                WHERE [TeamNaam] = @team AND [Actief] = 1 AND [ClubCode] = @cc
                 ORDER BY [Prioriteit] DESC
             ", conn);
             cmd.Parameters.AddWithValue("@team", teamNaam);
+            cmd.Parameters.AddWithValue("@cc", cc);
 
             using var reader = await cmd.ExecuteReaderAsync();
             while (await reader.ReadAsync())
@@ -319,8 +325,9 @@ namespace SportlinkFunction.Planner
             return results;
         }
 
-        public static async Task<Dictionary<string, (int bufferVoor, int bufferNa)>> GetAllTeamBuffersAsync()
+        public static async Task<Dictionary<string, (int bufferVoor, int bufferNa)>> GetAllTeamBuffersAsync(string? clubCode = null)
         {
+            var cc = clubCode ?? SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
             var result = new Dictionary<string, (int bufferVoor, int bufferNa)>(StringComparer.OrdinalIgnoreCase);
             using var conn = new SqlConnection(ConnectionString);
             await conn.OpenAsync();
@@ -328,7 +335,9 @@ namespace SportlinkFunction.Planner
                 SELECT [TeamNaam], [RegelType], [WaardeMinuten]
                 FROM [dbo].[TeamRegels]
                 WHERE [RegelType] IN ('BufferVoor', 'BufferNa') AND [Actief] = 1 AND [WaardeMinuten] IS NOT NULL
+                  AND [ClubCode] = @cc
             ", conn);
+            cmd.Parameters.AddWithValue("@cc", cc);
             using var reader = await cmd.ExecuteReaderAsync();
             while (await reader.ReadAsync())
             {

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.9.0.0</Version>
-    <AssemblyVersion>2.9.0.0</AssemblyVersion>
-    <FileVersion>2.9.0.0</FileVersion>
+    <Version>2.9.1.0</Version>
+    <AssemblyVersion>2.9.1.0</AssemblyVersion>
+    <FileVersion>2.9.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
## Summary

Drie P1 bug fixes voortkomend uit code review #468:

- **#463 fail-closed uitsluitingslijst** — `LaadUitgeslotenAdressenAsync` had een interne catch die exceptions insloot en een lege HashSet teruggaf. De outer cold-start catch zag dit niet, waardoor `_uitgeslotenCacheGeladen = true` gezet werd ook bij een DB-fout. AI-classificatie ging dan door met nul uitgesloten adressen. Fix: interne try/catch verwijderd; exception propageert naar de outer catch die correct `return` doet (fail-closed).

- **#464 matchdetails partialFailure** — `FetchAndStoreMatchDetails` slukte exceptions stil in. De foreach-loop had geen try/catch en zette nooit `partialFailure = true`. Fix: methode geeft nu `bool` terug; foreach trackt fouten en zet `partialFailure = true`. Logs tonen succesvol/mislukt-tellingen.

- **#469 ClubCode-filter planner lookups** — Vier PlannerDataAccess-methoden bevroegen tabellen met ClubCode-kolom zonder te filteren: `GetSpeeltijdenLookupAsync`, `GetTeamRulesAsync`, `GetAllTeamBuffersAsync` en `GetTeamLeeftijdLookupAsync`. ALLSTARS-testdata kon doorlekken in planner-berekeningen. Fix: ClubCode-filter toegevoegd met AppSettings-fallback (optionele parameter, backward compatible).

## Test plan

- [ ] Build groen (`dotnet build FunctionApp`)
- [ ] Lokaal: cold-start met neergehaalde DB → FunctionApp logt "AI-verwerking uitgesteld" en verwerkt geen mails
- [ ] Lokaal: sync met één foutieve wedstrijdcode → log toont "X succesvol, Y mislukt", LastSyncTimestamp niet bijgewerkt
- [ ] Planner: verplaats wedstrijd met ALLSTARS actief → geen ALLSTARS teamregels of speeltijden in planner-output

Closes #463
Closes #464
Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)