### PR TITLE
fix(#543): review mode stuurt geen email meer — alleen 'Geen AI antwoord' label

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.16.0.0</Version>
-    <AssemblyVersion>2.16.0.0</AssemblyVersion>
-    <FileVersion>2.16.0.0</FileVersion>
+    <Version>2.16.0.1</Version>
+    <AssemblyVersion>2.16.0.1</AssemblyVersion>
+    <FileVersion>2.16.0.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Changed
+- Review mode stuurt geen email meer terug aan de coördinator — in plaats daarvan wordt de originele email gemarkeerd met 'Geen AI antwoord' zodat de coördinator deze handmatig kan afhandelen. Interne notificaties (teamleider, team-contact) worden ook onderdrukt tijdens review mode.
+
 ## [2.16.0.0] — 2026-06-01
 
 ### Security

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -319,18 +319,34 @@ public class EmailProcessorFunction
         await UpdatePlannerResponseAsync(verwerkingId, plannerResponseJson);
         await UpdateStatusAsync(verwerkingId, EmailStatus.Verwerkt, null);
 
+        var reviewMode = string.Equals(
+            Environment.GetEnvironmentVariable("EmailReviewMode"), "true", StringComparison.OrdinalIgnoreCase);
+
+        // #543: in review mode geen email versturen — alleen 'Geen AI antwoord' label zetten
+        if (reviewMode)
+        {
+            try
+            {
+                await graphService.EnsureMasterCategoryAsync("Geen AI antwoord", "preset0");
+                await graphService.SetCategoriesAsync(email.MessageId, "Geen AI antwoord");
+                await graphService.MarkAsReadAsync(email.MessageId);
+                log.LogInformation("Email {Id} review mode — Geen AI antwoord label gezet, geen reply verstuurd", verwerkingId);
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "Graph-categorie mislukt voor verwerking {Id} in review mode", verwerkingId);
+                try { await UpdateFoutAsync(email.MessageId, SanitizeFoutMelding(ex.Message)); } catch { }
+            }
+            return;
+        }
+
         var (onderwerp, antwoordBody) = await BerichtPipeline.BouwTemplateAntwoord(
             classificatie, plannerResponseJson, email, log);
-
-        var reviewMode = Environment.GetEnvironmentVariable("EmailReviewMode");
-        var ontvanger = string.Equals(reviewMode, "true", StringComparison.OrdinalIgnoreCase)
-            ? Environment.GetEnvironmentVariable("EmailReviewRecipient") ?? email.Afzender
-            : email.Afzender;
 
         // Fail-explicit: alleen AntwoordVerstuurd en MarkAsRead als Graph-send slaagt. (#432)
         try
         {
-            await graphService.SendReplyAsync(ontvanger, onderwerp, antwoordBody, email.ConversationId);
+            await graphService.SendReplyAsync(email.Afzender, onderwerp, antwoordBody, email.ConversationId);
         }
         catch (Exception ex)
         {
@@ -339,7 +355,7 @@ public class EmailProcessorFunction
             return; // mail NIET als gelezen markeren — wordt bij volgende poll opnieuw opgepikt
         }
 
-        await UpdateAntwoordVerstuurdAsync(verwerkingId, ontvanger, antwoordBody);
+        await UpdateAntwoordVerstuurdAsync(verwerkingId, email.Afzender, antwoordBody);
         await graphService.MarkAsReadAsync(email.MessageId);
 
         log.LogInformation("Email {Id} volledig verwerkt, antwoord verstuurd (ontvanger niet gelogd — AVG #210)",
@@ -351,7 +367,7 @@ public class EmailProcessorFunction
             && !string.IsNullOrWhiteSpace(classificatie.Datum))
         {
             await StuurTeamleiderNotificatieAsync(
-                graphService, classificatie.TeamNaam, classificatie.Datum, reviewMode, log);
+                graphService, classificatie.TeamNaam, classificatie.Datum, log);
         }
 
         // Stuur vraag door naar coach bij team-contact-opvragen (#168)
