### PR TITLE
fix(#498): tegenstander-autofill respecteert nu _globalTegenstander

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.16.0.1</Version>
-    <AssemblyVersion>2.16.0.1</AssemblyVersion>
-    <FileVersion>2.16.0.1</FileVersion>
+    <Version>2.16.0.2</Version>
+    <AssemblyVersion>2.16.0.2</AssemblyVersion>
+    <FileVersion>2.16.0.2</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/Pages/TestData/Wedstrijden.razor
+++ b/BlazorAdmin/Pages/TestData/Wedstrijden.razor
@@ -592,7 +592,10 @@ else
                 ? waarde[(waarde.IndexOf(' ') + 1)..]
                 : waarde;
             if (string.IsNullOrEmpty(rij.UitTeam) || rij.UitTeam == _globalTegenstander)
-                rij.UitTeam = $"FC Onbekend {suffix}";
+            {
+                var basis = string.IsNullOrWhiteSpace(_globalTegenstander) ? "FC Onbekend" : _globalTegenstander;
+                rij.UitTeam = $"{basis} {suffix}";
+            }
         }
 
         _ = AutoSaveAsync(rij);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- Testdata: het auto-invullen van het uitteam bij selectie van een thuisteam respecteert nu de ingestelde 'Tegenstander (nieuw)' — was voorheen hardcoded op 'FC Onbekend' ook als de gebruiker iets anders had ingevuld. (#498)
+
 ### Security
 - `populate-sunset` endpoint gebruikt nu Easy Auth + RequireAdmin in plaats van function-key authenticatie — brengt het endpoint in lijn met alle andere admin-endpoints en voegt een Entra-audittrail toe.
 - Log-aanroepen in Utilities.cs en MergeStgToHis.cs gebruiken nu structured logging (`LogError(ex, "...")`) in plaats van string-interpolatie met `ex.Message` — voorkomt dat infrastructuurdetails (servernaam, gebruikersnaam) als losse string in Application Insights terechtkomen.

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.16.0.1</Version>
-    <AssemblyVersion>2.16.0.1</AssemblyVersion>
-    <FileVersion>2.16.0.1</FileVersion>
+    <Version>2.16.0.2</Version>
+    <AssemblyVersion>2.16.0.2</AssemblyVersion>
+    <FileVersion>2.16.0.2</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->


### PR DESCRIPTION
## Probleem

Op de pagina `/testdata/wedstrijden` heeft de gebruiker een 'Tegenstander (nieuw)' invoerveld om de standaard tegenstander in te stellen. Bij het selecteren van een thuisteam werd het uitteam echter altijd auto-filled met 'FC Onbekend', ook als een andere tegenstander was ingevuld.

## Oorzaak

`OnThuisTeamChanged` hardcodeerde 'FC Onbekend' in de auto-fill — inconsistent met `VoegAlleTeamsToeAsync` dat `_globalTegenstander` al correct gebruikte.

## Fix

`OnThuisTeamChanged` gebruikt nu `_globalTegenstander` (fallback naar 'FC Onbekend' als het veld leeg is) — consistent met de rest van de pagina.

## Versie
`2.16.0.1` → `2.16.0.2`

Closes #498