### PR TITLE
security(#501,#528): DEFAULT 'VRC' verwijderd + CSP connect-src specifiek

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -317,6 +317,14 @@ jobs:
             > BlazorAdmin/wwwroot/appsettings.Production.json
           echo "appsettings.Production.json gegenereerd (inhoud niet gelogd — bevat tenant/client IDs)"
 
+      - name: staticwebapp.config.json CSP-substitutie (#528)
+        if: steps.check.outputs.skip == 'false'
+        env:
+          AZURE_FUNCTIONAPP_URL: ${{ vars.AZURE_FUNCTIONAPP_URL }}
+        run: |
+          sed -i "s|{{AZURE_FUNCTIONAPP_URL}}|${AZURE_FUNCTIONAPP_URL}|g" \
+            BlazorAdmin/wwwroot/staticwebapp.config.json
+
       - name: Blazor WASM publiceren
         if: steps.check.outputs.skip == 'false'
         run: |

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.16.0.3</Version>
-    <AssemblyVersion>2.16.0.3</AssemblyVersion>
-    <FileVersion>2.16.0.3</FileVersion>
+    <Version>2.16.0.4</Version>
+    <AssemblyVersion>2.16.0.4</AssemblyVersion>
+    <FileVersion>2.16.0.4</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/wwwroot/staticwebapp.config.json
+++ b/BlazorAdmin/wwwroot/staticwebapp.config.json
@@ -1,6 +1,6 @@
 {
   "globalHeaders": {
-    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https:; connect-src 'self' https://login.microsoftonline.com https://*.azurewebsites.net; frame-ancestors 'none'; object-src 'none'",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; font-src 'self'; img-src 'self' data: https:; connect-src 'self' https://login.microsoftonline.com {{AZURE_FUNCTIONAPP_URL}}; frame-ancestors 'none'; object-src 'none'",
     "Referrer-Policy": "no-referrer",
     "X-Content-Type-Options": "nosniff",
     "Permissions-Policy": "camera=(), microphone=(), geolocation=()"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Hardcoded club-locatiepad vervangen door generieke placeholder in setup-script. (#517)
 - CI deploy-workflow: database-resume gebruikt nu TCP-verbindingspoging (triggert Azure SQL Serverless auto-resume) in plaats van REST API-aanroep waarvoor onvoldoende RBAC beschikbaar was — lost structureel op dat deploys blijven hangen bij gepauzeerde database.
 - `Start-Debug.ps1` toont nu een waarschuwing als `.githooks/sensitive-patterns.txt` ontbreekt op de ontwikkelmachine. (#514)
+- CSP `connect-src` in `staticwebapp.config.json` gebruikt geen wildcard `*.azurewebsites.net` meer — bij deploy wordt de waarde vervangen door de specifieke URL van de eigen Function App via CI-substitutie. (#528)
+- `DEFAULT 'VRC'` verwijderd uit drie tabeldefinities (`AppSettingsAudit`, `TeamVoorkeurTijden`, `UitgeslotenEmailAdressen`) — vervangen door `CHECK (LEN([ClubCode]) > 0)` conform het patroon van issue #242. Voorkomt stille datavervuiling bij multi-club deployments. (#501)
+- `Test-App.ps1`: schema-repair voor ontbrekende `ClubCode` kolom gebruikt niet meer `DEFAULT 'VRC'` maar `DEFAULT ''` — zelfde principe als boven. (#501)
 
 ## [2.16.0.0] — 2026-06-01
 

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -453,6 +453,13 @@ BEGIN
     );
 END
 GO
+-- #501: Verwijder club-specifieke DEFAULT 'VRC' uit AppSettingsAudit.ClubCode
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_AppSettingsAudit_ClubCode')
+    ALTER TABLE [dbo].[AppSettingsAudit] DROP CONSTRAINT [DF_AppSettingsAudit_ClubCode];
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.check_constraints WHERE name = 'CK_AppSettingsAudit_ClubCode')
+    ALTER TABLE [dbo].[AppSettingsAudit] ADD CONSTRAINT [CK_AppSettingsAudit_ClubCode] CHECK (LEN([ClubCode]) > 0);
+GO
 
 -- v2 — #62: TeamVoorkeurTijden
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.TeamVoorkeurTijden'))
@@ -471,6 +478,13 @@ BEGIN
     );
 END
 GO
+-- #501: Verwijder club-specifieke DEFAULT 'VRC' uit TeamVoorkeurTijden.ClubCode
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_TeamVoorkeurTijden_ClubCode')
+    ALTER TABLE [dbo].[TeamVoorkeurTijden] DROP CONSTRAINT [DF_TeamVoorkeurTijden_ClubCode];
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.check_constraints WHERE name = 'CK_TeamVoorkeurTijden_ClubCode')
+    ALTER TABLE [dbo].[TeamVoorkeurTijden] ADD CONSTRAINT [CK_TeamVoorkeurTijden_ClubCode] CHECK (LEN([ClubCode]) > 0);
+GO
 
 -- v2 — UitgeslotenEmailAdressen: expliciete uitsluitingslijst voor email-verwerking
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.UitgeslotenEmailAdressen'))
@@ -486,6 +500,13 @@ BEGIN
         CONSTRAINT [UQ_UitgeslotenEmailAdressen_Adres] UNIQUE ([EmailAdres], [ClubCode])
     );
 END
+GO
+-- #501: Verwijder club-specifieke DEFAULT 'VRC' uit UitgeslotenEmailAdressen.ClubCode
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_UitgeslotenEmailAdressen_ClubCode')
+    ALTER TABLE [dbo].[UitgeslotenEmailAdressen] DROP CONSTRAINT [DF_UitgeslotenEmailAdressen_ClubCode];
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.check_constraints WHERE name = 'CK_UitgeslotenEmailAdressen_ClubCode')
+    ALTER TABLE [dbo].[UitgeslotenEmailAdressen] ADD CONSTRAINT [CK_UitgeslotenEmailAdressen_ClubCode] CHECK (LEN([ClubCode]) > 0);
 GO
 
 -- v2 — #119: ClubCode toevoegen aan planner.EmailVerwerking (multi-club isolatie email-log)

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.16.0.3</Version>
-    <AssemblyVersion>2.16.0.3</AssemblyVersion>
-    <FileVersion>2.16.0.3</FileVersion>
+    <Version>2.16.0.4</Version>
+    <AssemblyVersion>2.16.0.4</AssemblyVersion>
+    <FileVersion>2.16.0.4</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/scripts/dev/Test-App.ps1
+++ b/scripts/dev/Test-App.ps1
@@ -166,7 +166,7 @@ foreach ($tableKey in $expectedColumns.Keys) {
                 "AccommodatieLatitude" { "FLOAT NULL" }
                 "AccommodatieLongitude"{ "FLOAT NULL" }
                 "EmailVoetnoot"        { "NVARCHAR(MAX) NULL" }
-                "ClubCode"             { "NVARCHAR(20) NOT NULL CONSTRAINT [DF_${table}_ClubCode] DEFAULT 'VRC'" }
+                "ClubCode"             { "NVARCHAR(20) NOT NULL CONSTRAINT [DF_${table}_ClubCode] DEFAULT ''" }
                 "mta_inserted"         { "DATETIME2 NOT NULL CONSTRAINT [DF_${table}_Inserted] DEFAULT GETDATE()" }
                 "mta_modified"         { "DATETIME2 NOT NULL CONSTRAINT [DF_${table}_Modified] DEFAULT GETDATE()" }
                 "Actief"               { "BIT NOT NULL CONSTRAINT [DF_${table}_Actief] DEFAULT 1" }


### PR DESCRIPTION
## Summary

- **#501** — `DEFAULT 'VRC'` verwijderd uit drie tabeldefinities (`AppSettingsAudit`, `TeamVoorkeurTijden`, `UitgeslotenEmailAdressen`). Vervangen door `CHECK (LEN([ClubCode]) > 0)` conform het patroon van issue #242. `Test-App.ps1` schema-repair gebruikt nu `DEFAULT ''` in plaats van `DEFAULT 'VRC'`.

- **#528** — CSP `connect-src` wildcard `*.azurewebsites.net` vervangen door `{{AZURE_FUNCTIONAPP_URL}}` placeholder in `staticwebapp.config.json`. Deploy-workflow substitueert de waarde bij elke deploy (zelfde patroon als `appsettings.Production.json`).

## Test plan

- [ ] Security Gate groen
- [ ] FunctionApp build slaagt
- [ ] BlazorAdmin build slaagt
- [ ] Geen hardcoded club-identifiers in diff

Closes #501
Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)