### PR TITLE
ci: release.yml — 4-component tag-patroon + idempotent tag-aanmaak

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
   workflow_dispatch:
     inputs:
@@ -75,8 +76,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}"
-          git push origin "${{ steps.version.outputs.tag }}"
+          git tag "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.tag }}" 2>/dev/null || echo "Tag bestaat al — overgeslagen"
+          git push origin "${{ steps.version.outputs.tag }}" 2>/dev/null || echo "Tag staat al op remote — overgeslagen"
 
       - name: GitHub Release aanmaken
         uses: actions/github-script@v9


### PR DESCRIPTION
## Probleem
release.yml triggerde niet bij push van 4-component tag (`v2.16.0.0`). Patroon `v[0-9]+.[0-9]+.[0-9]+` matcht alleen 3-component versies.

Workflow_dispatch faalde ook als tag al bestond (exit 128).

## Oplossing
- Tag-patroon `v[0-9]+.[0-9]+.[0-9]+.[0-9]+` toegevoegd
- Tag-aanmaak stap idempotent gemaakt — overspringt als tag al bestaat

🤖 Generated with [Claude Code](https://claude.com/claude-code)