### PR TITLE
docs(#-): versie-strategie — MINOR alleen bij productie-release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -723,40 +723,44 @@ De API-standaarden staan in `docs/api-standaarden/`:
 
 ## Versiebeheer en Release-protocol
 
-### Semantic Versioning (semver)
+### Semantic Versioning (semver) — twee fasen
 
-Versienummering volgt `MAJOR.MINOR.PATCH`:
+Het versienummer heeft vier cijfers: `MAJOR.MINOR.PATCH.REVISION`
 
-| Type | Wanneer | Voorbeeld |
+**Fase 1 — development (commit-voor-commit op feature/* branch):**
+
+| Commit-type | Versie-impact | Voorbeeld |
 |---|---|---|
-| **MAJOR** (x.0.0) | Nieuwe architectuurlaag, breaking API-wijziging, grote nieuwe functie-set | v2.0.0 — Admin GUI toegevoegd |
-| **MINOR** (2.x.0) | Nieuwe feature, backwards compatible (nieuw endpoint, nieuw scherm) | v2.1.0 — WhatsApp-kanaal toegevoegd |
-| **PATCH** (2.0.x) | Bugfix, beveiligingspatch, documentatie zonder gedragswijziging | v2.0.1 — 500-error op teams-endpoint |
+| `feat:` — nieuwe feature | PATCH bump | `2.15.0.0 → 2.15.1.0` |
+| `fix:` of `security:` — bugfix | REVISION bump | `2.15.1.0 → 2.15.1.1` |
+| Kleine fix, CSS, UX, chore **met zichtbaar effect** | REVISION bump | `2.15.1.0 → 2.15.1.1` |
+| `BREAKING CHANGE:` in commit-body | MAJOR bump | `2.15.x.x → 3.0.0.0` |
+| Puur intern (refactor zonder effect, docs, CLAUDE.md) | Geen bump | — |
+
+**Fase 2 — release (develop → main PR, één keer per release):**
+
+| Inhoud van `[Unreleased]` | Versie-impact | Voorbeeld |
+|---|---|---|
+| Bevat minimaal één `feat:` | **MINOR bump**, PATCH + REVISION → 0 | `2.15.x.x → 2.16.0.0` |
+| Alleen `fix:`/`security:`, geen `feat:` | PATCH bump, REVISION → 0 | `2.15.2.3 → 2.15.3.0` |
+| BREAKING CHANGE aanwezig | MAJOR bump | `2.15.x.x → 3.0.0.0` |
+
+> **Waarom deze scheiding?** Productie gaat netjes `2.15 → 2.16 → 2.17` — één zichtbare stap per release.
+> Development heeft tussentijds volledige granulariteit (`2.15.1.0`, `2.15.2.3`) zonder de
+> productie-MINOR op te blazen. MAJOR is altijd een expliciete architectuurkeuze.
 
 > Volledige definities (bug vs. issue vs. feature vs. enhancement, wat in changelog hoort):
 > zie [docs/VERSIONING.md](docs/VERSIONING.md).
 
 ### Conventional Commits → versie-bump
 
-Het versienummer heeft vier cijfers: `MAJOR.MINOR.PATCH.REVISION`
-
-| Commit-type | Versie-impact | Voorbeeld |
-|---|---|---|
-| `feat:` | MINOR bump — Patch en Revision resetten naar 0 | `2.5.0.3 → 2.6.0.0` |
-| `fix:` of `security:` | PATCH bump — Revision reset naar 0 | `2.5.0.3 → 2.5.1.0` |
-| `BREAKING CHANGE:` in commit-body | MAJOR bump | `2.5.x.x → 3.0.0.0` |
-| Kleine fix, CSS, UX, chore **met zichtbaar effect** | REVISION bump | `2.5.0.0 → 2.5.0.1` |
-| Puur intern (refactor zonder effect, docs, CLAUDE.md) | Geen bump | — |
-
-> **Reden voor Revision:** de beheerder ziet het versienummer in de header. Na een deployment
-> kan de beheerder bevestigen dat de juiste versie actief is. Zonder Revision-bump is elke
-> kleine fix onzichtbaar in de UI.
+Samenvatting: **development** = `feat:` → PATCH, `fix:` → REVISION. **Release** = MINOR als er features in zitten.
 
 Zet alle drie velden synchroon in **beide** csproj's:
 ```xml
-<Version>2.5.0.1</Version>
-<AssemblyVersion>2.5.0.1</AssemblyVersion>
-<FileVersion>2.5.0.1</FileVersion>
+<Version>2.15.1.0</Version>
+<AssemblyVersion>2.15.1.0</AssemblyVersion>
+<FileVersion>2.15.1.0</FileVersion>
 ```
 
 ### CHANGELOG.md bijhouden

--- a/docs/ARCHITECTURE-PLANNER.md
+++ b/docs/ARCHITECTURE-PLANNER.md
@@ -136,6 +136,25 @@ Een veld heeft capaciteit **1.00**. Wedstrijden gebruiken een fractie op basis v
 
 ---
 
+## Codestructuur (intern)
+
+`PlannerService` is een dunne facade die delegeert naar use-case services. Bestaande callers (PlannerFunctions, EmailProcessorFunction) roepen `PlannerService.*Async(...)` aan — de interne indeling is transparant.
+
+| Service | Locatie | Verantwoordelijkheid |
+|---|---|---|
+| `PlannerService` | `Planner/PlannerService.cs` | Facade — delegeert naar services |
+| `AvailabilityService` | `Planner/Services/` | CheckAvailabilityAsync, Doordeweeks |
+| `AutoPlanService` | `Planner/Services/` | AutoPlanAsync, Toepassen |
+| `OptimizationService` | `Planner/Services/` | OptimaliseerAsync |
+| `RescheduleService` | `Planner/Services/` | CheckRescheduleAvailabilityAsync |
+| `TeamScheduleService` | `Planner/Services/` | GetTeamScheduleAsync |
+| `PlannerShared` | `Planner/Services/` | CanFitMatch, FieldScheduler, constanten |
+| `PlannerDataAccess` | `Planner/PlannerDataAccess.cs` | Facade → repositories in `Planner/Repositories/` |
+
+`FieldScheduler` is de pure scheduling engine — geen DB of API-calls, alleen slot-berekening op basis van beschikbaarheid en buffers.
+
+---
+
 ## API-contract
 
 ### Endpoint: `POST /api/planner/check-availability`

--- a/docs/BEHEERDER-HANDLEIDING.md
+++ b/docs/BEHEERDER-HANDLEIDING.md
@@ -64,6 +64,20 @@ In testmodus:
 
 Volledige documentatie: [docs/TESTMODUS-ALLSTARS.md](TESTMODUS-ALLSTARS.md)
 
+### Dagplanning — status-badges
+
+De dagplanning toont per wedstrijd een badge in de Status-kolom:
+
+| Badge | Betekenis |
+|---|---|
+| ✓ OK (groen) | Huidige slot is al optimaal |
+| Nieuw (geel) | Nieuw timeslot toegewezen |
+| Wijzig (blauw) | Bestaand slot kan eerder/anders |
+| Probleem (rood) | Geen slot mogelijk (velden vol) |
+| Onbekend (grijs) | Team heeft geen speeltijdsconfiguratie (bijv. veldboeking door 'Toernooi commissie') — wordt ongewijzigd getoond, optimizer slaat het over |
+
+Teams met een grijze "Onbekend"-badge blokkeren wel hun tijdslot voor andere teams; ze worden niet als fout beschouwd.
+
 ---
 
 ## 3. Way of working

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -232,48 +232,59 @@ Voorbeelden:
 
 ## 6. Versie-bump beslisboom
 
-Het versienummer heeft **vier** cijfers: `MAJOR.MINOR.PATCH.REVISION`
+Het versienummer heeft **vier** cijfers: `MAJOR.MINOR.PATCH.REVISION` — met twee duidelijk gescheiden fasen.
+
+### Fase 1 — development (commit-voor-commit op feature/* branch)
 
 | Getal | Wanneer omhoog | Reset bij |
 |---|---|---|
 | **MAJOR** | Breaking change voor de gebruiker | — |
-| **MINOR** | Nieuwe feature | MAJOR-bump → 0 |
-| **PATCH** | Bugfix of security-patch | MINOR-bump → 0 |
-| **REVISION** | **Elke commit die gebruikerszichtbare bestanden raakt** (.razor, .cs, .css, .sql, .json in wwwroot) | PATCH-bump → 0 |
+| **PATCH** | Nieuwe feature (`feat:`) | MINOR-bump → 0 |
+| **REVISION** | Bugfix, security-patch, kleine fix, CSS/UX met zichtbaar effect | PATCH-bump → 0 |
 
-> **Waarom Revision?** De beheerder ziet het versienummer in de header (bijv. `v2.5.0.1`).
-> Na een deployment kan de beheerder bevestigen dat de juiste versie actief is door het getal te checken.
-> Zonder Revision ziet elke kleine fix er hetzelfde uit — geen bevestiging mogelijk.
+> **Waarom MINOR niet tijdens development?** Productie-MINOR-nummers moeten overeen komen met
+> echte releases. Als elke `feat:`-commit de MINOR ophoogt, raakt productie (v2.5) ver achter op
+> development (v2.15) zonder dat er ook maar één release is geweest.
 
 ```
-Wat is er gewijzigd?
+Development — wat is er gewijzigd?
 │
 ├── Verwijdert of breekt bestaande functionaliteit voor een gebruiker?
 │   └── JA → MAJOR (x.0.0.0)
 │
-├── Voegt nieuwe gebruikersfunctionaliteit toe?
-│   └── JA → MINOR (2.x.0.0)
+├── Voegt nieuwe gebruikersfunctionaliteit toe? (feat:)
+│   └── JA → PATCH (2.15.x.0)
 │
-├── Repareert iets wat verkeerd werkte voor een gebruiker?
-│   └── JA → PATCH (2.0.x.0)
-│
-├── Beveiligingspatch?
-│   └── JA → PATCH (2.0.x.0) — tenzij breaking → MAJOR
+├── Repareert iets wat verkeerd werkte? (fix: / security:)
+│   └── JA → REVISION (2.15.1.x)
 │
 ├── Kleine fix, CSS, UX-verbetering of chore met zichtbaar effect?
-│   └── JA → REVISION (2.0.0.x)
+│   └── JA → REVISION (2.15.1.x)
 │
 └── Alleen intern (refactor zonder effect, docs, tooling, CLAUDE.md)?
     └── Geen versie-bump
 ```
 
+### Fase 2 — release (develop → main, één keer per release)
+
+Kijk naar de inhoud van `[Unreleased]` in CHANGELOG.md en bepaal dan pas de MINOR/PATCH:
+
+| Inhoud van `[Unreleased]` | Versie-actie | Voorbeeld |
+|---|---|---|
+| Bevat minimaal één `feat:` | **MINOR bump**, PATCH + REVISION → 0 | `2.15.2.3 → 2.16.0.0` |
+| Alleen `fix:`/`security:`, geen `feat:` | PATCH bump, REVISION → 0 | `2.15.2.3 → 2.15.3.0` |
+| BREAKING CHANGE aanwezig | MAJOR bump | `2.15.x.x → 3.0.0.0` |
+
+> **Resultaat:** productie gaat netjes `2.15 → 2.16 → 2.17`. Development heeft tussentijds
+> volledige granulariteit (`2.15.1.0`, `2.15.2.3`) zonder de productie-teller op te blazen.
+
 ### In de csproj
 
-Zet alle drie velden synchroon op het volledige 4-cijferige nummer:
+Zet alle drie velden synchroon op het volledige 4-cijferige nummer in **beide** csproj's:
 ```xml
-<Version>2.5.0.1</Version>
-<AssemblyVersion>2.5.0.1</AssemblyVersion>
-<FileVersion>2.5.0.1</FileVersion>
+<Version>2.15.1.0</Version>
+<AssemblyVersion>2.15.1.0</AssemblyVersion>
+<FileVersion>2.15.1.0</FileVersion>
 ```
 
 Dit getal wordt via `Assembly.GetExecutingAssembly().GetName().Version?.ToString(4)` getoond in de header.
@@ -281,10 +292,10 @@ Dit getal wordt via `Assembly.GetExecutingAssembly().GetName().Version?.ToString
 ### Twijfelgevallen
 
 **"Is dit een bug of een feature?"**
-→ Was het gedrag ooit zo bedoeld? JA = bug. NEEN (het werkte nooit anders) = feature.
+→ Was het gedrag ooit zo bedoeld? JA = bug (REVISION). NEEN (het werkte nooit anders) = feature (PATCH).
 
-**"Is dit MINOR of PATCH?"**
-→ Voegt het iets toe aan wat de gebruiker kan? JA = MINOR. Alleen repareren = PATCH.
+**"Is dit PATCH of REVISION tijdens development?"**
+→ Voegt het iets toe aan wat de gebruiker kan? JA = PATCH. Alleen repareren/verfijnen = REVISION.
 
 **"Is dit MAJOR?"**
 → Alleen als een bestaande gebruiker iets moet aanpassen (API, config, workflow) om te kunnen blijven werken na de update.


### PR DESCRIPTION
## Summary

- CLAUDE.md versie-bump regels bijgesteld: MINOR only bij release (develop→main), PATCH per feature commit tijdens development, REVISION per kleine fix
- docs/VERSIONING.md sectie 6 bijgewerkt met twee-fasen beslisboom

## Reden

Productie liep ver achter (v2.5 online, v2.15 lokaal) omdat MINOR per `feat:` commit werd gebumpt. Nieuwe afspraak: MINOR alleen ophogen op het moment van deployen naar productie.

## Test plan
- [ ] Geen functionele wijzigingen — alleen docs
- [ ] CI security scan groen