### PR TITLE
feat(#466): Function1 refactor — sync pipeline + staging repository

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.10.0.0</Version>
-    <AssemblyVersion>2.10.0.0</AssemblyVersion>
-    <FileVersion>2.10.0.0</FileVersion>
+    <Version>2.11.0.0</Version>
+    <AssemblyVersion>2.11.0.0</AssemblyVersion>
+    <FileVersion>2.11.0.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+## [2.11.0.0] — 2026-05-31
+
+### Changed
+- Sportlink-sync refactored: `Function1.cs` is nu een dunne trigger-wrapper. Orchestratie-logica verplaatst naar `SportlinkSyncPipeline`; SQL-staging naar `SportlinkStagingRepository`. Gedeelde match-velden geëxtraheerd in helper-methode (minder duplicaat-code). (#466)
+
 ## [2.10.0.0] — 2026-05-31
 
 ### Changed

--- a/FunctionApp/Function1.cs
+++ b/FunctionApp/Function1.cs
@@ -1,65 +1,61 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
-using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using SportlinkFunction.Infrastructure;
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading.Tasks;
 using static SportlinkFunction.SystemUtilities;
 
 namespace SportlinkFunction
 {
+    /// <summary>
+    /// Azure Functions triggers voor Sportlink-sync.
+    /// Orchestratie-logica en staging-SQL zijn verplaatst naar:
+    ///   - SportlinkSyncPipeline (FetchAndStore + RunSyncAsync)
+    ///   - SportlinkStagingRepository (SQL staging writes)
+    /// (#466)
+    /// </summary>
     public static class FetchAndStoreApiData
     {
-        private static readonly HttpClient client = new HttpClient();
-
         [Function("FetchAndStoreApiData")]
         public static async Task Run([TimerTrigger("%FETCH_SCHEDULE%")] TimerInfo myTimer, FunctionContext context)
         {
             var log = context.GetLogger("FetchAndStoreApiData");
-            log.LogInformation($"Azure Function executed at: {DateTime.Now}");
+            log.LogInformation("Azure Function executed at: {Now}", DateTime.UtcNow);
 
             try
             {
-                await SystemUtilities.WaitForDatabaseAsync(log);
-                await SystemUtilities.AppSettings.LoadSettingsAsync(log);
+                await WaitForDatabaseAsync(log);
+                await AppSettings.LoadSettingsAsync(log);
 
-                string? sportlinkApiUrl = SystemUtilities.AppSettings.GetSetting("sportlinkApiUrl");
+                string? sportlinkApiUrl = AppSettings.GetSetting("sportlinkApiUrl");
                 if (string.IsNullOrEmpty(sportlinkApiUrl))
                 {
                     log.LogError("sportlinkApiUrl is not configured.");
                     return;
                 }
 
-                // SyncEnabled = 0 → skip sync for demo-clubs (e.g. AllStars FC)
-                var syncEnabledStr = SystemUtilities.AppSettings.GetSetting("syncEnabled");
+                var syncEnabledStr = AppSettings.GetSetting("syncEnabled");
                 if (syncEnabledStr == "0")
                 {
                     log.LogInformation("SyncEnabled = 0 — sync overgeslagen voor deze club.");
                     return;
                 }
 
-                string sportlinkClientId = $"clientId={SystemUtilities.AppSettings.GetSetting("sportlinkClientId")}";
-
-                // Default: previous week (-1) up to end of current season
+                string sportlinkClientId = $"clientId={AppSettings.GetSetting("sportlinkClientId")}";
                 int toWeekOffset = await SeasonHelper.GetSeasonEndWeekOffsetAsync(log);
-                log.LogInformation($"Sync range: weekOffset -1 to {toWeekOffset} (end of season)");
-                await RunSyncAsync(-1, toWeekOffset, sportlinkApiUrl, sportlinkClientId, log);
+                log.LogInformation("Sync range: weekOffset -1 to {ToWeekOffset} (end of season)", toWeekOffset);
+                await SportlinkSyncPipeline.RunSyncAsync(-1, toWeekOffset, sportlinkApiUrl, sportlinkClientId, log);
             }
             catch (Exception ex)
             {
-                log.LogError($"Error: {ex.Message}");
+                log.LogError(ex, "FetchAndStoreApiData fout");
                 await GitHubIssueReporter.ReportAsync(ex, "FetchAndStoreApiData", log);
             }
         }
 
         /// <summary>
-        /// HTTP trigger to manually start a sync.
-        /// Default (no params): same as timer — previous week through end of season.
+        /// HTTP trigger om handmatig een sync te starten.
+        /// Default (geen params): vorige week t/m einde seizoen.
         /// Reset mode: GET /api/sync-matches?reset=true&amp;season=2024
         ///   Downloads all matches from the start of the given season year through end of current season.
         /// </summary>
@@ -69,629 +65,54 @@ namespace SportlinkFunction
             FunctionContext context)
         {
             var log = context.GetLogger("SyncMatchesHttp");
-            log.LogInformation($"HTTP trigger SyncMatchesHttp executed at: {DateTime.Now}");
+            log.LogInformation("HTTP trigger SyncMatchesHttp executed at: {Now}", DateTime.UtcNow);
 
             try
             {
-                await SystemUtilities.WaitForDatabaseAsync(log);
-                await SystemUtilities.AppSettings.LoadSettingsAsync(log);
+                await WaitForDatabaseAsync(log);
+                await AppSettings.LoadSettingsAsync(log);
 
-                string? sportlinkApiUrl = SystemUtilities.AppSettings.GetSetting("sportlinkApiUrl");
+                string? sportlinkApiUrl = AppSettings.GetSetting("sportlinkApiUrl");
                 if (string.IsNullOrEmpty(sportlinkApiUrl))
                 {
                     log.LogError("sportlinkApiUrl is not configured.");
                     return new StatusCodeResult(500);
                 }
-                string sportlinkClientId = $"clientId={SystemUtilities.AppSettings.GetSetting("sportlinkClientId")}";
+                string sportlinkClientId = $"clientId={AppSettings.GetSetting("sportlinkClientId")}";
 
-                bool isReset = string.Equals(req.Query["reset"], "true", StringComparison.OrdinalIgnoreCase);
+                bool   isReset    = string.Equals(req.Query["reset"], "true", StringComparison.OrdinalIgnoreCase);
                 string? seasonParam = req.Query["season"];
 
-                int toWeekOffset = await SeasonHelper.GetSeasonEndWeekOffsetAsync(log);
-                int fromWeekOffset = -1; // default: previous week
+                int toWeekOffset   = await SeasonHelper.GetSeasonEndWeekOffsetAsync(log);
+                int fromWeekOffset = -1;
 
                 if (isReset && int.TryParse(seasonParam, out int seasonStartYear))
                 {
                     fromWeekOffset = await SeasonHelper.GetSeasonStartWeekOffsetAsync(seasonStartYear, log);
-                    log.LogInformation($"Reset mode: season {seasonStartYear}, weekOffset {fromWeekOffset} to {toWeekOffset}");
+                    log.LogInformation("Reset mode: season {Year}, weekOffset {From} to {To}",
+                        seasonStartYear, fromWeekOffset, toWeekOffset);
                 }
                 else
                 {
-                    log.LogInformation($"Default mode: weekOffset {fromWeekOffset} to {toWeekOffset}");
+                    log.LogInformation("Default mode: weekOffset {From} to {To}", fromWeekOffset, toWeekOffset);
                 }
 
-                await RunSyncAsync(fromWeekOffset, toWeekOffset, sportlinkApiUrl, sportlinkClientId, log);
+                await SportlinkSyncPipeline.RunSyncAsync(fromWeekOffset, toWeekOffset, sportlinkApiUrl, sportlinkClientId, log);
                 return new OkObjectResult($"Sync completed. WeekOffset range: {fromWeekOffset} to {toWeekOffset}.");
             }
             catch (Exception ex)
             {
-                log.LogError($"Error: {ex.Message}");
+                log.LogError(ex, "SyncMatchesHttp fout");
                 await GitHubIssueReporter.ReportAsync(ex, "SyncMatchesHttp", log);
                 return new StatusCodeResult(500);
             }
         }
 
-        public static async Task RunSyncAsync(int fromWeekOffset, int toWeekOffset, string sportlinkApiUrl, string sportlinkClientId, ILogger log)
-        {
-            string ApiUrl;
-
-            // Drop and create staging table
-            // partialFailure: als één stap faalt, slaan we LastSyncTimestamp NIET op. (#438)
-            var partialFailure = false;
-
-            await CreateStagingTable.ExecuteAsync("teams");
-            // Fetch and store Teams data
-            ApiUrl = $"{sportlinkApiUrl}/teams?{sportlinkClientId}";
-            try
-            {
-                await FetchAndStoreTeamsData(ApiUrl, log);
-                log.LogInformation("TEAMS - GET endpoint=/teams");
-            }
-            catch (Exception ex)
-            {
-                log.LogError(ex, "TEAMS - fetch mislukt");
-                partialFailure = true;
-            }
-
-            // Drop and create staging table
-            await CreateStagingTable.ExecuteAsync("matches");
-
-            // Step 1: /programma — fetch all weeks (past + future) for planning info
-            // (referee, venue, kleedkamers, logos, gather/depart times)
-            log.LogInformation($"MATCHES/PROGRAMMA - Fetching weekOffset {fromWeekOffset} to {toWeekOffset}");
-            for (int weekOffset = fromWeekOffset; weekOffset <= toWeekOffset; weekOffset++)
-            {
-                ApiUrl = $"{sportlinkApiUrl}/programma?{sportlinkClientId}&weekoffset={weekOffset}";
-                try
-                {
-                    await FetchAndStoreProgrammaMatches(ApiUrl, log);
-                    log.LogInformation("MATCHES/PROGRAMMA - GET endpoint=/programma weekOffset={WeekOffset}", weekOffset);
-                }
-                catch (Exception ex)
-                {
-                    log.LogError(ex, "MATCHES/PROGRAMMA - fetch mislukt weekOffset={WeekOffset}", weekOffset);
-                    partialFailure = true;
-                }
-            }
-
-            // Step 2: /uitslagen — fetch past weeks only for scores (uitslag, uitslag-regulier, etc.)
-            // Updates rows already inserted by /programma; inserts historical rows not in /programma.
-            int scoreFromOffset = Math.Min(fromWeekOffset, -2);
-            log.LogInformation($"MATCHES/UITSLAGEN - Fetching scores weekOffset {scoreFromOffset} to 0");
-            for (int weekOffset = scoreFromOffset; weekOffset <= 0; weekOffset++)
-            {
-                ApiUrl = $"{sportlinkApiUrl}/uitslagen?{sportlinkClientId}&weekoffset={weekOffset}";
-                try
-                {
-                    await FetchAndStoreUitslagenScores(ApiUrl, log);
-                    log.LogInformation("MATCHES/UITSLAGEN - GET endpoint=/uitslagen weekOffset={WeekOffset}", weekOffset);
-                }
-                catch (Exception ex)
-                {
-                    log.LogError(ex, "MATCHES/UITSLAGEN - fetch mislukt weekOffset={WeekOffset}", weekOffset);
-                    partialFailure = true;
-                }
-            }
-            // Drop and create staging table
-            await CreateStagingTable.ExecuteAsync("matchdetails");
-            // Fetch and store match details for each match in the staging table
-            var wedstrijdcodes = await FetchWedstrijdcodesFromStagingMatches(log);
-            int matchDetailsOk = 0, matchDetailsFout = 0;
-            foreach (var wedstrijdcode in wedstrijdcodes)
-            {
-                ApiUrl = $"{sportlinkApiUrl}/wedstrijd-informatie?{sportlinkClientId}&wedstrijdcode={wedstrijdcode}";
-                if (await FetchAndStoreMatchDetails(ApiUrl, log))
-                {
-                    matchDetailsOk++;
-                    log.LogInformation("MATCHDETAILS - GET endpoint=/wedstrijd-informatie wedstrijdcode={Wedstrijdcode}", wedstrijdcode);
-                }
-                else
-                {
-                    matchDetailsFout++;
-                    partialFailure = true;
-                }
-            }
-            log.LogInformation("MATCHDETAILS - {Ok} succesvol, {Fout} mislukt van {Totaal} wedstrijdcodes",
-                matchDetailsOk, matchDetailsFout, wedstrijdcodes.Count);
-            // Merge staging data into history tables
-            await new MergeStgToHis("stg", "teams",        "his", "teams").ExecuteAsync(log);
-            await new MergeStgToHis("stg", "matches",      "his", "matches").ExecuteAsync(log);
-            await new MergeStgToHis("stg", "matchdetails", "his", "matchdetails").ExecuteAsync(log);
-
-            await SportlinkFunction.Planner.PlannerDataAccess.MarkeerVervallenGeplandeWedstrijdenAsync(log);
-
-            // LastSyncTimestamp = laatste volledig succesvolle sync, niet laatste poging. (#438)
-            if (!partialFailure)
-                await SystemUtilities.AppSettings.SaveLastSyncTimestampAsync(log);
-            else
-                log.LogWarning("Sync gedeeltelijk mislukt — LastSyncTimestamp NIET bijgewerkt");
-        }
-
-        // Retourneert true bij succes, false bij elke fout — zodat de caller partialFailure kan bijhouden. (#464)
-        private static async Task<bool> FetchAndStoreMatchDetails(string apiUrl, ILogger log)
-        {
-            try
-            {
-                using var client = new HttpClient();
-                var response = await client.GetAsync(apiUrl);
-                response.EnsureSuccessStatusCode();
-
-                string jsonResponse = await response.Content.ReadAsStringAsync();
-                try
-                {
-                    MatchDetails? matchDetails = JsonConvert.DeserializeObject<MatchDetails>(jsonResponse, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-                    if (matchDetails != null)
-                        await SaveToDatabaseMatchDetails(matchDetails, log);
-                    else
-                        log.LogWarning("MATCHDETAILS - No match details found.");
-                }
-                catch (JsonSerializationException ex)
-                {
-                    log.LogError("MATCHDETAILS - JSON-deserialisatiefout: {Message}", ex.Message);
-                    return false;
-                }
-                return true;
-            }
-            catch (Exception ex)
-            {
-                log.LogError("MATCHDETAILS - Ophalen mislukt voor {ApiUrl}: {Message}", apiUrl, ex.Message);
-                return false;
-            }
-        }
-        private static async Task<List<string>> FetchWedstrijdcodesFromStagingMatches(ILogger log)
-        {
-            try
-            {
-                var query = "SELECT wedstrijdcode FROM [stg].[matches]";
-                var wedstrijdcodes = new List<string>();
-                using (var connection = new Microsoft.Data.SqlClient.SqlConnection(DatabaseConfig.ConnectionString))
-                {
-                    await connection.OpenAsync();
-                    using (var command = new Microsoft.Data.SqlClient.SqlCommand(query, connection))
-                    using (var reader = await command.ExecuteReaderAsync())
-                    {
-                        while (await reader.ReadAsync())
-                        {
-                            var wedstrijdcode = reader["wedstrijdcode"]?.ToString();
-                            if (wedstrijdcode != null)
-                            {
-                                wedstrijdcodes.Add(wedstrijdcode);
-                            }
-                        }
-                    }
-                    connection.Close();
-                }
-                return wedstrijdcodes;
-            }
-            catch (Exception ex)
-            {
-                log.LogError($"Error fetching wedstrijdcodes from database: {ex.Message}");
-                throw;
-            }
-        }
-
-
-        private static async Task FetchAndStoreTeamsData(string apiUrl, ILogger log)
-        {
-            try
-            {
-                HttpResponseMessage response = await client.GetAsync(apiUrl);
-                response.EnsureSuccessStatusCode();
-
-                string jsonResponse = await response.Content.ReadAsStringAsync();
-                List<Team>? teams = JsonConvert.DeserializeObject<List<Team>>(jsonResponse, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-                if (teams != null)
-                {
-                    log.LogInformation($"TEAMS - {teams.Count} count.");
-                    await SaveToDatabaseTeams(teams, log);
-                }
-                else
-                {
-                    log.LogWarning("TEAMS - No teams data found.");
-                }
-            }
-            catch (Exception ex)
-            {
-                log.LogError($"TEAMS - Error fetching or deserializing: {ex.Message}");
-                throw;
-            }
-        }
-
-        private static async Task FetchAndStoreProgrammaMatches(string apiUrl, ILogger log)
-        {
-            try
-            {
-                HttpResponseMessage response = await client.GetAsync(apiUrl);
-                response.EnsureSuccessStatusCode();
-
-                string jsonResponse = await response.Content.ReadAsStringAsync();
-                List<Match>? matches = JsonConvert.DeserializeObject<List<Match>>(jsonResponse, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-                if (matches != null && matches.Count > 0)
-                {
-                    log.LogInformation($"MATCHES/PROGRAMMA - {matches.Count} count.");
-                    await SaveProgrammaToStaging(matches, log);
-                }
-            }
-            catch (Exception ex)
-            {
-                log.LogError($"MATCHES/PROGRAMMA - Error fetching or deserializing: {ex.Message}");
-                throw;
-            }
-        }
-
-        private static async Task FetchAndStoreUitslagenScores(string apiUrl, ILogger log)
-        {
-            try
-            {
-                HttpResponseMessage response = await client.GetAsync(apiUrl);
-                response.EnsureSuccessStatusCode();
-
-                string jsonResponse = await response.Content.ReadAsStringAsync();
-                List<Match>? matches = JsonConvert.DeserializeObject<List<Match>>(jsonResponse, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
-                if (matches != null && matches.Count > 0)
-                {
-                    log.LogInformation($"MATCHES/UITSLAGEN - {matches.Count} count.");
-                    await MergeUitslagenIntoStaging(matches, log);
-                }
-            }
-            catch (Exception ex)
-            {
-                log.LogError($"MATCHES/UITSLAGEN - Error fetching or deserializing: {ex.Message}");
-                throw;
-            }
-        }
-
-        private static async Task SaveToDatabaseMatchDetails(MatchDetails matchDetails, ILogger log)
-        {
-            using (SqlConnection connection = new SqlConnection(DatabaseConfig.ConnectionString))
-            {
-                await connection.OpenAsync();
-                try
-                {
-                    var query = @"
-                    IF NOT EXISTS (SELECT 1 FROM [stg].[matchdetails] WHERE WedstrijdCode = @WedstrijdCode)
-                    INSERT INTO [stg].[matchdetails] (
-                        WedstrijdCode, InternCode, VeldNaam, VeldLocatie, VertrekTijd, Rijder, 
-                        ThuisScore, ThuisScoreRegulier, ThuisScoreNV, ThuisScoreS, UitScore, UitScoreRegulier, 
-                        UitScoreNV, UitScoreS, Klasse, WedstrijdType, CompetitieType, Categorie, MatchDateTime, 
-                        MatchDate, Aanvangstijd, Duration, SpelType, Aanduiding, PouleCode, Poule, ThuisTeamID, 
-                        ThuisTeam, UitTeamID, UitTeam, Opmerkingen, VerenigingScheidsrechterCode, VerenigingScheidsrechter, 
-                        OverigeOfficialCode, OverigeOfficial, Scheidsrechters, KleedkamerThuis, KleedkamerUit, KleedkamerOfficial, 
-                        AccommodatieNaam, AccommodatieStraat, AccommodatiePlaats, AccommodatieTelefoon, AccommodatieRouteplanner, 
-                        ThuisTeamNaam, ThuisTeamCode, ThuisTeamWebsite, ThuisTeamShirtKleur, ThuisTeamStraat, 
-                        ThuisTeamPostcodePlaats, ThuisTeamTelefoon, ThuisTeamEmail, UitTeamNaam, UitTeamCode, 
-                        UitTeamWebsite, UitTeamShirtKleur, UitTeamStraat, UitTeamPostcodePlaats, UitTeamTelefoon, UitTeamEmail
-                    ) 
-                    VALUES (
-                        @WedstrijdCode, @InternCode, @VeldNaam, @VeldLocatie, @VertrekTijd, @Rijder, 
-                        @ThuisScore, @ThuisScoreRegulier, @ThuisScoreNV, @ThuisScoreS, @UitScore, @UitScoreRegulier, 
-                        @UitScoreNV, @UitScoreS, @Klasse, @WedstrijdType, @CompetitieType, @Categorie, @MatchDateTime, 
-                        @MatchDate, @Aanvangstijd, @Duration, @SpelType, @Aanduiding, @PouleCode, @Poule, @ThuisTeamID, 
-                        @ThuisTeam, @UitTeamID, @UitTeam, @Opmerkingen, @VerenigingScheidsrechterCode, @VerenigingScheidsrechter, 
-                        @OverigeOfficialCode, @OverigeOfficial, @Scheidsrechters, @KleedkamerThuis, @KleedkamerUit, @KleedkamerOfficial, 
-                        @AccommodatieNaam, @AccommodatieStraat, @AccommodatiePlaats, @AccommodatieTelefoon, @AccommodatieRouteplanner, 
-                        @ThuisTeamNaam, @ThuisTeamCode, @ThuisTeamWebsite, @ThuisTeamShirtKleur, @ThuisTeamStraat, 
-                        @ThuisTeamPostcodePlaats, @ThuisTeamTelefoon, @ThuisTeamEmail, @UitTeamNaam, @UitTeamCode, 
-                        @UitTeamWebsite, @UitTeamShirtKleur, @UitTeamStraat, @UitTeamPostcodePlaats, @UitTeamTelefoon, @UitTeamEmail
-                    )";
-
-                    using (SqlCommand command = new SqlCommand(query, connection))
-                    {
-                        // Match wedstrijdinformatie fields
-                        command.Parameters.AddWithValue("@WedstrijdCode", matchDetails.Wedstrijdinformatie.Wedstrijdnummer);
-                        command.Parameters.AddWithValue("@InternCode", matchDetails.Wedstrijdinformatie.Wedstijdnummerintern);
-                        command.Parameters.AddWithValue("@VeldNaam", matchDetails.Wedstrijdinformatie.Veldnaam ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@VeldLocatie", matchDetails.Wedstrijdinformatie.Veldlocatie ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@VertrekTijd", matchDetails.Wedstrijdinformatie.Vertrektijd ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@Rijder", matchDetails.Wedstrijdinformatie.Rijder ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisScore", matchDetails.Wedstrijdinformatie.Thuisscore ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisScoreRegulier", matchDetails.Wedstrijdinformatie.ThuisscoreRegulier ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisScoreNV", matchDetails.Wedstrijdinformatie.ThuisscoreNv ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisScoreS", matchDetails.Wedstrijdinformatie.ThuisscoreS ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitScore", matchDetails.Wedstrijdinformatie.Uitscore ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitScoreRegulier", matchDetails.Wedstrijdinformatie.UitscoreRegulier ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitScoreNV", matchDetails.Wedstrijdinformatie.UitscoreNv ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitScoreS", matchDetails.Wedstrijdinformatie.UitscoreS ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@Klasse", matchDetails.Wedstrijdinformatie.Klasse ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@WedstrijdType", matchDetails.Wedstrijdinformatie.Wedstrijdtype ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@CompetitieType", matchDetails.Wedstrijdinformatie.Competitietype ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@Categorie", matchDetails.Wedstrijdinformatie.Categorie ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@MatchDateTime", matchDetails.Wedstrijdinformatie.Wedstrijddatetime ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@MatchDate", matchDetails.Wedstrijdinformatie.Wedstrijddatum ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@Aanvangstijd", TimeSpan.TryParse(matchDetails.Wedstrijdinformatie.Aanvangstijd, out TimeSpan aanvangstijd) ? (object)aanvangstijd : DBNull.Value);
-                        command.Parameters.AddWithValue("@Duration", matchDetails.Wedstrijdinformatie.Duur ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@SpelType", matchDetails.Wedstrijdinformatie.Speltype ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@Aanduiding", matchDetails.Wedstrijdinformatie.Aanduiding ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@PouleCode", int.TryParse(matchDetails.Wedstrijdinformatie.Poulecode, out int pouleCode) ? (object)pouleCode : DBNull.Value);
-                        command.Parameters.AddWithValue("@Poule", matchDetails.Wedstrijdinformatie.Poule ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisTeamID", matchDetails.Wedstrijdinformatie.Thuisteamid);
-                        command.Parameters.AddWithValue("@ThuisTeam", matchDetails.Wedstrijdinformatie.Thuisteam ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitTeamID", matchDetails.Wedstrijdinformatie.Uitteamid);
-                        command.Parameters.AddWithValue("@UitTeam", matchDetails.Wedstrijdinformatie.Uitteam ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@Opmerkingen", matchDetails.Wedstrijdinformatie.Opmerkingen ?? (object)DBNull.Value);
-
-                        // Match officials and kleedkamers
-                        command.Parameters.AddWithValue("@VerenigingScheidsrechterCode", matchDetails.Officials.Verenigingsscheidsrechtercode ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@VerenigingScheidsrechter", matchDetails.Officials.Verenigingsscheidsrechter ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@OverigeOfficialCode", matchDetails.Officials.Overigeofficialcode ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@OverigeOfficial", matchDetails.Officials.Overigeofficial ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@Scheidsrechters", matchDetails.Matchofficials.Scheidsrechters ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@KleedkamerThuis", matchDetails.Kleedkamers.Thuis ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@KleedkamerUit", matchDetails.Kleedkamers.Uit ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@KleedkamerOfficial", matchDetails.Kleedkamers.Official ?? (object)DBNull.Value);
-
-                        // Match accommodatie details
-                        command.Parameters.AddWithValue("@AccommodatieNaam", matchDetails.Accommodatie.Naam ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@AccommodatieStraat", matchDetails.Accommodatie.Straat ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@AccommodatiePlaats", matchDetails.Accommodatie.Plaats ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@AccommodatieTelefoon", matchDetails.Accommodatie.Telefoon ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@AccommodatieRouteplanner", matchDetails.Accommodatie.Routeplanner ?? (object)DBNull.Value);
-
-                        // Match thuisteam and uitteam details
-                        command.Parameters.AddWithValue("@ThuisTeamNaam", matchDetails.Thuisteam.Naam ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisTeamCode", matchDetails.Thuisteam.Code ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisTeamWebsite", matchDetails.Thuisteam.Website ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisTeamShirtKleur", matchDetails.Thuisteam.Shirtkleur ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisTeamStraat", matchDetails.Thuisteam.Straat ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisTeamPostcodePlaats", matchDetails.Thuisteam.Postcodeplaats ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisTeamTelefoon", matchDetails.Thuisteam.Telefoon ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@ThuisTeamEmail", matchDetails.Thuisteam.Email ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitTeamNaam", matchDetails.Uitteam.Naam ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitTeamCode", matchDetails.Uitteam.Code ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitTeamWebsite", matchDetails.Uitteam.Website ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitTeamShirtKleur", matchDetails.Uitteam.Shirtkleur ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitTeamStraat", matchDetails.Uitteam.Straat ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitTeamPostcodePlaats", matchDetails.Uitteam.Postcodeplaats ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitTeamTelefoon", matchDetails.Uitteam.Telefoon ?? (object)DBNull.Value);
-                        command.Parameters.AddWithValue("@UitTeamEmail", matchDetails.Uitteam.Email ?? (object)DBNull.Value);
-
-                        await command.ExecuteNonQueryAsync();
-                        log.LogInformation("MATCHDETAILS - Successfully inserted stg.MatchDetails.");
-                        connection.Close(); 
-                    }
-                }
-                catch (Exception ex)
-                {
-                    log.LogError($"Error storing match details in database: {ex.Message}");
-                }
-            }
-        }
-
-        private static async Task SaveToDatabaseTeams(List<Team> teams, ILogger log)
-        {
-            using (SqlConnection connection = new SqlConnection(DatabaseConfig.ConnectionString))
-            {
-                await connection.OpenAsync();
-                foreach (var team in teams)
-                {
-                    string query = @"INSERT INTO [stg].[teams]
-                            ([teamcode]
-                            ,[lokaleteamcode]
-                            ,[poulecode]
-                            ,[teamnaam]
-                            ,[competitienaam]
-                            ,[klasse]
-                            ,[poule]
-                            ,[klassepoule]
-                            ,[spelsoort]
-                            ,[competitiesoort]
-                            ,[geslacht]
-                            ,[teamsoort]
-                            ,[leeftijdscategorie]
-                            ,[kalespelsoort]
-                            ,[speeldag]
-                            ,[speeldagteam]
-                            ,[more])
-                        VALUES
-                            (@teamcode
-                            ,@lokaleteamcode
-                            ,@poulecode
-                            ,@teamnaam
-                            ,@competitienaam
-                            ,@klasse
-                            ,@poule
-                            ,@klassepoule
-                            ,@spelsoort
-                            ,@competitiesoort
-                            ,@geslacht
-                            ,@teamsoort
-                            ,@leeftijdscategorie
-                            ,@kalespelsoort
-                            ,@speeldag
-                            ,@speeldagteam
-                            ,@more 
-                            )";
-
-                    using (SqlCommand cmd = new SqlCommand(query, connection))
-                    {
-                        cmd.Parameters.AddWithValue("@teamcode", team.teamcode);
-                        cmd.Parameters.AddWithValue("@lokaleteamcode", team.lokaleteamcode); 
-                        cmd.Parameters.AddWithValue("@poulecode", team.poulecode ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@teamnaam", team.teamnaam);
-                        cmd.Parameters.AddWithValue("@competitienaam", team.competitienaam ?? (object)DBNull.Value); 
-                        cmd.Parameters.AddWithValue("@klasse", team.klasse ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@poule", team.poule ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@klassepoule", team.klassepoule ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@spelsoort", team.spelsoort ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@competitiesoort", team.competitiesoort ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@geslacht", team.geslacht ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@teamsoort", team.teamsoort ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@leeftijdscategorie", team.leeftijdscategorie ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@kalespelsoort", team.kalespelsoort ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@speeldag", team.speeldag ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@speeldagteam", team.speeldagteam ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@more", team.more ?? (object)DBNull.Value);
-                        await cmd.ExecuteNonQueryAsync();
-                    }
-                }
-                log.LogInformation("TEAMS - Data inserted into staging table.");
-                connection.Close();
-            }
-        }
-
-        private static async Task SaveProgrammaToStaging(List<Match> matches, ILogger log)
-        {
-            using (SqlConnection connection = new SqlConnection(DatabaseConfig.ConnectionString))
-            {
-                await connection.OpenAsync();
-                int inserted = 0;
-                foreach (var match in matches)
-                {
-                    string query = @"
-                        IF NOT EXISTS (SELECT 1 FROM [stg].[matches] WHERE [wedstrijdcode] = @wedstrijdcode)
-                        INSERT INTO [stg].[matches] (
-                             [wedstrijddatum],[wedstrijdcode],[wedstrijdnummer],[datum],[wedstrijd]
-                            ,[accommodatie],[aanvangstijd],[thuisteam],[thuisteamid],[thuisteamlogo]
-                            ,[thuisteamclubrelatiecode],[uitteamclubrelatiecode],[uitteam],[uitteamid]
-                            ,[uitteamlogo],[competitiesoort],[status],[meer]
-                            ,[teamnaam],[teamvolgorde],[competitie],[klasse],[poule],[klassepoule]
-                            ,[kaledatum],[vertrektijd],[verzameltijd],[scheidsrechters],[scheidsrechter]
-                            ,[veld],[locatie],[plaats],[rijders]
-                            ,[kleedkamerthuisteam],[kleedkameruitteam],[kleedkamerscheidsrechter]
-                        ) VALUES (
-                             @wedstrijddatum,@wedstrijdcode,@wedstrijdnummer,@datum,@wedstrijd
-                            ,@accommodatie,@aanvangstijd,@thuisteam,@thuisteamid,@thuisteamlogo
-                            ,@thuisteamclubrelatiecode,@uitteamclubrelatiecode,@uitteam,@uitteamid
-                            ,@uitteamlogo,@competitiesoort,@status,@meer
-                            ,@teamnaam,@teamvolgorde,@competitie,@klasse,@poule,@klassepoule
-                            ,@kaledatum,@vertrektijd,@verzameltijd,@scheidsrechters,@scheidsrechter
-                            ,@veld,@locatie,@plaats,@rijders
-                            ,@kleedkamerthuisteam,@kleedkameruitteam,@kleedkamerscheidsrechter
-                        )";
-
-                    using (SqlCommand cmd = new SqlCommand(query, connection))
-                    {
-                        // Shared fields
-                        cmd.Parameters.AddWithValue("@wedstrijddatum", match.wedstrijddatum ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@wedstrijdcode", match.wedstrijdcode);
-                        cmd.Parameters.AddWithValue("@wedstrijdnummer", match.wedstrijdnummer);
-                        cmd.Parameters.AddWithValue("@datum", match.datum ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@wedstrijd", match.wedstrijd ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@accommodatie", match.accommodatie ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@aanvangstijd", match.aanvangstijd ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@thuisteam", match.thuisteam ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@thuisteamid", match.thuisteamid ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@thuisteamlogo", match.thuisteamlogo ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@thuisteamclubrelatiecode", match.thuisteamclubrelatiecode ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitteamclubrelatiecode", match.uitteamclubrelatiecode ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitteam", match.uitteam ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitteamid", match.uitteamid ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitteamlogo", match.uitteamlogo ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@competitiesoort", match.competitiesoort ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@status", match.status ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@meer", match.meer ?? (object)DBNull.Value);
-                        // /programma specific fields
-                        cmd.Parameters.AddWithValue("@teamnaam", match.teamnaam ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@teamvolgorde", match.teamvolgorde);
-                        cmd.Parameters.AddWithValue("@competitie", match.competitie ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@klasse", match.klasse ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@poule", match.poule ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@klassepoule", match.klassepoule ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@kaledatum", match.kaledatum ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@vertrektijd", match.vertrektijd ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@verzameltijd", match.verzameltijd ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@scheidsrechters", match.scheidsrechters ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@scheidsrechter", match.scheidsrechter ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@veld", match.veld ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@locatie", match.locatie ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@plaats", match.plaats ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@rijders", match.rijders ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@kleedkamerthuisteam", match.kleedkamerthuisteam ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@kleedkameruitteam", match.kleedkameruitteam ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@kleedkamerscheidsrechter", match.kleedkamerscheidsrechter ?? (object)DBNull.Value);
-                        int rowsAffected = await cmd.ExecuteNonQueryAsync();
-                        if (rowsAffected > 0) inserted++;
-                    }
-                }
-                log.LogInformation($"MATCHES/PROGRAMMA - {inserted} new rows inserted into staging.");
-                connection.Close();
-            }
-        }
-
-        private static async Task MergeUitslagenIntoStaging(List<Match> matches, ILogger log)
-        {
-            using (SqlConnection connection = new SqlConnection(DatabaseConfig.ConnectionString))
-            {
-                await connection.OpenAsync();
-                int updated = 0;
-                foreach (var match in matches)
-                {
-                    // UPDATE: alleen scorevelden bijwerken op bestaande programma-rij.
-                    // INSERT: alleen voor verleden wedstrijden die niet via /programma binnenkwamen.
-                    // /programma is de primaire bron voor toekomstige wedstrijden (inclusief oefenwedstrijden).
-                    string query = @"
-                        IF EXISTS (SELECT 1 FROM [stg].[matches] WHERE [wedstrijdcode] = @wedstrijdcode)
-                            UPDATE [stg].[matches] SET
-                                 [uitslag]              = @uitslag
-                                ,[uitslag-regulier]     = @uitslagregulier
-                                ,[uitslag-nv]           = @uitslagnv
-                                ,[uitslag-s]            = @uitslags
-                                ,[datumopgemaakt]       = @datumopgemaakt
-                                ,[competitienaam]       = @competitienaam
-                                ,[eigenteam]            = @eigenteam
-                                ,[sportomschrijving]    = @sportomschrijving
-                                ,[verenigingswedstrijd] = @verenigingswedstrijd
-                                ,[status]               = @status
-                            WHERE [wedstrijdcode] = @wedstrijdcode
-                        ELSE IF @wedstrijddatum <= CONVERT(NVARCHAR(50), GETUTCDATE(), 127)
-                            INSERT INTO [stg].[matches] (
-                                 [wedstrijddatum],[wedstrijdcode],[wedstrijdnummer],[datum],[wedstrijd]
-                                ,[accommodatie],[aanvangstijd],[thuisteam],[thuisteamid],[thuisteamlogo]
-                                ,[thuisteamclubrelatiecode],[uitteamclubrelatiecode],[uitteam],[uitteamid]
-                                ,[uitteamlogo],[competitiesoort],[status],[meer]
-                                ,[datumopgemaakt],[uitslag],[uitslag-regulier],[uitslag-nv],[uitslag-s]
-                                ,[competitienaam],[eigenteam],[sportomschrijving],[verenigingswedstrijd]
-                            ) VALUES (
-                                 @wedstrijddatum,@wedstrijdcode,@wedstrijdnummer,@datum,@wedstrijd
-                                ,@accommodatie,@aanvangstijd,@thuisteam,@thuisteamid,@thuisteamlogo
-                                ,@thuisteamclubrelatiecode,@uitteamclubrelatiecode,@uitteam,@uitteamid
-                                ,@uitteamlogo,@competitiesoort,@status,@meer
-                                ,@datumopgemaakt,@uitslag,@uitslagregulier,@uitslagnv,@uitslags
-                                ,@competitienaam,@eigenteam,@sportomschrijving,@verenigingswedstrijd
-                            )";
-
-                    using (SqlCommand cmd = new SqlCommand(query, connection))
-                    {
-                        // Shared fields
-                        cmd.Parameters.AddWithValue("@wedstrijddatum", match.wedstrijddatum ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@wedstrijdcode", match.wedstrijdcode);
-                        cmd.Parameters.AddWithValue("@wedstrijdnummer", match.wedstrijdnummer);
-                        cmd.Parameters.AddWithValue("@datum", match.datum ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@wedstrijd", match.wedstrijd ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@accommodatie", match.accommodatie ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@aanvangstijd", match.aanvangstijd ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@thuisteam", match.thuisteam ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@thuisteamid", match.thuisteamid ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@thuisteamlogo", match.thuisteamlogo ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@thuisteamclubrelatiecode", match.thuisteamclubrelatiecode ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitteamclubrelatiecode", match.uitteamclubrelatiecode ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitteam", match.uitteam ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitteamid", match.uitteamid ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitteamlogo", match.uitteamlogo ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@competitiesoort", match.competitiesoort ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@status", match.status ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@meer", match.meer ?? (object)DBNull.Value);
-                        // /uitslagen specific fields
-                        cmd.Parameters.AddWithValue("@datumopgemaakt", match.datumopgemaakt ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitslag", match.uitslag ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitslagregulier", match.uitslag_regulier ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitslagnv", match.uitslag_nv ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@uitslags", match.uitslag_s ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@competitienaam", match.competitienaam ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@eigenteam", match.eigenteam ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@sportomschrijving", match.sportomschrijving ?? (object)DBNull.Value);
-                        cmd.Parameters.AddWithValue("@verenigingswedstrijd", match.verenigingswedstrijd ?? (object)DBNull.Value);
-
-                        int rows = await cmd.ExecuteNonQueryAsync();
-                        // IF EXISTS returns 1 row affected for UPDATE; ELSE returns 1 for INSERT
-                        // We track by checking which branch ran via a secondary count query isn't feasible,
-                        // so just track total affected rows.
-                        if (rows > 0) updated++;
-                    }
-                }
-                log.LogInformation($"MATCHES/UITSLAGEN - {updated} rows merged (updated or inserted) into staging.");
-                connection.Close();
-            }
-        }
+        // Publieke entry-point voor AdminSyncFunction (fire-and-forget achtergrondtaak).
+        public static async Task RunSyncAsync(
+            int fromWeekOffset, int toWeekOffset,
+            string sportlinkApiUrl, string sportlinkClientId,
+            ILogger log)
+            => await SportlinkSyncPipeline.RunSyncAsync(fromWeekOffset, toWeekOffset, sportlinkApiUrl, sportlinkClientId, log);
     }
 }

--- a/FunctionApp/Sync/SportlinkStagingRepository.cs
+++ b/FunctionApp/Sync/SportlinkStagingRepository.cs
@@ -1,0 +1,292 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using static SportlinkFunction.SystemUtilities;
+
+namespace SportlinkFunction;
+
+/// <summary>
+/// Staging-laag voor Sportlink-data: schrijft opgehaalde API-data naar stg.*-tabellen.
+/// Extracted uit Function1.cs (#466).
+/// </summary>
+internal static class SportlinkStagingRepository
+{
+    private static string Cs => DatabaseConfig.ConnectionString;
+
+    internal static async Task<List<string>> GetWedstrijdcodesAsync(ILogger log)
+    {
+        var list = new List<string>();
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand("SELECT wedstrijdcode FROM [stg].[matches]", conn);
+        using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var code = reader["wedstrijdcode"]?.ToString();
+            if (code != null) list.Add(code);
+        }
+        return list;
+    }
+
+    internal static async Task SaveTeamsAsync(List<Team> teams, ILogger log)
+    {
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        foreach (var team in teams)
+        {
+            using var cmd = new SqlCommand(@"
+                INSERT INTO [stg].[teams]
+                    ([teamcode],[lokaleteamcode],[poulecode],[teamnaam],[competitienaam],[klasse],
+                     [poule],[klassepoule],[spelsoort],[competitiesoort],[geslacht],[teamsoort],
+                     [leeftijdscategorie],[kalespelsoort],[speeldag],[speeldagteam],[more])
+                VALUES
+                    (@teamcode,@lokaleteamcode,@poulecode,@teamnaam,@competitienaam,@klasse,
+                     @poule,@klassepoule,@spelsoort,@competitiesoort,@geslacht,@teamsoort,
+                     @leeftijdscategorie,@kalespelsoort,@speeldag,@speeldagteam,@more)", conn);
+            cmd.Parameters.AddWithValue("@teamcode",          team.teamcode);
+            cmd.Parameters.AddWithValue("@lokaleteamcode",    team.lokaleteamcode);
+            cmd.Parameters.AddWithValue("@poulecode",         team.poulecode         ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@teamnaam",          team.teamnaam);
+            cmd.Parameters.AddWithValue("@competitienaam",    team.competitienaam    ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@klasse",            team.klasse            ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@poule",             team.poule             ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@klassepoule",       team.klassepoule       ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@spelsoort",         team.spelsoort         ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@competitiesoort",   team.competitiesoort   ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@geslacht",          team.geslacht          ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@teamsoort",         team.teamsoort         ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@leeftijdscategorie",team.leeftijdscategorie?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@kalespelsoort",     team.kalespelsoort     ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@speeldag",          team.speeldag          ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@speeldagteam",      team.speeldagteam      ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@more",              team.more              ?? (object)DBNull.Value);
+            await cmd.ExecuteNonQueryAsync();
+        }
+        log.LogInformation("TEAMS - {Count} rows inserted into staging.", teams.Count);
+    }
+
+    internal static async Task<int> SaveProgrammaAsync(List<Match> matches, ILogger log)
+    {
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        int inserted = 0;
+        foreach (var match in matches)
+        {
+            using var cmd = new SqlCommand(@"
+                IF NOT EXISTS (SELECT 1 FROM [stg].[matches] WHERE [wedstrijdcode] = @wedstrijdcode)
+                INSERT INTO [stg].[matches] (
+                     [wedstrijddatum],[wedstrijdcode],[wedstrijdnummer],[datum],[wedstrijd]
+                    ,[accommodatie],[aanvangstijd],[thuisteam],[thuisteamid],[thuisteamlogo]
+                    ,[thuisteamclubrelatiecode],[uitteamclubrelatiecode],[uitteam],[uitteamid]
+                    ,[uitteamlogo],[competitiesoort],[status],[meer]
+                    ,[teamnaam],[teamvolgorde],[competitie],[klasse],[poule],[klassepoule]
+                    ,[kaledatum],[vertrektijd],[verzameltijd],[scheidsrechters],[scheidsrechter]
+                    ,[veld],[locatie],[plaats],[rijders]
+                    ,[kleedkamerthuisteam],[kleedkameruitteam],[kleedkamerscheidsrechter]
+                ) VALUES (
+                     @wedstrijddatum,@wedstrijdcode,@wedstrijdnummer,@datum,@wedstrijd
+                    ,@accommodatie,@aanvangstijd,@thuisteam,@thuisteamid,@thuisteamlogo
+                    ,@thuisteamclubrelatiecode,@uitteamclubrelatiecode,@uitteam,@uitteamid
+                    ,@uitteamlogo,@competitiesoort,@status,@meer
+                    ,@teamnaam,@teamvolgorde,@competitie,@klasse,@poule,@klassepoule
+                    ,@kaledatum,@vertrektijd,@verzameltijd,@scheidsrechters,@scheidsrechter
+                    ,@veld,@locatie,@plaats,@rijders
+                    ,@kleedkamerthuisteam,@kleedkameruitteam,@kleedkamerscheidsrechter
+                )", conn);
+            AddMatchParams(cmd, match);
+            cmd.Parameters.AddWithValue("@teamnaam",                   match.teamnaam                  ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@teamvolgorde",               match.teamvolgorde);
+            cmd.Parameters.AddWithValue("@competitie",                 match.competitie                ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@klasse",                     match.klasse                    ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@poule",                      match.poule                     ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@klassepoule",                match.klassepoule               ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@kaledatum",                  match.kaledatum                 ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@vertrektijd",                match.vertrektijd               ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@verzameltijd",               match.verzameltijd              ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@scheidsrechters",            match.scheidsrechters           ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@scheidsrechter",             match.scheidsrechter            ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@veld",                       match.veld                      ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@locatie",                    match.locatie                   ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@plaats",                     match.plaats                    ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@rijders",                    match.rijders                   ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@kleedkamerthuisteam",        match.kleedkamerthuisteam       ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@kleedkameruitteam",          match.kleedkameruitteam         ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@kleedkamerscheidsrechter",   match.kleedkamerscheidsrechter  ?? (object)DBNull.Value);
+            if (await cmd.ExecuteNonQueryAsync() > 0) inserted++;
+        }
+        log.LogInformation("MATCHES/PROGRAMMA - {Inserted} new rows inserted into staging.", inserted);
+        return inserted;
+    }
+
+    internal static async Task<int> MergeUitslagenAsync(List<Match> matches, ILogger log)
+    {
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        int updated = 0;
+        foreach (var match in matches)
+        {
+            using var cmd = new SqlCommand(@"
+                IF EXISTS (SELECT 1 FROM [stg].[matches] WHERE [wedstrijdcode] = @wedstrijdcode)
+                    UPDATE [stg].[matches] SET
+                         [uitslag]              = @uitslag
+                        ,[uitslag-regulier]     = @uitslagregulier
+                        ,[uitslag-nv]           = @uitslagnv
+                        ,[uitslag-s]            = @uitslags
+                        ,[datumopgemaakt]       = @datumopgemaakt
+                        ,[competitienaam]       = @competitienaam
+                        ,[eigenteam]            = @eigenteam
+                        ,[sportomschrijving]    = @sportomschrijving
+                        ,[verenigingswedstrijd] = @verenigingswedstrijd
+                        ,[status]               = @status
+                    WHERE [wedstrijdcode] = @wedstrijdcode
+                ELSE IF @wedstrijddatum <= CONVERT(NVARCHAR(50), GETUTCDATE(), 127)
+                    INSERT INTO [stg].[matches] (
+                         [wedstrijddatum],[wedstrijdcode],[wedstrijdnummer],[datum],[wedstrijd]
+                        ,[accommodatie],[aanvangstijd],[thuisteam],[thuisteamid],[thuisteamlogo]
+                        ,[thuisteamclubrelatiecode],[uitteamclubrelatiecode],[uitteam],[uitteamid]
+                        ,[uitteamlogo],[competitiesoort],[status],[meer]
+                        ,[datumopgemaakt],[uitslag],[uitslag-regulier],[uitslag-nv],[uitslag-s]
+                        ,[competitienaam],[eigenteam],[sportomschrijving],[verenigingswedstrijd]
+                    ) VALUES (
+                         @wedstrijddatum,@wedstrijdcode,@wedstrijdnummer,@datum,@wedstrijd
+                        ,@accommodatie,@aanvangstijd,@thuisteam,@thuisteamid,@thuisteamlogo
+                        ,@thuisteamclubrelatiecode,@uitteamclubrelatiecode,@uitteam,@uitteamid
+                        ,@uitteamlogo,@competitiesoort,@status,@meer
+                        ,@datumopgemaakt,@uitslag,@uitslagregulier,@uitslagnv,@uitslags
+                        ,@competitienaam,@eigenteam,@sportomschrijving,@verenigingswedstrijd
+                    )", conn);
+            AddMatchParams(cmd, match);
+            cmd.Parameters.AddWithValue("@datumopgemaakt",      match.datumopgemaakt     ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@uitslag",             match.uitslag            ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@uitslagregulier",     match.uitslag_regulier   ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@uitslagnv",           match.uitslag_nv         ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@uitslags",            match.uitslag_s          ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@competitienaam",      match.competitienaam     ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@eigenteam",           match.eigenteam          ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@sportomschrijving",   match.sportomschrijving  ?? (object)DBNull.Value);
+            cmd.Parameters.AddWithValue("@verenigingswedstrijd",match.verenigingswedstrijd ?? (object)DBNull.Value);
+            if (await cmd.ExecuteNonQueryAsync() > 0) updated++;
+        }
+        log.LogInformation("MATCHES/UITSLAGEN - {Updated} rows merged (updated or inserted) into staging.", updated);
+        return updated;
+    }
+
+    internal static async Task SaveMatchDetailsAsync(MatchDetails matchDetails, ILogger log)
+    {
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand(@"
+            IF NOT EXISTS (SELECT 1 FROM [stg].[matchdetails] WHERE WedstrijdCode = @WedstrijdCode)
+            INSERT INTO [stg].[matchdetails] (
+                WedstrijdCode, InternCode, VeldNaam, VeldLocatie, VertrekTijd, Rijder,
+                ThuisScore, ThuisScoreRegulier, ThuisScoreNV, ThuisScoreS, UitScore, UitScoreRegulier,
+                UitScoreNV, UitScoreS, Klasse, WedstrijdType, CompetitieType, Categorie, MatchDateTime,
+                MatchDate, Aanvangstijd, Duration, SpelType, Aanduiding, PouleCode, Poule, ThuisTeamID,
+                ThuisTeam, UitTeamID, UitTeam, Opmerkingen, VerenigingScheidsrechterCode, VerenigingScheidsrechter,
+                OverigeOfficialCode, OverigeOfficial, Scheidsrechters, KleedkamerThuis, KleedkamerUit, KleedkamerOfficial,
+                AccommodatieNaam, AccommodatieStraat, AccommodatiePlaats, AccommodatieTelefoon, AccommodatieRouteplanner,
+                ThuisTeamNaam, ThuisTeamCode, ThuisTeamWebsite, ThuisTeamShirtKleur, ThuisTeamStraat,
+                ThuisTeamPostcodePlaats, ThuisTeamTelefoon, ThuisTeamEmail, UitTeamNaam, UitTeamCode,
+                UitTeamWebsite, UitTeamShirtKleur, UitTeamStraat, UitTeamPostcodePlaats, UitTeamTelefoon, UitTeamEmail
+            ) VALUES (
+                @WedstrijdCode, @InternCode, @VeldNaam, @VeldLocatie, @VertrekTijd, @Rijder,
+                @ThuisScore, @ThuisScoreRegulier, @ThuisScoreNV, @ThuisScoreS, @UitScore, @UitScoreRegulier,
+                @UitScoreNV, @UitScoreS, @Klasse, @WedstrijdType, @CompetitieType, @Categorie, @MatchDateTime,
+                @MatchDate, @Aanvangstijd, @Duration, @SpelType, @Aanduiding, @PouleCode, @Poule, @ThuisTeamID,
+                @ThuisTeam, @UitTeamID, @UitTeam, @Opmerkingen, @VerenigingScheidsrechterCode, @VerenigingScheidsrechter,
+                @OverigeOfficialCode, @OverigeOfficial, @Scheidsrechters, @KleedkamerThuis, @KleedkamerUit, @KleedkamerOfficial,
+                @AccommodatieNaam, @AccommodatieStraat, @AccommodatiePlaats, @AccommodatieTelefoon, @AccommodatieRouteplanner,
+                @ThuisTeamNaam, @ThuisTeamCode, @ThuisTeamWebsite, @ThuisTeamShirtKleur, @ThuisTeamStraat,
+                @ThuisTeamPostcodePlaats, @ThuisTeamTelefoon, @ThuisTeamEmail, @UitTeamNaam, @UitTeamCode,
+                @UitTeamWebsite, @UitTeamShirtKleur, @UitTeamStraat, @UitTeamPostcodePlaats, @UitTeamTelefoon, @UitTeamEmail
+            )", conn);
+
+        var wi = matchDetails.Wedstrijdinformatie;
+        cmd.Parameters.AddWithValue("@WedstrijdCode",               wi.Wedstrijdnummer);
+        cmd.Parameters.AddWithValue("@InternCode",                  wi.Wedstijdnummerintern);
+        cmd.Parameters.AddWithValue("@VeldNaam",                    wi.Veldnaam             ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@VeldLocatie",                 wi.Veldlocatie          ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@VertrekTijd",                 wi.Vertrektijd          ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@Rijder",                      wi.Rijder               ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisScore",                  wi.Thuisscore           ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisScoreRegulier",          wi.ThuisscoreRegulier   ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisScoreNV",                wi.ThuisscoreNv         ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisScoreS",                 wi.ThuisscoreS          ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitScore",                    wi.Uitscore             ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitScoreRegulier",            wi.UitscoreRegulier     ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitScoreNV",                  wi.UitscoreNv           ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitScoreS",                   wi.UitscoreS            ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@Klasse",                      wi.Klasse               ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@WedstrijdType",               wi.Wedstrijdtype        ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@CompetitieType",              wi.Competitietype       ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@Categorie",                   wi.Categorie            ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@MatchDateTime",               wi.Wedstrijddatetime    ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@MatchDate",                   wi.Wedstrijddatum       ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@Aanvangstijd",
+            TimeSpan.TryParse(wi.Aanvangstijd, out var ts) ? (object)ts : DBNull.Value);
+        cmd.Parameters.AddWithValue("@Duration",                    wi.Duur                 ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@SpelType",                    wi.Speltype             ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@Aanduiding",                  wi.Aanduiding           ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@PouleCode",
+            int.TryParse(wi.Poulecode, out var pc) ? (object)pc : DBNull.Value);
+        cmd.Parameters.AddWithValue("@Poule",                       wi.Poule                ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisTeamID",                 wi.Thuisteamid);
+        cmd.Parameters.AddWithValue("@ThuisTeam",                   wi.Thuisteam            ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitTeamID",                   wi.Uitteamid);
+        cmd.Parameters.AddWithValue("@UitTeam",                     wi.Uitteam              ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@Opmerkingen",                 wi.Opmerkingen          ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@VerenigingScheidsrechterCode", matchDetails.Officials.Verenigingsscheidsrechtercode ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@VerenigingScheidsrechter",     matchDetails.Officials.Verenigingsscheidsrechter     ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@OverigeOfficialCode",          matchDetails.Officials.Overigeofficialcode           ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@OverigeOfficial",              matchDetails.Officials.Overigeofficial               ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@Scheidsrechters",              matchDetails.Matchofficials.Scheidsrechters           ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@KleedkamerThuis",              matchDetails.Kleedkamers.Thuis                        ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@KleedkamerUit",                matchDetails.Kleedkamers.Uit                          ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@KleedkamerOfficial",           matchDetails.Kleedkamers.Official                     ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@AccommodatieNaam",             matchDetails.Accommodatie.Naam                        ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@AccommodatieStraat",           matchDetails.Accommodatie.Straat                      ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@AccommodatiePlaats",           matchDetails.Accommodatie.Plaats                      ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@AccommodatieTelefoon",         matchDetails.Accommodatie.Telefoon                    ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@AccommodatieRouteplanner",     matchDetails.Accommodatie.Routeplanner                ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisTeamNaam",                matchDetails.Thuisteam.Naam                           ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisTeamCode",                matchDetails.Thuisteam.Code                           ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisTeamWebsite",             matchDetails.Thuisteam.Website                        ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisTeamShirtKleur",          matchDetails.Thuisteam.Shirtkleur                     ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisTeamStraat",              matchDetails.Thuisteam.Straat                         ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisTeamPostcodePlaats",      matchDetails.Thuisteam.Postcodeplaats                 ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisTeamTelefoon",            matchDetails.Thuisteam.Telefoon                       ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@ThuisTeamEmail",               matchDetails.Thuisteam.Email                          ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitTeamNaam",                  matchDetails.Uitteam.Naam                             ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitTeamCode",                  matchDetails.Uitteam.Code                             ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitTeamWebsite",               matchDetails.Uitteam.Website                          ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitTeamShirtKleur",            matchDetails.Uitteam.Shirtkleur                       ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitTeamStraat",                matchDetails.Uitteam.Straat                           ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitTeamPostcodePlaats",        matchDetails.Uitteam.Postcodeplaats                   ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitTeamTelefoon",              matchDetails.Uitteam.Telefoon                         ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@UitTeamEmail",                 matchDetails.Uitteam.Email                            ?? (object)DBNull.Value);
+        await cmd.ExecuteNonQueryAsync();
+        log.LogInformation("MATCHDETAILS - stg.matchdetails rij opgeslagen.");
+    }
+
+    // Gedeelde basisvelden voor programma én uitslagen.
+    private static void AddMatchParams(SqlCommand cmd, Match match)
+    {
+        cmd.Parameters.AddWithValue("@wedstrijddatum",           match.wedstrijddatum            ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@wedstrijdcode",            match.wedstrijdcode);
+        cmd.Parameters.AddWithValue("@wedstrijdnummer",          match.wedstrijdnummer);
+        cmd.Parameters.AddWithValue("@datum",                    match.datum                     ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@wedstrijd",                match.wedstrijd                 ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@accommodatie",             match.accommodatie              ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@aanvangstijd",             match.aanvangstijd              ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@thuisteam",                match.thuisteam                 ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@thuisteamid",              match.thuisteamid               ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@thuisteamlogo",            match.thuisteamlogo             ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@thuisteamclubrelatiecode", match.thuisteamclubrelatiecode  ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@uitteamclubrelatiecode",   match.uitteamclubrelatiecode    ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@uitteam",                  match.uitteam                   ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@uitteamid",                match.uitteamid                 ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@uitteamlogo",              match.uitteamlogo               ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@competitiesoort",          match.competitiesoort           ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@status",                   match.status                    ?? (object)DBNull.Value);
+        cmd.Parameters.AddWithValue("@meer",                     match.meer                      ?? (object)DBNull.Value);
+    }
+}

--- a/FunctionApp/Sync/SportlinkSyncPipeline.cs
+++ b/FunctionApp/Sync/SportlinkSyncPipeline.cs
@@ -1,0 +1,175 @@
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using static SportlinkFunction.SystemUtilities;
+
+namespace SportlinkFunction;
+
+/// <summary>
+/// Orkestreert de volledige Sportlink-sync: API ophalen → staging → merge → timestamp.
+/// Extracted uit Function1.cs (#466).
+/// </summary>
+internal static class SportlinkSyncPipeline
+{
+    private static readonly HttpClient _client = new();
+
+    // partialFailure: als één stap faalt, slaan we LastSyncTimestamp NIET op. (#438, #464)
+    internal static async Task RunSyncAsync(
+        int fromWeekOffset, int toWeekOffset,
+        string sportlinkApiUrl, string sportlinkClientId,
+        ILogger log)
+    {
+        var partialFailure = false;
+
+        await CreateStagingTable.ExecuteAsync("teams");
+        try
+        {
+            await FetchAndStoreTeamsAsync($"{sportlinkApiUrl}/teams?{sportlinkClientId}", log);
+            log.LogInformation("TEAMS - GET endpoint=/teams");
+        }
+        catch (Exception ex)
+        {
+            log.LogError(ex, "TEAMS - fetch mislukt");
+            partialFailure = true;
+        }
+
+        await CreateStagingTable.ExecuteAsync("matches");
+
+        log.LogInformation("MATCHES/PROGRAMMA - Fetching weekOffset {From} to {To}", fromWeekOffset, toWeekOffset);
+        for (int weekOffset = fromWeekOffset; weekOffset <= toWeekOffset; weekOffset++)
+        {
+            try
+            {
+                await FetchAndStoreProgrammaAsync(
+                    $"{sportlinkApiUrl}/programma?{sportlinkClientId}&weekoffset={weekOffset}", log);
+                log.LogInformation("MATCHES/PROGRAMMA - GET weekOffset={WeekOffset}", weekOffset);
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "MATCHES/PROGRAMMA - fetch mislukt weekOffset={WeekOffset}", weekOffset);
+                partialFailure = true;
+            }
+        }
+
+        int scoreFrom = Math.Min(fromWeekOffset, -2);
+        log.LogInformation("MATCHES/UITSLAGEN - Fetching weekOffset {From} to 0", scoreFrom);
+        for (int weekOffset = scoreFrom; weekOffset <= 0; weekOffset++)
+        {
+            try
+            {
+                await FetchAndStoreUitslagenAsync(
+                    $"{sportlinkApiUrl}/uitslagen?{sportlinkClientId}&weekoffset={weekOffset}", log);
+                log.LogInformation("MATCHES/UITSLAGEN - GET weekOffset={WeekOffset}", weekOffset);
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "MATCHES/UITSLAGEN - fetch mislukt weekOffset={WeekOffset}", weekOffset);
+                partialFailure = true;
+            }
+        }
+
+        await CreateStagingTable.ExecuteAsync("matchdetails");
+        var wedstrijdcodes = await SportlinkStagingRepository.GetWedstrijdcodesAsync(log);
+        int mdOk = 0, mdFout = 0;
+        foreach (var wedstrijdcode in wedstrijdcodes)
+        {
+            if (await FetchAndStoreMatchDetailsAsync(
+                    $"{sportlinkApiUrl}/wedstrijd-informatie?{sportlinkClientId}&wedstrijdcode={wedstrijdcode}",
+                    log))
+            {
+                mdOk++;
+                log.LogInformation("MATCHDETAILS - GET wedstrijdcode={Code}", wedstrijdcode);
+            }
+            else
+            {
+                mdFout++;
+                partialFailure = true;
+            }
+        }
+        log.LogInformation("MATCHDETAILS - {Ok} succesvol, {Fout} mislukt van {Total}",
+            mdOk, mdFout, wedstrijdcodes.Count);
+
+        await new MergeStgToHis("stg", "teams",        "his", "teams").ExecuteAsync(log);
+        await new MergeStgToHis("stg", "matches",      "his", "matches").ExecuteAsync(log);
+        await new MergeStgToHis("stg", "matchdetails", "his", "matchdetails").ExecuteAsync(log);
+
+        await Planner.PlannerDataAccess.MarkeerVervallenGeplandeWedstrijdenAsync(log);
+
+        if (!partialFailure)
+            await AppSettings.SaveLastSyncTimestampAsync(log);
+        else
+            log.LogWarning("Sync gedeeltelijk mislukt — LastSyncTimestamp NIET bijgewerkt");
+    }
+
+    private static async Task FetchAndStoreTeamsAsync(string apiUrl, ILogger log)
+    {
+        var response = await _client.GetAsync(apiUrl);
+        response.EnsureSuccessStatusCode();
+        var json  = await response.Content.ReadAsStringAsync();
+        var teams = JsonConvert.DeserializeObject<List<Team>>(json, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+        if (teams != null)
+        {
+            log.LogInformation("TEAMS - {Count} gevonden.", teams.Count);
+            await SportlinkStagingRepository.SaveTeamsAsync(teams, log);
+        }
+        else
+        {
+            log.LogWarning("TEAMS - geen data gevonden.");
+        }
+    }
+
+    private static async Task FetchAndStoreProgrammaAsync(string apiUrl, ILogger log)
+    {
+        var response = await _client.GetAsync(apiUrl);
+        response.EnsureSuccessStatusCode();
+        var json    = await response.Content.ReadAsStringAsync();
+        var matches = JsonConvert.DeserializeObject<List<Match>>(json, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+        if (matches is { Count: > 0 })
+        {
+            log.LogInformation("MATCHES/PROGRAMMA - {Count} gevonden.", matches.Count);
+            await SportlinkStagingRepository.SaveProgrammaAsync(matches, log);
+        }
+    }
+
+    private static async Task FetchAndStoreUitslagenAsync(string apiUrl, ILogger log)
+    {
+        var response = await _client.GetAsync(apiUrl);
+        response.EnsureSuccessStatusCode();
+        var json    = await response.Content.ReadAsStringAsync();
+        var matches = JsonConvert.DeserializeObject<List<Match>>(json, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+        if (matches is { Count: > 0 })
+        {
+            log.LogInformation("MATCHES/UITSLAGEN - {Count} gevonden.", matches.Count);
+            await SportlinkStagingRepository.MergeUitslagenAsync(matches, log);
+        }
+    }
+
+    // Retourneert true bij succes, false bij elke fout — zodat de caller partialFailure kan bijhouden. (#464)
+    internal static async Task<bool> FetchAndStoreMatchDetailsAsync(string apiUrl, ILogger log)
+    {
+        try
+        {
+            var response = await _client.GetAsync(apiUrl);
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync();
+            try
+            {
+                var details = JsonConvert.DeserializeObject<MatchDetails>(json, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+                if (details != null)
+                    await SportlinkStagingRepository.SaveMatchDetailsAsync(details, log);
+                else
+                    log.LogWarning("MATCHDETAILS - geen data gevonden.");
+            }
+            catch (JsonSerializationException ex)
+            {
+                log.LogError("MATCHDETAILS - JSON-deserialisatiefout: {Message}", ex.Message);
+                return false;
+            }
+            return true;
+        }
+        catch (Exception ex)
+        {
+            log.LogError("MATCHDETAILS - ophalen mislukt voor {Url}: {Message}", apiUrl, ex.Message);
+            return false;
+        }
+    }
+}

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.10.0.0</Version>
-    <AssemblyVersion>2.10.0.0</AssemblyVersion>
-    <FileVersion>2.10.0.0</FileVersion>
+    <Version>2.11.0.0</Version>
+    <AssemblyVersion>2.11.0.0</AssemblyVersion>
+    <FileVersion>2.11.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
## Summary

`Function1.cs` verkleind van 697 naar 110 regels. Orchestratie-logica en SQL-staging zijn verplaatst naar twee nieuwe klassen:

- **`SportlinkSyncPipeline`** — `RunSyncAsync` + `FetchAndStore*` methoden
- **`SportlinkStagingRepository`** — alle SQL-staging writes (teams, programma, uitslagen, matchdetails) + `AddMatchParams` helper die 18 dubbele parameter-toewijzingen elimineert

`FetchAndStoreApiData` bewaart zijn publieke `RunSyncAsync` façade voor `AdminSyncFunction` compatibiliteit.

## Test plan
- [ ] Build groen
- [ ] Timer-trigger en HTTP-trigger (`/api/sync-matches`) aanroepbaar
- [ ] Staging wordt gevuld en gemerged naar his.*

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)