@@ -359,12 +375,12 @@ public class EmailProcessorFunction
             && !string.IsNullOrWhiteSpace(classificatie.TeamNaam))
         {
             await StuurTeamContactBerichtDoorAsync(
-                graphService, classificatie.TeamNaam, email, reviewMode, log);
+                graphService, classificatie.TeamNaam, email, log);
         }
     }
 
     private static async Task StuurTeamleiderNotificatieAsync(
-        EmailGraphService graphService, string teamNaam, string datum, string? reviewMode, ILogger log)
+        EmailGraphService graphService, string teamNaam, string datum, ILogger log)
     {
         try
         {
@@ -390,12 +406,8 @@ public class EmailProcessorFunction
                 + $"Als je vragen hebt over dit herplanverzoek, neem dan contact op met de veldplanner.\n\n"
                 + $"Met vriendelijke groet,\n{plannerNaam}";
 
-            var notificatieOntvanger = string.Equals(reviewMode, "true", StringComparison.OrdinalIgnoreCase)
-                ? Environment.GetEnvironmentVariable("EmailReviewRecipient") ?? teamleider.Emailadres
-                : teamleider.Emailadres;
-
             await graphService.SendReplyAsync(
-                notificatieOntvanger,
+                teamleider.Emailadres,
                 $"Herplanverzoek ontvangen voor {teamNaam} op {datumDisplay}",
                 notificatieBody,
                 null);
@@ -409,8 +421,7 @@ public class EmailProcessorFunction
     }
 
     private static async Task StuurTeamContactBerichtDoorAsync(
-        EmailGraphService graphService, string teamNaam, InkomendBericht email,
-        string? reviewMode, ILogger log)
+        EmailGraphService graphService, string teamNaam, InkomendBericht email, ILogger log)
     {
         try
         {
@@ -428,14 +439,10 @@ public class EmailProcessorFunction
                      + $"---\n{email.Body}\n---\n\n"
                      + "U kunt direct antwoorden op dit bericht — uw antwoord gaat naar de vraagsteller.";
 
-            var coachOntvanger = string.Equals(reviewMode, "true", StringComparison.OrdinalIgnoreCase)
-                ? Environment.GetEnvironmentVariable("EmailReviewRecipient") ?? coach.Emailadres
-                : coach.Emailadres;
-
             // AVG: Reply-To = email.Afzender zodat coach rechtstreeks kan antwoorden
             // BCC coördinator voor audit; coach-email nooit in logs
             await graphService.StuurTeamContactDoorAsync(
-                coachOntvanger, subject, body, email.Afzender, coordinatorEmail);
+                coach.Emailadres, subject, body, email.Afzender, coordinatorEmail);
 
             log.LogInformation("Teambegeleiding-vraag doorgestuurd voor {Team}", teamNaam);
         }

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.16.0.0</Version>
-    <AssemblyVersion>2.16.0.0</AssemblyVersion>
-    <FileVersion>2.16.0.0</FileVersion>
+    <Version>2.16.0.1</Version>
+    <AssemblyVersion>2.16.0.1</AssemblyVersion>
+    <FileVersion>2.16.0.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->


### PR DESCRIPTION
## Wijziging

In review mode (`EmailReviewMode=true`) werd eerder een reply verstuurd naar `EmailReviewRecipient` met `=== REVIEW MODE ===` header. Dit is vervangen door:

1. **Label 'Geen AI antwoord' zetten** op de originele email (Graph Categories API)
2. **Email als gelezen markeren**
3. **Geen email versturen** — niet naar `EmailReviewRecipient`, niet naar de originele afzender
4. Interne notificaties (teamleider, team-contact) worden ook onderdrukt — ze worden niet bereikt door de early return vóór de aanroepen

### Technische details

- `VerwerkEmailAsync`: early return na het zetten van het label als `reviewMode=true`, nog vóór `BouwTemplateAntwoord()` wordt aangeroepen
- `StuurTeamleiderNotificatieAsync` en `StuurTeamContactBerichtDoorAsync`: `reviewMode` parameter verwijderd (niet meer nodig)

## Test plan

- [ ] `EmailReviewMode=false`: gedrag ongewijzigd — antwoord verstuurd naar originele afzender
- [ ] `EmailReviewMode=true`: geen email verstuurd, label 'Geen AI antwoord' zichtbaar in Outlook op de originele email

Closes #543