### PR TITLE
feat(#521): KNVB-regels en speeldagenkalender bijwerken naar seizoen 2026/'27

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.16.0.1</Version>
-    <AssemblyVersion>2.16.0.1</AssemblyVersion>
-    <FileVersion>2.16.0.1</FileVersion>
+    <Version>2.16.1.0</Version>
+    <AssemblyVersion>2.16.1.0</AssemblyVersion>
+    <FileVersion>2.16.1.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Added
+- KNVB-speeldagenkalender voor seizoen 2026/'27 (district West en Landelijk) is opgenomen in de database. Per speeldatum is nu bekend of het een competitie-, beker-, inhaal-, nacompetitie- of vrije dag is, welke leeftijdscategorieën actief zijn en welke schoolvakanties of feestdagen spelen.
+
 ### Changed
+- De KNVB-verplaatsingsregels waarop de AI herplanverzoeken beoordeelt zijn bijgewerkt naar seizoen 2026/'27. Verzoeken worden niet langer getoetst aan de verlopen deadlines van seizoen 2025/'26. Nieuw toegevoegd: de seizoensdata (competitiestart, winterstop, laatste speelronde, nacompetitie) en de verplaatsingsdeadlines voor de landelijke divisies.
 - Review mode stuurt geen email meer terug aan de coördinator — in plaats daarvan wordt de originele email gemarkeerd met 'Geen AI antwoord' zodat de coördinator deze handmatig kan afhandelen. Interne notificaties (teamleider, team-contact) worden ook onderdrukt tijdens review mode.
 
 ## [2.16.0.0] — 2026-06-01

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -289,6 +289,153 @@ END
 GO
 
 -- ============================================================
+-- #521: KnvbKalenderDag seizoen 2026/2027 (West + Landelijk)
+-- Bron: https://www.knvb.nl/assist-wedstrijdsecretarissen/veldvoetbal/seizoensplanning/speeldagenkalenders
+-- Weekendrijen gebruiken de zaterdagdatum; vrijdagrijen zijn pupillen 7x7-toernooien.
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM [dbo].[KnvbKalenderDag] WHERE [Seizoen] = '2026/2027' AND [Regio] = 'West')
+BEGIN
+    INSERT INTO [dbo].[KnvbKalenderDag]
+        ([Seizoen],[Regio],[Datum],[DagType],[HeeftSenioren],[HeeftJeugd],[HeeftMeiden],[PupillenToernooi],[Schoolvakantie],[Feestdag],[Opmerking],[Bron])
+    VALUES
+        -- Augustus / september 2026
+        ('2026/2027','West','2026-08-15','Vrij',       0,0,0,0,'N',  NULL,                  N'Volledig vrij; schoolvak. Noord t/m 16 aug',              'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-08-22','Vrij',       0,0,0,0,'Z',  NULL,                  N'Volledig vrij; schoolvak. Zuid t/m 23 aug',               'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-08-29','Beker',      1,1,1,0,'M',  NULL,                  N'Bekerpoule senioren+junioren; Beker KO O23 cat A; start fase 1 meiden div+hoofdkl', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-09-05','Beker',      1,1,1,0,NULL, NULL,                  N'Bekerpoule senioren+junioren; WD NJ O23 cat A; Beker KO O23 cat B; start fase 1 junioren+pupillen', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-09-12','Beker',      1,1,1,0,NULL, NULL,                  N'Bekerpoule senioren+junioren; WD NJ O23; meiden week 3 / fase 1', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-09-18','Toernooi',   0,0,0,1,NULL, NULL,                  N'Pupillen 7x7 toernooi (vrijdag)',                         'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-09-19','Competitie', 1,1,1,0,NULL, NULL,                  N'Start competitie: WD senioren; WD NJ O23+junioren; meiden week 4 / fase 1', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-09-26','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD NJ O23+junioren; meiden week 5 / fase 1',  'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        -- Oktober 2026
+        ('2026/2027','West','2026-10-02','Toernooi',   0,0,0,1,NULL, NULL,                  N'Pupillen 7x7 toernooi (vrijdag, week 1)',                 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-10-03','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD NJ O23+junioren; meiden week 6 / fase 1',  'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-10-09','Toernooi',   0,0,0,1,NULL, NULL,                  N'Pupillen 7x7 toernooi (vrijdag, week 2)',                 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-10-10','Competitie', 1,1,1,0,'N',  NULL,                  N'WD senioren; junioren inhaal; meiden week 7 / inhaal; herfstvak. Noord 10-18 okt', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-10-17','Inhaal',     1,1,1,0,'MNZ',NULL,                  N'Inh./Bek. senioren+O23+junioren cat A; meiden inhaal; herfstvakantie alle regio''s', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-10-24','Competitie', 1,1,0,0,'MZ', NULL,                  N'WD senioren; WD NJ O23; start fase 2 junioren cat A+pupillen; meiden vrij; herfstvak. M+Z 17-25 okt', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-10-30','Toernooi',   0,0,0,1,NULL, NULL,                  N'Pupillen 7x7 toernooi (vrijdag)',                         'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-10-31','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD NJ O23+junioren; meiden div fase 2 / hoofdkl fase 2', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        -- November 2026
+        ('2026/2027','West','2026-11-07','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD NJ O23+junioren; meiden fase 2',           'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-11-13','Toernooi',   0,0,0,1,NULL, NULL,                  N'Pupillen 7x7 toernooi (vrijdag)',                         'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-11-14','Competitie', 1,1,1,0,NULL, NULL,                  N'WD schema 14; Inh./Bek. schema 12; WD NJ O23+junioren; meiden fase 2', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-11-21','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD NJ O23+junioren; meiden fase 2',           'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-11-27','Toernooi',   0,0,0,1,NULL, NULL,                  N'Pupillen 7x7 toernooi (vrijdag)',                         'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-11-28','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD NJ O23+junioren; meiden fase 2',           'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        -- December 2026
+        ('2026/2027','West','2026-12-05','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD NJ O23+junioren; meiden fase 2',           'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-12-12','Competitie', 1,1,1,0,NULL, NULL,                  N'Laatste speelronde najaar: WD schema 14 cat A; rest Inh./Bek.; pupillen uitwijk', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2026-12-19','Inhaal',     1,1,1,0,'MNZ',NULL,                  N'Inh./Bek. schema 14 cat A + O23 cat A + junioren cat B; meiden hoofdkl inhaal; kerstvakantie 19 dec-3 jan', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        -- Januari 2027
+        ('2026/2027','West','2027-01-09','Vrij',       0,0,0,0,NULL, NULL,                  N'Volledig vrij',                                           'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-01-16','Competitie', 1,1,0,0,NULL, NULL,                  N'Start voorjaar cat B: WD schema 14 cat B; Inh./Bek. schema 12 cat B; Beker O23 cat A; junioren cat B inhaal', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-01-23','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren (Inh./Bek. schema 12 cat A); WD VJ O23 cat A; beker junioren; start fase 3 meiden+pupillen', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-01-30','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD VJ O23; beker junioren; meiden+pupillen fase 3', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        -- Februari 2027
+        ('2026/2027','West','2027-02-06','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD VJ O23+junioren; start fase 3 junioren districtscomp.; carnavalsweekend', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-02-13','Competitie', 1,1,1,0,'Z',  NULL,                  N'WD cat B senioren; Inh./Bek. cat A; WD VJ O23 cat B+junioren; voorjaarsvak. Zuid 13-21 feb', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-02-20','Inhaal',     1,1,1,0,'MNZ',NULL,                  N'Inh./Bek. alle categorieen; meiden inhaal; voorjaarsvakantie alle regio''s', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-02-27','Competitie', 1,1,1,0,'MN', NULL,                  N'WD cat A senioren; Inh./Bek. cat B+junioren; WD VJ O23 cat A; voorjaarsvak. Noord+Midden 20-28 feb', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        -- Maart 2027
+        ('2026/2027','West','2027-03-06','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD VJ O23+junioren; meiden+pupillen fase 3',  'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-03-13','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD VJ O23+junioren; meiden+pupillen fase 3',  'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-03-19','Toernooi',   0,0,0,1,NULL, NULL,                  N'Pupillen 7x7 toernooi (vrijdag)',                         'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-03-20','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD VJ O23+junioren; meiden+pupillen fase 3',  'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-03-27','Inhaal',     1,1,1,0,NULL, N'Paaszaterdag',       N'Inh./Bek. cat A senioren+O23; Vrij/Bek. cat B; meiden inhaal; junioren Inh./Bek.', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-03-29','Feestdag',   1,0,0,0,NULL, N'2e Paasdag',         N'Inh./Bek. cat A senioren; Vrij/Bek. cat B senioren; rest geen wedstrijden', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        -- April 2027
+        ('2026/2027','West','2027-04-02','Toernooi',   0,0,0,1,NULL, NULL,                  N'Pupillen 7x7 toernooi (vrijdag)',                         'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-04-03','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD VJ O23+junioren; meiden fase 3; start fase 4 pupillen', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-04-10','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD VJ O23+junioren; meiden fase 3; pupillen fase 4', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-04-16','Toernooi',   0,0,0,1,NULL, NULL,                  N'Pupillen 7x7 toernooi (vrijdag)',                         'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-04-17','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD VJ O23+junioren; meiden fase 3; pupillen fase 4', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-04-24','Competitie', 1,1,1,0,'MNZ',NULL,                  N'WD schema 14; Inh./Bek. schema 12+junioren; WD VJ O23 cat A; meivakantie 24 apr-2 mei', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        -- Mei 2027
+        ('2026/2027','West','2027-05-01','Inhaal',     1,1,1,0,'MNZ',NULL,                  N'Inh./Bek. alle categorieen; evt. finale bekerkampioenschap standaardteams; meivakantie', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-05-06','Feestdag',   1,0,0,0,NULL, N'Hemelvaartsdag',     N'Evt. bekerfinale standaardteams; rest geen wedstrijden',   'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-05-07','Toernooi',   0,0,0,1,NULL, NULL,                  N'Pupillen 7x7 toernooi (vrijdag)',                         'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-05-08','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD VJ O23+junioren; meiden fase 3; pupillen fase 4', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-05-15','Competitie', 1,1,1,0,NULL, N'Pinksterzaterdag',   N'WD cat A senioren + WD (zat) schema 14 cat B; Inh./Bek. O23+junioren; meiden inhaal', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-05-17','Feestdag',   1,1,0,0,NULL, N'2e Pinksterdag',     N'WD cat A senioren + WD (zon) schema 14 cat B; Inh./Bek. schema 12 cat B + junioren cat A', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-05-21','Toernooi',   0,0,0,1,NULL, NULL,                  N'Pupillen 7x7 toernooi (vrijdag)',                         'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-05-22','Competitie', 1,1,1,0,NULL, NULL,                  N'WD senioren; WD VJ O23+junioren; meiden fase 3; pupillen fase 4', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-05-29','NC',         1,1,1,0,NULL, NULL,                  N'NC senioren cat A; inhaal cat B; WD VJ O23 cat A+junioren; meiden hoofdkl fase 3', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        -- Juni 2027
+        ('2026/2027','West','2027-06-05','NC',         1,1,1,0,NULL, NULL,                  N'NC senioren cat A; Inh./Bek. cat B; beker O23+junioren; final league meiden; finales districtsbeker', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-06-12','NC',         1,0,0,0,NULL, NULL,                  N'NC alleen senioren cat A',                                'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027'),
+        ('2026/2027','West','2027-06-19','NC',         1,0,0,0,NULL, NULL,                  N'NC alleen senioren cat A',                                'https://www.knvb.nl/downloads/sites/bestand/knvb/29863/speeldagenkalender-veld-west-2026-2027');
+END
+GO
+
+IF NOT EXISTS (SELECT 1 FROM [dbo].[KnvbKalenderDag] WHERE [Seizoen] = '2026/2027' AND [Regio] = 'Landelijk')
+BEGIN
+    INSERT INTO [dbo].[KnvbKalenderDag]
+        ([Seizoen],[Regio],[Datum],[DagType],[HeeftSenioren],[HeeftJeugd],[HeeftMeiden],[PupillenToernooi],[Schoolvakantie],[Feestdag],[Opmerking],[Bron])
+    VALUES
+        -- Augustus / september 2026
+        ('2026/2027','Landelijk','2026-08-08','Vrij',       0,0,0,0,NULL, NULL,                 N'Geen competitie',                                        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-08-15','Competitie', 1,0,0,0,'N',  NULL,                 N'2e/3e divisie ronde 1; schoolvak. Noord t/m 16 aug',      'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-08-22','Competitie', 1,1,0,0,'Z',  NULL,                 N'2e/3e div ronde 2; O23 inhaal; jeugd inhaal/Jeugdcup; schoolvak. Zuid t/m 23 aug', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-08-29','Competitie', 1,1,1,0,'M',  NULL,                 N'2e/3e div ronde 3; 4e div ronde 1; bekerpoule vrouwen 1e klassen; O23+jeugd ronde 1', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-09-05','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 4/2; Beker Q1 vrouwen top+hoofdklasse; bekerpoule vrouwen 1e klassen; O23+jeugd ronde 2', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-09-12','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 5/3; Beker Q2 vrouwen top+hoofdklasse; bekerpoule vrouwen 1e klassen; O23+jeugd ronde 3', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-09-19','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 6/4; vrouwen ronde 1; O23+jeugd ronde 4',           'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-09-26','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 7/5; vrouwen ronde 2; O23+jeugd ronde 5',           'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        -- Oktober 2026
+        ('2026/2027','Landelijk','2026-10-03','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 8/6; vrouwen ronde 3; O23+jeugd ronde 6',           'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-10-10','Competitie', 1,1,1,0,'N',  NULL,                 N'Ronde 9/7; vrouwen ronde 4; O23+jeugd ronde 7; herfstvak. Noord', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-10-17','Competitie', 1,1,1,0,'MNZ',NULL,                 N'2e/3e div ronde 10; rest Inh./Bek.; jeugd inhaal/Jeugdcup; herfstvak. alle regio''s', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-10-24','Competitie', 1,1,1,0,'MZ', NULL,                 N'Ronde 11/8; vrouwen Inh./Bek.; O23+jeugd ronde 8; herfstvak. Midden en Zuid', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-10-31','Competitie', 1,1,1,0,NULL, NULL,                 N'2e/3e div inhaal; 4e div ronde 9; vrouwen ronde 5; O23+jeugd ronde 9', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        -- November 2026
+        ('2026/2027','Landelijk','2026-11-07','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 12/10; vrouwen ronde 6; O23+jeugd ronde 10',        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-11-14','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 13/11; vrouwen ronde 7; O23+jeugd ronde 11',        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-11-21','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 14/12; vrouwen ronde 8; O23+jeugd ronde 12',        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-11-28','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 15/13; vrouwen ronde 9; O23 inhaal; jeugd inhaal/Jeugdcup', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        -- December 2026
+        ('2026/2027','Landelijk','2026-12-05','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 16/14; vrouwen ronde 10; O23+jeugd ronde 13',       'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-12-12','Competitie', 1,1,1,0,NULL, NULL,                 N'Laatste speelronde najaar (verplaatsingsdeadline 13 dec 2026): ronde 17/15; vrouwen Inh./Bek.; O23+jeugd ronde 14', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-12-19','Inhaal',     1,1,0,0,'MNZ',NULL,                 N'Inhaalmoment uitsluitend voor calamiteiten of gelijktijdige laatste speelronde; vrouwen vrij; kerstvakantie', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2026-12-26','Vrij',       0,0,0,0,'MNZ',NULL,                 N'Kerstvakantie',                                          'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        -- Januari 2027
+        ('2026/2027','Landelijk','2027-01-02','Vrij',       0,0,0,0,'MNZ',NULL,                 N'Kerstvakantie',                                          'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-01-09','Competitie', 1,0,0,0,NULL, NULL,                 N'2e/3e divisie ronde 18; rest vrij',                      'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-01-16','Competitie', 1,1,1,0,NULL, NULL,                 N'2e/3e div ronde 19; vrouwen Inh./Bek.; O23+jeugd voorjaar ronde 1', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-01-23','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 20/16; vrouwen ronde 11; O23+jeugd ronde 2',        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-01-30','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 21/17; vrouwen ronde 12; O23+jeugd ronde 3',        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        -- Februari 2027
+        ('2026/2027','Landelijk','2027-02-06','Inhaal',     1,1,1,0,NULL, NULL,                 N'Inhaal alle divisies; vrouwen Inh./Bek.; jeugd inhaal/Jeugdcup; carnavalsweekend', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-02-13','Competitie', 1,1,1,0,'Z',  NULL,                 N'Ronde 22/18; vrouwen ronde 13; O23+jeugd inhaal; voorjaarsvak. Zuid', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-02-20','Competitie', 1,1,1,0,'MNZ',NULL,                 N'Ronde 23/19; vrouwen ronde 14; O23 inhaal; Jeugdcup kwartfinale; voorjaarsvak. alle regio''s', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-02-27','Competitie', 1,1,1,0,'M',  NULL,                 N'Ronde 24/20; vrouwen Inh./Bek.; O23+jeugd ronde 4; voorjaarsvak. Midden/West', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        -- Maart 2027
+        ('2026/2027','Landelijk','2027-03-06','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 25/21; vrouwen ronde 15; O23+jeugd ronde 5',        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-03-13','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 26/22; vrouwen ronde 16; O23+jeugd ronde 6',        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-03-20','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 27/23; vrouwen ronde 17; O23+jeugd ronde 7',        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-03-27','Inhaal',     1,1,1,0,NULL, N'Paaszaterdag',      N'Inhaal alle divisies; vrouwen Inh./Bek.; jeugd inhaal/Jeugdcup; paasweekend', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        -- April 2027
+        ('2026/2027','Landelijk','2027-04-03','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 28/24; vrouwen ronde 18; O23+jeugd ronde 8',        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-04-10','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 29/25; vrouwen ronde 19; O23+jeugd ronde 9',        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-04-17','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 30/26; vrouwen ronde 20; O23+jeugd ronde 10',       'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-04-24','Competitie', 1,1,1,0,'MNZ',NULL,                 N'Ronde 31/27; vrouwen Inh./Bek.; O23+jeugd ronde 11; meivakantie', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        -- Mei 2027
+        ('2026/2027','Landelijk','2027-05-01','Inhaal',     1,1,1,0,'MNZ',NULL,                 N'Inhaal alle divisies; vrouwen Inh./Bek.; Jeugdcup finale; meivakantie', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-05-06','Inhaal',     1,1,1,0,NULL, N'Hemelvaartsdag',    N'Midweeks inhaalmoment 5-6 mei; vrouwen Inh./Bek.',        'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-05-08','Competitie', 1,1,1,0,NULL, NULL,                 N'Ronde 32/28; vrouwen ronde 21; O23+jeugd ronde 12',       'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-05-15','Competitie', 1,1,1,0,NULL, N'Pinksterzaterdag',  N'Speelweekend 15-17 mei: ronde 33/29; vrouwen ronde 22; O23+jeugd ronde 13', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-05-22','Competitie', 1,1,1,0,NULL, NULL,                 N'Laatste inhaalmoment voorjaar 23 mei 2027: ronde 34/30; vrouwen NC; O23+jeugd inhaal', 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-05-26','NC',         1,0,1,0,NULL, NULL,                 N'NC divisies mannen + vrouwen (woensdag)',                 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-05-29','NC',         1,1,1,0,NULL, NULL,                 N'NC divisies + vrouwen; O23+jeugd ronde 14',               'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        -- Juni 2027
+        ('2026/2027','Landelijk','2027-06-03','NC',         1,0,1,0,NULL, NULL,                 N'NC divisies mannen + vrouwen (donderdag)',                'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-06-05','NC',         1,1,1,0,NULL, NULL,                 N'NC divisies + vrouwen; finale divisie 1 O23+jeugd',       'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-06-09','NC',         1,0,1,0,NULL, NULL,                 N'NC divisies mannen + vrouwen (woensdag)',                 'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027'),
+        ('2026/2027','Landelijk','2027-06-12','NC',         1,0,1,0,NULL, NULL,                 N'NC divisies mannen + vrouwen',                            'https://www.knvb.nl/downloads/sites/bestand/knvb/29859/speeldagenkalender-veld-landelijk-2026-2027');
+END
+GO
+
+-- ============================================================
 -- #424: planner.sp_CleanupClassificatieCorrectie (AVG-retentie)
 -- Moet VOOR sp_CleanupEmailVerwerking worden aangeroepen (FK-afhankelijkheid)
 -- ============================================================

--- a/FunctionApp/Email/BerichtAiService.cs
+++ b/FunctionApp/Email/BerichtAiService.cs
@@ -13,10 +13,21 @@ public class BerichtAiService
     private readonly ILogger<BerichtAiService> _logger;
     private readonly IChatClient _chatClient;
 
-    // KNVB-verplaatsingsregels voor seizoen 2025/'26 — wordt door AI gebruikt om overtreding te signaleren
+    // KNVB-verplaatsingsregels voor seizoen 2026/'27 — wordt door AI gebruikt om overtreding te signaleren
     // Bron: https://www.knvb.nl/assist-wedstrijdsecretarissen/veldvoetbal/regelen-dagelijkse-praktijk/verplaatsen-van-wedstrijden
+    // + https://www.knvb.nl/assist-wedstrijdsecretarissen/veldvoetbal/seizoensplanning/speeldagenkalenders
+    //   (Speeldagenkalender Landelijk 2026/'27, geraadpleegd 2026-07-25 — zie issue #521)
     private const string KnvbRegelsContext = """
-        ## KNVB-verplaatsingsregels seizoen 2025/'26
+        ## KNVB-verplaatsingsregels seizoen 2026/'27
+
+        ### Seizoensdata (speeldagenkalender)
+        - Bekerpoules district: vanaf 29/30 augustus 2026
+        - Competitiestart district: 19/20 september 2026 (landelijke divisies: 15/16 augustus 2026)
+        - Laatste speelronde najaar: 12/13 december 2026
+        - Winterstop: 19 december 2026 t/m 8 januari 2027
+        - Start voorjaar: 16/17 januari 2027
+        - Laatste competitieweekend: 29/30 mei 2027; nacompetitie t/m 19/20 juni 2027
+        - Finales districtsbeker: 5/6 juni 2027
 
         ### Aanvangstijdwijzigingen
         - Tot 8 dagen voor wedstrijd: aanpasbaar via Sportlink Club (geen KNVB-goedkeuring nodig)
@@ -29,23 +40,25 @@ public class BerichtAiService
 
         ### Categorie A (strenge regels)
         Geldt voor: mannen senioren standaard, vrouwen top/hoofd/1e klasse, landelijke jeugddivisies + hoofdklasse
-        - Mannen/vrouwen senioren: GEEN verplaatsing na 1 mei 2026
-        - Vrouwen 2e klasse: GEEN verplaatsing na 1 mei 2026
-        - Jeugd divisies + hoofdklasse najaar: deadline 13 december 2025
-        - Jeugd divisies + hoofdklasse voorjaar: deadline 16 mei 2026
+        - Mannen/vrouwen senioren: GEEN verplaatsing na 1 mei 2027
+        - Vrouwen 2e klasse: GEEN verplaatsing na 1 mei 2027
+        - Jeugd divisies + hoofdklasse najaar: deadline 13 december 2026
+        - Jeugd divisies + hoofdklasse voorjaar: deadline 16 mei 2027
+        - Landelijke divisies: verplaatsen alleen vóór de laatste speelronde najaar (13 december 2026)
+          en/of vóór het laatste inhaalmoment voorjaar (23 mei 2027)
         - Laatste 2 wedstrijddagen van de competitie: GEEN verplaatsing
 
         ### Categorie B (flexibeler — onderling overleg)
         Geldt voor: pupillen, junioren regionaal, senioren 3e klasse en lager, vrouwen 3e klasse
-        - Senioren 21 sep–31 dec: verplaatst uiterlijk 31 januari 2026
-        - Senioren 1 jan–1 jun: verplaatst uiterlijk 21 juni 2026
-        - Vrouwen 3e klasse: uiterlijk 9 mei 2026; geen verplaatsing na 1 mei
+        - Senioren 21 sep–31 dec: verplaatst uiterlijk 31 januari 2027
+        - Senioren 1 jan–1 jun: verplaatst uiterlijk 21 juni 2027
+        - Vrouwen 3e klasse: uiterlijk 9 mei 2027; geen verplaatsing na 1 mei
         - Pupillen (O7–O12): voor volgende fase schriftelijk vastleggen
 
         ### Snipperdagen (alleen Categorie B)
         - Max 1 per team per seizoen
         - Aanvraag uiterlijk dinsdag 23:59 van de voorafgaande week
-        - Periode: seizoenstart t/m eerste volledige weekend maart 2026
+        - Periode: seizoenstart t/m eerste volledige weekend maart 2027
         - NIET voor: beker, O7–O12, MO13–MO20
 
         ### Bekerwedstrijden
@@ -124,7 +137,7 @@ public class BerichtAiService
 
             KNVB-regelcheck (voor herplan_verzoek):
             Vul "knvbNotitie" in als op basis van datum en teamtype een KNVB-regel waarschijnlijk van toepassing is.
-            Wees kort (1-2 zinnen). Voorbeeld: "Senioren mogen na 1 mei 2026 geen wedstrijden meer verplaatsen (KNVB Cat A)."
+            Wees kort (1-2 zinnen). Voorbeeld: "Senioren mogen na 1 mei 2027 geen wedstrijden meer verplaatsen (KNVB Cat A)."
             Laat null als datum ruim voor eventuele deadlines valt of het teamtype niet duidelijk is.
 
             {{KnvbRegelsContext}}

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.16.0.1</Version>
-    <AssemblyVersion>2.16.0.1</AssemblyVersion>
-    <FileVersion>2.16.0.1</FileVersion>
+    <Version>2.16.1.0</Version>
+    <AssemblyVersion>2.16.1.0</AssemblyVersion>
+    <FileVersion>2.16.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/docs/ARCHITECTUUR-AI-SERVICES.md
+++ b/docs/ARCHITECTUUR-AI-SERVICES.md
@@ -170,15 +170,19 @@ Dit maakt model-upgrades (gpt-4o-mini → gpt-4.1-mini, etc.) zonder deployment 
 ## Jaarlijkse onderhoudsplicht: KNVB-regels
 
 De `KnvbRegelsContext` constante in `BerichtAiService.cs` bevat KNVB-verplaatsingsregels
-voor één specifiek seizoen (bijv. 2025/'26). Deze datums zijn jaarlijks verouderd.
+voor één specifiek seizoen (huidig: 2026/'27). Deze datums zijn jaarlijks verouderd.
 
 **Verplichting:** bij elke nieuwe seizoensstart (augustus/september):
 1. Controleer KNVB-website op gewijzigde verplaatsingsregels
-2. Update `KnvbRegelsContext` met nieuwe deadlines
+2. Update `KnvbRegelsContext` met nieuwe deadlines én de seizoensdata uit de speeldagenkalender
 3. Update de seizoensvermelding (`## KNVB-verplaatsingsregels seizoen 20XX/'YY`)
-4. Voeg CHANGELOG-entry toe onder `### Changed`
+4. Archiveer de nieuwe speeldagenkalender-PDF's in `docs/knvb-speeldagenkalenders/<seizoen>/`
+   en seed `dbo.KnvbKalenderDag` via `Database/Script.PostDeployment1.sql`
+5. Voeg CHANGELOG-entry toe onder `### Changed`
 
-**Bron:** [KNVB verplaatsen van wedstrijden](https://www.knvb.nl/assist-wedstrijdsecretarissen/veldvoetbal/regelen-dagelijkse-praktijk/verplaatsen-van-wedstrijden)
+**Bronnen:**
+- [KNVB verplaatsen van wedstrijden](https://www.knvb.nl/assist-wedstrijdsecretarissen/veldvoetbal/regelen-dagelijkse-praktijk/verplaatsen-van-wedstrijden)
+- [KNVB speeldagenkalenders](https://www.knvb.nl/assist-wedstrijdsecretarissen/veldvoetbal/seizoensplanning/speeldagenkalenders)
 
 **GitHub-herinnering:** maak elk jaar in augustus een issue aan met label `chore` en title
 `"KNVB-regels bijwerken voor seizoen 20XX/'YY"`.

--- a/docs/knvb-speeldagenkalenders/README.md
+++ b/docs/knvb-speeldagenkalenders/README.md
@@ -57,7 +57,17 @@ Landelijke jeugd kan afwijken door interlands (voetnoot in PDF).
 
 ## Hoe wordt dit gebruikt?
 
-De inhoud is samengevat in de SQL-tabel `dbo.KnvbKalenderDag` voor seizoen 2025/'26
+De inhoud is samengevat in de SQL-tabel `dbo.KnvbKalenderDag` voor seizoen 2025/'26 en 2026/'27
 (West + Landelijk). Zie [Database/Script.PostDeployment1.sql](../../Database/Script.PostDeployment1.sql).
+
+Weekendrijen gebruiken de **zaterdagdatum**; vrijdagrijen zijn pupillen 7x7-toernooien
+(`PupillenToernooi = 1`). Midweekse reeksen zonder één vaste datum (bijv. "1 - 3 juni") worden
+niet geseed — de tabel is een weekend-overzicht.
+
+De verplaatsingsdeadlines uit deze kalenders zijn daarnaast verwerkt in `KnvbRegelsContext`
+in [FunctionApp/Email/BerichtAiService.cs](../../FunctionApp/Email/BerichtAiService.cs) —
+de AI gebruikt die om te signaleren dat een herplanverzoek een KNVB-regel raakt.
+Zie [docs/ARCHITECTUUR-AI-SERVICES.md](../ARCHITECTUUR-AI-SERVICES.md) voor de jaarlijkse
+onderhoudsplicht.
 
 Toekomstige automatische import: zie open feature request op GitHub.


### PR DESCRIPTION
Closes #521

## Waarom

De `KnvbRegelsContext` in `FunctionApp/Email/BerichtAiService.cs` bevatte nog de deadlines van seizoen 2025/'26. Die zijn allemaal verstreken. De AI-classificatie toetste herplanverzoeken daarmee aan verlopen regels — risico op onjuiste afwijzing of onjuiste goedkeuring, en strijd met de informatieplicht (AVG art. 5(1)(d)).

## Wat is gewijzigd

**AI-context (`BerichtAiService.cs`)**
- Alle categorie A- en B-deadlines bijgewerkt naar 2026/'27
- Snipperdagperiode naar "eerste volledige weekend maart 2027"
- Nieuwe sectie **Seizoensdata**: bekerpoules, competitiestart, laatste speelronde najaar, winterstop, start voorjaar, laatste competitieweekend, nacompetitie, bekerfinales
- Nieuwe regel voor de **landelijke divisies**: verplaatsen alleen vóór de laatste speelronde najaar (13 december 2026) en/of vóór het laatste inhaalmoment voorjaar (23 mei 2027)
- Few-shot voorbeeld in de prompt bijgewerkt (geen hardcoded verlopen jaar meer)

**Speeldagenkalender (`Database/Script.PostDeployment1.sql`)**
- 106 rijen `dbo.KnvbKalenderDag` voor seizoen 2026/2027 — regio West en Landelijk
- Idempotent via `IF NOT EXISTS` per seizoen+regio, conform het bestaande 2025/2026-blok
- Weekendrijen gebruiken de zaterdagdatum; vrijdagrijen zijn pupillen 7x7-toernooien

**Documentatie**
- `docs/ARCHITECTUUR-AI-SERVICES.md` — jaarlijkse onderhoudsplicht uitgebreid: ook PDF's archiveren en `KnvbKalenderDag` seeden; beide KNVB-bronnen opgenomen
- `docs/knvb-speeldagenkalenders/README.md` — datumconventie en de link naar de AI-context gedocumenteerd
- `CHANGELOG.md` — entries onder `[Unreleased]`

**Versie** 2.16.0.1 → 2.16.1.0 (feat → PATCH bump in development, beide csproj's synchroon)

## Bronnen

Alle datums komen uit de officiële KNVB-publicaties — niets uit trainingsdata:
- [Verplaatsen van wedstrijden](https://www.knvb.nl/assist-wedstrijdsecretarissen/veldvoetbal/regelen-dagelijkse-praktijk/verplaatsen-van-wedstrijden)
- [Speeldagenkalenders](https://www.knvb.nl/assist-wedstrijdsecretarissen/veldvoetbal/seizoensplanning/speeldagenkalenders) — PDF's Landelijk en West 2026/'27, gearchiveerd in `docs/knvb-speeldagenkalenders/2026-2027/`

## Verificatie

| Check | Resultaat |
|---|---|
| `dotnet build FunctionApp` (Debug) | 0 warnings, 0 errors |
| `dotnet build BlazorAdmin` | 0 warnings, 0 errors |
| `dotnet test` | 24 passed, 0 failed, 3 skipped |
| T-SQL syntaxvalidatie hele script (ScriptDom `TSql160Parser`) | geen fouten |
| Seed-data: kolomaantal per rij | 106/106 correct |
| Seed-data: PK-uniciteit (Seizoen, Regio, Datum) | geen duplicaten |
| Seed-data: `DagType` binnen CHECK-constraint | alle waarden geldig |
| Seed-data: `Opmerking` binnen NVARCHAR(200) | alle rijen |
| Seed-data: dag-van-week per datum | zaterdag/vrijdag/feestdag zoals verwacht |

**Niet uitgevoerd:** de database-secties van `Test-App.ps1`. De lokale SQL Server-service staat `Stopped` en kan zonder verhoogde rechten niet worden gestart. Build-, test- en Blazor-secties zijn wel gedekt; de wijziging raakt geen `.razor`-bestanden, geen endpoints en geen DDL, dus er is geen GUI- of API-oppervlak veranderd.

De seed wordt bij deploy naar `main` toegepast door de bestaande stap "Database-migratie uitvoeren (PostDeployment script — idempotent)" in `deploy.yml`.

## Kostenbeleid

Geen nieuwe Azure-resources, geen tierwijziging, geen configuratiewijziging aan bestaande resources. Kosten blijven €0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)