### PR TITLE
feat(#465): EmailProcessorFunction SQL repositories extraheren

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.11.0.0</Version>
-    <AssemblyVersion>2.11.0.0</AssemblyVersion>
-    <FileVersion>2.11.0.0</FileVersion>
+    <Version>2.12.0.0</Version>
+    <AssemblyVersion>2.12.0.0</AssemblyVersion>
+    <FileVersion>2.12.0.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+## [2.12.0.0] — 2026-05-31
+
+### Changed
+- EmailProcessorFunction: alle SQL-operaties verplaatst naar `EmailProcessingRepository` en `LearningMomentRepository`. Function-klasse bevat geen inline SQL meer; private methoden zijn dunne delegating wrappers. Orchestrator/mailbox/notification splits volgen in vervolg-iteratie. (#465)
+
 ## [2.11.0.0] — 2026-05-31
 
 ### Changed

--- a/FunctionApp/Email/EmailProcessingRepository.cs
+++ b/FunctionApp/Email/EmailProcessingRepository.cs
@@ -1,0 +1,172 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using SportlinkFunction.Processing;
+
+namespace SportlinkFunction.Email;
+
+/// <summary>
+/// SQL data-access voor planner.EmailVerwerking.
+/// Extracted uit EmailProcessorFunction (#465).
+/// </summary>
+internal static class EmailProcessingRepository
+{
+    private static string Cs => SystemUtilities.DatabaseConfig.ConnectionString;
+
+    internal static async Task<bool> BestaatMessageIdAsync(string messageId)
+    {
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand(
+            "SELECT COUNT(1) FROM [planner].[EmailVerwerking] WHERE [MessageId] = @MessageId", conn);
+        cmd.Parameters.AddWithValue("@MessageId", messageId);
+        return (int)(await cmd.ExecuteScalarAsync())! > 0;
+    }
+
+    internal static async Task<int> InsertEmailVerwerkingAsync(InkomendBericht email)
+    {
+        var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
+            ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand(@"
+            INSERT INTO [planner].[EmailVerwerking]
+                ([MessageId], [ConversationId], [Afzender], [Onderwerp], [OntvangstDatum], [EmailBody], [VerzoekType], [Status], [ClubCode])
+            VALUES
+                (@MessageId, @ConversationId, @Afzender, @Onderwerp, @OntvangstDatum, @EmailBody, 'Onbekend', 'Ontvangen', @ClubCode);
+            SELECT CAST(SCOPE_IDENTITY() AS INT);", conn);
+        cmd.Parameters.AddWithValue("@MessageId",     email.MessageId);
+        cmd.Parameters.AddWithValue("@ConversationId",(object?)email.ConversationId ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@Afzender",      email.Afzender);
+        cmd.Parameters.AddWithValue("@Onderwerp",     email.Onderwerp);
+        cmd.Parameters.AddWithValue("@OntvangstDatum",email.OntvangstDatum);
+        cmd.Parameters.AddWithValue("@EmailBody",     (object?)email.Body ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@ClubCode",      clubCode);
+        return (int)(await cmd.ExecuteScalarAsync())!;
+    }
+
+    internal static async Task UpdateStatusAsync(int verwerkingId, EmailStatus status, string? geextraheerdeData)
+    {
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+
+        var setClauses = "[Status] = @Status, [mta_modified] = GETUTCDATE()";
+        if (geextraheerdeData != null)
+            setClauses += ", [GeextraheerdeData] = @Data, [VerzoekType] = @VerzoekType";
+
+        using var cmd = new SqlCommand(
+            $"UPDATE [planner].[EmailVerwerking] SET {setClauses} WHERE [Id] = @Id", conn);
+        cmd.Parameters.AddWithValue("@Id", verwerkingId);
+        cmd.Parameters.AddWithValue("@Status", status.ToString());
+        if (geextraheerdeData != null)
+        {
+            cmd.Parameters.AddWithValue("@Data", geextraheerdeData);
+            try
+            {
+                var c = JsonConvert.DeserializeObject<BerichtClassificatie>(geextraheerdeData);
+                cmd.Parameters.AddWithValue("@VerzoekType", c?.Type.ToString() ?? "Onbekend");
+            }
+            catch { cmd.Parameters.AddWithValue("@VerzoekType", "Onbekend"); }
+        }
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    internal static async Task UpdatePlannerResponseAsync(int verwerkingId, string plannerResponseJson)
+    {
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand(@"
+            UPDATE [planner].[EmailVerwerking]
+            SET [PlannerResponse] = @Response, [mta_modified] = GETUTCDATE()
+            WHERE [Id] = @Id", conn);
+        cmd.Parameters.AddWithValue("@Id",       verwerkingId);
+        cmd.Parameters.AddWithValue("@Response", plannerResponseJson);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    internal static async Task UpdateAntwoordVerstuurdAsync(int verwerkingId, string verstuurdNaar, string antwoordEmail)
+    {
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand(@"
+            UPDATE [planner].[EmailVerwerking]
+            SET [Status] = 'AntwoordVerstuurd', [VerstuurdNaar] = @Naar, [AntwoordEmail] = @Antwoord, [mta_modified] = GETUTCDATE()
+            WHERE [Id] = @Id", conn);
+        cmd.Parameters.AddWithValue("@Id",      verwerkingId);
+        cmd.Parameters.AddWithValue("@Naar",    verstuurdNaar);
+        cmd.Parameters.AddWithValue("@Antwoord",antwoordEmail);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    internal static async Task UpdateFoutAsync(string messageId, string foutMelding)
+    {
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand(@"
+            UPDATE [planner].[EmailVerwerking]
+            SET [Status] = 'Fout', [FoutMelding] = @Fout, [mta_modified] = GETUTCDATE()
+            WHERE [MessageId] = @MessageId", conn);
+        cmd.Parameters.AddWithValue("@MessageId", messageId);
+        cmd.Parameters.AddWithValue("@Fout", foutMelding.Length > 1000 ? foutMelding[..1000] : foutMelding);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    internal static async Task<(bool IsReply, int? OrigineleVerwerkingId, string? OrigineelType, string? OriginaleSamenvatting)>
+        DetecteerReplyOpOnsAntwoordAsync(string conversationId, string clubCode, ILogger log)
+    {
+        try
+        {
+            using var conn = new SqlConnection(Cs);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(@"
+                SELECT TOP 1 [Id], [VerzoekType], [GeextraheerdeData]
+                FROM [planner].[EmailVerwerking]
+                WHERE [ConversationId] = @ConversationId
+                  AND [VerstuurdNaar] IS NOT NULL
+                  AND [ClubCode] = @ClubCode
+                ORDER BY [mta_inserted] DESC", conn);
+            cmd.Parameters.AddWithValue("@ConversationId", conversationId);
+            cmd.Parameters.AddWithValue("@ClubCode", clubCode);
+
+            using var r = await cmd.ExecuteReaderAsync();
+            if (!await r.ReadAsync()) return (false, null, null, null);
+
+            var id = r.GetInt32(0);
+            var verzoekType = r.IsDBNull(1) ? null : r.GetString(1);
+            var data        = r.IsDBNull(2) ? null : r.GetString(2);
+
+            string? samenvatting = null;
+            if (!string.IsNullOrEmpty(data))
+            {
+                try
+                {
+                    using var doc = System.Text.Json.JsonDocument.Parse(data);
+                    if (doc.RootElement.TryGetProperty("Samenvatting", out var s))
+                        samenvatting = s.GetString();
+                }
+                catch { /* optioneel */ }
+            }
+            return (true, id, verzoekType, samenvatting);
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "Reply-detectie kon niet worden uitgevoerd — doorgaan als nieuw bericht");
+            return (false, null, null, null);
+        }
+    }
+
+    internal static async Task UpdateReplyStatusAsync(int verwerkingId, bool isReply, int replyOpVerwerkingId)
+    {
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand(@"
+            UPDATE [planner].[EmailVerwerking]
+            SET [IsReplyOpOnsAntwoord] = @IsReply, [ReplyOpVerwerkingId] = @ReplyOpId, [mta_modified] = GETUTCDATE()
+            WHERE [Id] = @Id", conn);
+        cmd.Parameters.AddWithValue("@Id",       verwerkingId);
+        cmd.Parameters.AddWithValue("@IsReply",  isReply);
+        cmd.Parameters.AddWithValue("@ReplyOpId",replyOpVerwerkingId);
+        await cmd.ExecuteNonQueryAsync();
+    }
+}

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -550,7 +550,7 @@ public class EmailProcessorFunction
         }
     }
 
-    // --- Database operaties ---
+    // --- Database operaties → gedelegeerd naar repositories (#465) ---
 
     // Laadt uitsluitingslijst strikt — exception propageren zodat de outer cold-start catch
     // fail-closed kan garanderen (_uitgeslotenCacheGeladen blijft false bij fout). (#463)
@@ -572,238 +572,42 @@ public class EmailProcessorFunction
         return adressen;
     }
 
-    private static async Task<bool> BestaatMessageIdAsync(string messageId)
-    {
-        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
-        await connection.OpenAsync();
-        using var command = new SqlCommand(
-            "SELECT COUNT(1) FROM [planner].[EmailVerwerking] WHERE [MessageId] = @MessageId", connection);
-        command.Parameters.AddWithValue("@MessageId", messageId);
-        var count = (int)(await command.ExecuteScalarAsync())!;
-        return count > 0;
-    }
+    private static Task<bool>  BestaatMessageIdAsync(string messageId)
+        => EmailProcessingRepository.BestaatMessageIdAsync(messageId);
 
-    private static async Task<int> InsertEmailVerwerkingAsync(InkomendBericht email)
-    {
-        var clubCode = SystemUtilities.AppSettings.GetSetting("clubCode")
-            ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+    private static Task<int> InsertEmailVerwerkingAsync(InkomendBericht email)
+        => EmailProcessingRepository.InsertEmailVerwerkingAsync(email);
 
-        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
-        await connection.OpenAsync();
-        using var command = new SqlCommand(@"
-            INSERT INTO [planner].[EmailVerwerking]
-                ([MessageId], [ConversationId], [Afzender], [Onderwerp], [OntvangstDatum], [EmailBody], [VerzoekType], [Status], [ClubCode])
-            VALUES
-                (@MessageId, @ConversationId, @Afzender, @Onderwerp, @OntvangstDatum, @EmailBody, 'Onbekend', 'Ontvangen', @ClubCode);
-            SELECT CAST(SCOPE_IDENTITY() AS INT);", connection);
+    private static Task UpdateStatusAsync(int verwerkingId, EmailStatus status, string? geextraheerdeData)
+        => EmailProcessingRepository.UpdateStatusAsync(verwerkingId, status, geextraheerdeData);
 
-        command.Parameters.AddWithValue("@MessageId", email.MessageId);
-        command.Parameters.AddWithValue("@ConversationId", (object?)email.ConversationId ?? DBNull.Value);
-        command.Parameters.AddWithValue("@Afzender", email.Afzender);
-        command.Parameters.AddWithValue("@Onderwerp", email.Onderwerp);
-        command.Parameters.AddWithValue("@OntvangstDatum", email.OntvangstDatum);
-        command.Parameters.AddWithValue("@EmailBody", (object?)email.Body ?? DBNull.Value);
-        command.Parameters.AddWithValue("@ClubCode", clubCode);
+    private static Task UpdatePlannerResponseAsync(int verwerkingId, string plannerResponseJson)
+        => EmailProcessingRepository.UpdatePlannerResponseAsync(verwerkingId, plannerResponseJson);
 
-        return (int)(await command.ExecuteScalarAsync())!;
-    }
+    private static Task UpdateAntwoordVerstuurdAsync(int verwerkingId, string verstuurdNaar, string antwoordEmail)
+        => EmailProcessingRepository.UpdateAntwoordVerstuurdAsync(verwerkingId, verstuurdNaar, antwoordEmail);
 
-    private static async Task UpdateStatusAsync(int verwerkingId, EmailStatus status, string? geextraheerdeData)
-    {
-        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
-        await connection.OpenAsync();
+    private static Task UpdateFoutAsync(string messageId, string foutMelding)
+        => EmailProcessingRepository.UpdateFoutAsync(messageId, foutMelding);
 
-        var setClauses = "[Status] = @Status, [mta_modified] = GETUTCDATE()";
-        if (geextraheerdeData != null)
-            setClauses += ", [GeextraheerdeData] = @Data, [VerzoekType] = @VerzoekType";
-
-        using var command = new SqlCommand(
-            $"UPDATE [planner].[EmailVerwerking] SET {setClauses} WHERE [Id] = @Id", connection);
-        command.Parameters.AddWithValue("@Id", verwerkingId);
-        command.Parameters.AddWithValue("@Status", status.ToString());
-
-        if (geextraheerdeData != null)
-        {
-            command.Parameters.AddWithValue("@Data", geextraheerdeData);
-            try
-            {
-                var classificatie = JsonConvert.DeserializeObject<BerichtClassificatie>(geextraheerdeData);
-                command.Parameters.AddWithValue("@VerzoekType", classificatie?.Type.ToString() ?? "Onbekend");
-            }
-            catch
-            {
-                command.Parameters.AddWithValue("@VerzoekType", "Onbekend");
-            }
-        }
-
-        await command.ExecuteNonQueryAsync();
-    }
-
-    private static async Task UpdatePlannerResponseAsync(int verwerkingId, string plannerResponseJson)
-    {
-        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
-        await connection.OpenAsync();
-        using var command = new SqlCommand(@"
-            UPDATE [planner].[EmailVerwerking]
-            SET [PlannerResponse] = @Response, [mta_modified] = GETUTCDATE()
-            WHERE [Id] = @Id", connection);
-        command.Parameters.AddWithValue("@Id", verwerkingId);
-        command.Parameters.AddWithValue("@Response", plannerResponseJson);
-        await command.ExecuteNonQueryAsync();
-    }
-
-    private static async Task UpdateAntwoordVerstuurdAsync(int verwerkingId, string verstuurdNaar, string antwoordEmail)
-    {
-        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
-        await connection.OpenAsync();
-        using var command = new SqlCommand(@"
-            UPDATE [planner].[EmailVerwerking]
-            SET [Status] = 'AntwoordVerstuurd', [VerstuurdNaar] = @Naar, [AntwoordEmail] = @Antwoord, [mta_modified] = GETUTCDATE()
-            WHERE [Id] = @Id", connection);
-        command.Parameters.AddWithValue("@Id", verwerkingId);
-        command.Parameters.AddWithValue("@Naar", verstuurdNaar);
-        command.Parameters.AddWithValue("@Antwoord", antwoordEmail);
-        await command.ExecuteNonQueryAsync();
-    }
-
-    private static async Task UpdateFoutAsync(string messageId, string foutMelding)
-    {
-        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
-        await connection.OpenAsync();
-        using var command = new SqlCommand(@"
-            UPDATE [planner].[EmailVerwerking]
-            SET [Status] = 'Fout', [FoutMelding] = @Fout, [mta_modified] = GETUTCDATE()
-            WHERE [MessageId] = @MessageId", connection);
-        command.Parameters.AddWithValue("@MessageId", messageId);
-        command.Parameters.AddWithValue("@Fout", foutMelding.Length > 1000 ? foutMelding[..1000] : foutMelding);
-        await command.ExecuteNonQueryAsync();
-    }
-
-    // #323: reply-detectie helpers
-
-    private static async Task<(bool IsReply, int? OrigineleVerwerkingId, string? OrigineelType, string? OriginaleSamenvatting)>
+    private static Task<(bool IsReply, int? OrigineleVerwerkingId, string? OrigineelType, string? OriginaleSamenvatting)>
         DetecteerReplyOpOnsAntwoordAsync(string conversationId, string clubCode, ILogger log)
-    {
-        try
-        {
-            using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
-            await connection.OpenAsync();
-            using var command = new SqlCommand(@"
-                SELECT TOP 1 [Id], [VerzoekType], [GeextraheerdeData]
-                FROM [planner].[EmailVerwerking]
-                WHERE [ConversationId] = @ConversationId
-                  AND [VerstuurdNaar] IS NOT NULL
-                  AND [ClubCode] = @ClubCode
-                ORDER BY [mta_inserted] DESC", connection);
-            command.Parameters.AddWithValue("@ConversationId", conversationId);
-            command.Parameters.AddWithValue("@ClubCode", clubCode);
+        => EmailProcessingRepository.DetecteerReplyOpOnsAntwoordAsync(conversationId, clubCode, log);
 
-            using var reader = await command.ExecuteReaderAsync();
-            if (!await reader.ReadAsync())
-                return (false, null, null, null);
+    private static Task UpdateReplyStatusAsync(int verwerkingId, bool isReply, int replyOpVerwerkingId)
+        => EmailProcessingRepository.UpdateReplyStatusAsync(verwerkingId, isReply, replyOpVerwerkingId);
 
-            var id = reader.GetInt32(0);
-            var verzoekType = reader.IsDBNull(1) ? null : reader.GetString(1);
-            var geextraheerdeData = reader.IsDBNull(2) ? null : reader.GetString(2);
-
-            string? samenvatting = null;
-            if (!string.IsNullOrEmpty(geextraheerdeData))
-            {
-                try
-                {
-                    using var doc = System.Text.Json.JsonDocument.Parse(geextraheerdeData);
-                    if (doc.RootElement.TryGetProperty("Samenvatting", out var s))
-                        samenvatting = s.GetString();
-                }
-                catch { /* samenvatting optioneel */ }
-            }
-
-            return (true, id, verzoekType, samenvatting);
-        }
-        catch (Exception ex)
-        {
-            log.LogWarning(ex, "Reply-detectie kon niet worden uitgevoerd — doorgaan als nieuw bericht");
-            return (false, null, null, null);
-        }
-    }
-
-    private static async Task UpdateReplyStatusAsync(int verwerkingId, bool isReply, int replyOpVerwerkingId)
-    {
-        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
-        await connection.OpenAsync();
-        using var command = new SqlCommand(@"
-            UPDATE [planner].[EmailVerwerking]
-            SET [IsReplyOpOnsAntwoord] = @IsReply, [ReplyOpVerwerkingId] = @ReplyOpId, [mta_modified] = GETUTCDATE()
-            WHERE [Id] = @Id", connection);
-        command.Parameters.AddWithValue("@Id", verwerkingId);
-        command.Parameters.AddWithValue("@IsReply", isReply);
-        command.Parameters.AddWithValue("@ReplyOpId", replyOpVerwerkingId);
-        await command.ExecuteNonQueryAsync();
-    }
-
-    private static async Task InsertClassificatieCorrectieAsync(
+    private static Task InsertClassificatieCorrectieAsync(
         int origineleVerwerkingId, int correctionVerwerkingId,
         string origineelType, string? afgeleidType,
         string? originaleSamenvatting, string? correctieSamenvatting,
         string clubCode)
-    {
-        using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
-        await connection.OpenAsync();
-        using var command = new SqlCommand(@"
-            INSERT INTO [planner].[ClassificatieCorrectie]
-                ([OrigineleVerwerkingId], [CorrectionVerwerkingId], [OrigineelVerzoekType],
-                 [AfgeleidJuistType], [OrigineleSamenvatting], [CorrectieSamenvatting], [ClubCode])
-            VALUES
-                (@OrigineleId, @CorrectionId, @OrigineelType,
-                 @AfgeleidType, @OriginaleSamenvatting, @CorrectieSamenvatting, @ClubCode)", connection);
-        command.Parameters.AddWithValue("@OrigineleId", origineleVerwerkingId);
-        command.Parameters.AddWithValue("@CorrectionId", correctionVerwerkingId);
-        command.Parameters.AddWithValue("@OrigineelType", origineelType);
-        command.Parameters.AddWithValue("@AfgeleidType", (object?)afgeleidType ?? DBNull.Value);
-        command.Parameters.AddWithValue("@OriginaleSamenvatting",
-            (object?)TruncateString(originaleSamenvatting, 500) ?? DBNull.Value);
-        command.Parameters.AddWithValue("@CorrectieSamenvatting",
-            (object?)TruncateString(correctieSamenvatting, 500) ?? DBNull.Value);
-        command.Parameters.AddWithValue("@ClubCode", clubCode);
-        await command.ExecuteNonQueryAsync();
-    }
+        => LearningMomentRepository.InsertClassificatieCorrectieAsync(
+               origineleVerwerkingId, correctionVerwerkingId,
+               origineelType, afgeleidType,
+               originaleSamenvatting, correctieSamenvatting, clubCode);
 
-    private static async Task<List<ClassificatieCorrectieVoorbeeld>> HaalLeermomentVoorbeeldenOpAsync(
+    private static Task<List<ClassificatieCorrectieVoorbeeld>> HaalLeermomentVoorbeeldenOpAsync(
         string clubCode, ILogger log)
-    {
-        try
-        {
-            using var connection = new SqlConnection(SystemUtilities.DatabaseConfig.ConnectionString);
-            await connection.OpenAsync();
-            using var command = new SqlCommand(@"
-                SELECT TOP 20 [OrigineelVerzoekType], [AfgeleidJuistType],
-                              [OrigineleSamenvatting], [CorrectieSamenvatting]
-                FROM [planner].[ClassificatieCorrectie]
-                WHERE [IsGevalideerd] = 1 AND [IsAfgewezen] = 0 AND [ClubCode] = @ClubCode
-                ORDER BY [mta_modified] DESC", connection);
-            command.Parameters.AddWithValue("@ClubCode", clubCode);
-
-            var voorbeelden = new List<ClassificatieCorrectieVoorbeeld>();
-            using var reader = await command.ExecuteReaderAsync();
-            while (await reader.ReadAsync())
-            {
-                if (reader.IsDBNull(1)) continue;
-                voorbeelden.Add(new ClassificatieCorrectieVoorbeeld(
-                    OrigineelType: reader.GetString(0),
-                    JuistType: reader.GetString(1),
-                    OrigineleSamenvatting: reader.IsDBNull(2) ? "" : reader.GetString(2),
-                    CorrectieSamenvatting: reader.IsDBNull(3) ? "" : reader.GetString(3)
-                ));
-            }
-            return voorbeelden;
-        }
-        catch (Exception ex)
-        {
-            log.LogWarning(ex, "Leermomenten konden niet worden geladen — classificatie zonder few-shots");
-            return new List<ClassificatieCorrectieVoorbeeld>();
-        }
-    }
-
-    private static string? TruncateString(string? value, int maxLength) =>
-        value == null ? null : (value.Length > maxLength ? value[..maxLength] : value);
+        => LearningMomentRepository.HaalVoorbeeldenOpAsync(clubCode, log);
 }

--- a/FunctionApp/Email/LearningMomentRepository.cs
+++ b/FunctionApp/Email/LearningMomentRepository.cs
@@ -1,0 +1,76 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using SportlinkFunction.Processing;
+
+namespace SportlinkFunction.Email;
+
+/// <summary>
+/// SQL data-access voor planner.ClassificatieCorrectie (leermomenten).
+/// Extracted uit EmailProcessorFunction (#465).
+/// </summary>
+internal static class LearningMomentRepository
+{
+    private static string Cs => SystemUtilities.DatabaseConfig.ConnectionString;
+
+    internal static async Task InsertClassificatieCorrectieAsync(
+        int origineleVerwerkingId, int correctionVerwerkingId,
+        string origineelType, string? afgeleidType,
+        string? originaleSamenvatting, string? correctieSamenvatting,
+        string clubCode)
+    {
+        using var conn = new SqlConnection(Cs);
+        await conn.OpenAsync();
+        using var cmd = new SqlCommand(@"
+            INSERT INTO [planner].[ClassificatieCorrectie]
+                ([OrigineleVerwerkingId], [CorrectionVerwerkingId], [OrigineelVerzoekType],
+                 [AfgeleidJuistType], [OrigineleSamenvatting], [CorrectieSamenvatting], [ClubCode])
+            VALUES
+                (@OrigineleId, @CorrectionId, @OrigineelType,
+                 @AfgeleidType, @OriginaleSamenvatting, @CorrectieSamenvatting, @ClubCode)", conn);
+        cmd.Parameters.AddWithValue("@OrigineleId",          origineleVerwerkingId);
+        cmd.Parameters.AddWithValue("@CorrectionId",         correctionVerwerkingId);
+        cmd.Parameters.AddWithValue("@OrigineelType",         origineelType);
+        cmd.Parameters.AddWithValue("@AfgeleidType",          (object?)afgeleidType          ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@OriginaleSamenvatting", (object?)Truncate(originaleSamenvatting, 500) ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@CorrectieSamenvatting", (object?)Truncate(correctieSamenvatting, 500) ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("@ClubCode",              clubCode);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    internal static async Task<List<ClassificatieCorrectieVoorbeeld>> HaalVoorbeeldenOpAsync(string clubCode, ILogger log)
+    {
+        try
+        {
+            using var conn = new SqlConnection(Cs);
+            await conn.OpenAsync();
+            using var cmd = new SqlCommand(@"
+                SELECT TOP 20 [OrigineelVerzoekType], [AfgeleidJuistType],
+                              [OrigineleSamenvatting], [CorrectieSamenvatting]
+                FROM [planner].[ClassificatieCorrectie]
+                WHERE [IsGevalideerd] = 1 AND [IsAfgewezen] = 0 AND [ClubCode] = @ClubCode
+                ORDER BY [mta_modified] DESC", conn);
+            cmd.Parameters.AddWithValue("@ClubCode", clubCode);
+
+            var list = new List<ClassificatieCorrectieVoorbeeld>();
+            using var r = await cmd.ExecuteReaderAsync();
+            while (await r.ReadAsync())
+            {
+                if (r.IsDBNull(1)) continue;
+                list.Add(new ClassificatieCorrectieVoorbeeld(
+                    OrigineelType:       r.GetString(0),
+                    JuistType:           r.GetString(1),
+                    OrigineleSamenvatting:  r.IsDBNull(2) ? "" : r.GetString(2),
+                    CorrectieSamenvatting:  r.IsDBNull(3) ? "" : r.GetString(3)));
+            }
+            return list;
+        }
+        catch (Exception ex)
+        {
+            log.LogWarning(ex, "Leermomenten konden niet worden geladen — classificatie zonder few-shots");
+            return new List<ClassificatieCorrectieVoorbeeld>();
+        }
+    }
+
+    private static string? Truncate(string? value, int max) =>
+        value == null ? null : (value.Length > max ? value[..max] : value);
+}

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.11.0.0</Version>
-    <AssemblyVersion>2.11.0.0</AssemblyVersion>
-    <FileVersion>2.11.0.0</FileVersion>
+    <Version>2.12.0.0</Version>
+    <AssemblyVersion>2.12.0.0</AssemblyVersion>
+    <FileVersion>2.12.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
## Summary

Eerste stap van de EmailProcessorFunction-opsplitsing: alle SQL-operaties verplaatst naar twee nieuwe repository-klassen.

**`EmailProcessingRepository`** — planner.EmailVerwerking:
- BestaatMessageId, InsertEmailVerwerking, UpdateStatus, UpdatePlannerResponse, UpdateAntwoordVerstuurd, UpdateFout, DetecteerReplyOpOnsAntwoord, UpdateReplyStatus

**`LearningMomentRepository`** — planner.ClassificatieCorrectie:
- InsertClassificatieCorrectie, HaalVoorbeeldenOp

EmailProcessorFunction bevat nu geen inline SQL meer. Private methoden zijn dunne delegating wrappers.

**Nog niet:** orchestrator/mailbox/notification splits — deze vereisen meer refactoring en worden in een vervolg-iteratie opgepakt.

Closes #465 (SQL-extractie-deel; orchestrator-splits volgen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)