### PR TITLE
security(#495,#496): Easy Auth op populate-sunset + structured logging voor exceptions

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.16.0.0</Version>
-    <AssemblyVersion>2.16.0.0</AssemblyVersion>
-    <FileVersion>2.16.0.0</FileVersion>
+    <Version>2.16.0.1</Version>
+    <AssemblyVersion>2.16.0.1</AssemblyVersion>
+    <FileVersion>2.16.0.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Security
+- `populate-sunset` endpoint gebruikt nu Easy Auth + RequireAdmin in plaats van function-key authenticatie — brengt het endpoint in lijn met alle andere admin-endpoints en voegt een Entra-audittrail toe.
+- Log-aanroepen in Utilities.cs en MergeStgToHis.cs gebruiken nu structured logging (`LogError(ex, "...")`) in plaats van string-interpolatie met `ex.Message` — voorkomt dat infrastructuurdetails (servernaam, gebruikersnaam) als losse string in Application Insights terechtkomen.
+
 ## [2.16.0.0] — 2026-06-01
 
 ### Security

--- a/FunctionApp/MergeStgToHis.cs
+++ b/FunctionApp/MergeStgToHis.cs
@@ -46,7 +46,7 @@ namespace SportlinkFunction
             }
             catch (Exception ex)
             {
-                log.LogError($"Error: {ex.Message}");
+                log.LogError(ex, "Merge {SourceTable} into {TargetTable} failed", _sourceTable, _targetTable);
             }
         }
     }

--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -143,10 +143,12 @@ namespace SportlinkFunction.Planner
 
         [Function("PopulateSunset")]
         public static async Task<IActionResult> PopulateSunset(
-            [HttpTrigger(AuthorizationLevel.Admin, "post", Route = "planner/populate-sunset")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "planner/populate-sunset")] HttpRequest req,
             FunctionContext context)
         {
             var log = context.GetLogger("PopulateSunset");
+            var authResult = EasyAuthHelper.RequireAdmin(req);
+            if (authResult != null) return authResult;
             try
             {
                 await SystemUtilities.WaitForDatabaseAsync(log);

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -87,7 +87,7 @@ namespace SportlinkFunction
                 }
                 catch (Exception ex)
                 {
-                    log.LogError($"Error loading app settings: {ex.Message}");
+                    log.LogError(ex, "Error loading app settings");
                 }
             }
 
@@ -113,7 +113,7 @@ namespace SportlinkFunction
                 }
                 catch (Exception ex)
                 {
-                    log.LogError($"Error saving last sync timestamp: {ex.Message}");
+                    log.LogError(ex, "Error saving last sync timestamp");
                 }
             }
         }
@@ -144,7 +144,7 @@ namespace SportlinkFunction
                 catch (Exception ex)
                 {
                     retryCount++;
-                    log.LogWarning($"Database connection failed. Retry {retryCount}/{maxRetries}. Error: {ex.Message}");
+                    log.LogWarning(ex, "Database connection failed. Retry {RetryCount}/{MaxRetries}", retryCount, maxRetries);
                     if (retryCount < maxRetries)
                         await Task.Delay(delayBetweenRetries);
                 }
@@ -213,7 +213,7 @@ namespace SportlinkFunction
                 }
                 catch (Exception ex)
                 {
-                    log.LogError($"Error fetching season end date: {ex.Message}");
+                    log.LogError(ex, "Error fetching season end date");
                 }
                 return 30; // Fallback: ~30 weeks ahead
             }
@@ -240,7 +240,7 @@ namespace SportlinkFunction
                 }
                 catch (Exception ex)
                 {
-                    log.LogError($"Error fetching season start for year {startYear}: {ex.Message}");
+                    log.LogError(ex, "Error fetching season start for year {StartYear}", startYear);
                 }
                 return -40; // Fallback: ~40 weeks back
             }

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.16.0.0</Version>
-    <AssemblyVersion>2.16.0.0</AssemblyVersion>
-    <FileVersion>2.16.0.0</FileVersion>
+    <Version>2.16.0.1</Version>
+    <AssemblyVersion>2.16.0.1</AssemblyVersion>
+    <FileVersion>2.16.0.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->


### PR DESCRIPTION
## Wijzigingen

### #495 — populate-sunset: function-key auth vervangen door Easy Auth
- `AuthorizationLevel.Admin` → `AuthorizationLevel.Anonymous` in PlannerFunction.cs
- `EasyAuthHelper.RequireAdmin(req)` toegevoegd aan begin van functie-body
- Brengt het endpoint in lijn met alle andere admin-endpoints
- Voegt Entra-audittrail toe (eerder: alleen functie-log via function-key)

### #496 — Structured logging voor exceptions in Utilities.cs en MergeStgToHis.cs
- 5 locaties in `Utilities.cs`: `LogError($"...: {ex.Message}")` → `LogError(ex, "...")`
- 1 locatie in `MergeStgToHis.cs`: idem
- Voorkomt dat `SqlException.Message` (kan servernaam/gebruikersnaam bevatten) als losse string in Application Insights belandt

## Versie
`2.16.0.0` → `2.16.0.1` (security REVISION-bump)

Closes #495
Closes #496