### PR TITLE
fix(#564): PostDeployment-script draait weer bij meer dan één club

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.16.2.0</Version>
-    <AssemblyVersion>2.16.2.0</AssemblyVersion>
-    <FileVersion>2.16.2.0</FileVersion>
+    <Version>2.16.2.1</Version>
+    <AssemblyVersion>2.16.2.1</AssemblyVersion>
+    <FileVersion>2.16.2.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 ### Added
 - KNVB-speeldagenkalender voor seizoen 2026/'27 is opgenomen in de database voor **alle zes districten**: West, Noord, Oost, Zuid, Landelijk en Landelijk jeugd. Per speeldatum is nu bekend of het een competitie-, beker-, inhaal-, nacompetitie- of vrije dag is, welke leeftijdscategorieën actief zijn, en welke schoolvakanties of feestdagen spelen. Clubs buiten district West kunnen de kalender daarmee ook gebruiken.
 
+### Fixed
+- De databasemigratie liep bij elke deploy vast zodra er meer dan één club in de instellingen stond — wat altijd het geval is doordat de AllStars FC democlub wordt aangemaakt. Gevolg: het nieuwe seizoen werd niet meer automatisch aangemaakt en een deel van de migratie werd overgeslagen. Beide zijn verholpen.
+- De kolom die geplande wedstrijden aan een club koppelt werd door een fout in het migratiescript nooit aangemaakt. Daardoor ontbrak de scheiding tussen productie- en demogegevens voor geplande wedstrijden. De migratie werkt nu.
+
 ### Changed
 - De KNVB-verplaatsingsregels waarop de AI herplanverzoeken beoordeelt zijn bijgewerkt naar seizoen 2026/'27. Verzoeken worden niet langer getoetst aan de verlopen deadlines van seizoen 2025/'26. Nieuw toegevoegd: de seizoensdata (competitiestart, winterstop, laatste speelronde, nacompetitie) en de verplaatsingsdeadlines voor de landelijke divisies.
 - Review mode stuurt geen email meer terug aan de coördinator — in plaats daarvan wordt de originele email gemarkeerd met 'Geen AI antwoord' zodat de coördinator deze handmatig kan afhandelen. Interne notificaties (teamleider, team-contact) worden ook onderdrukt tijdens review mode.

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -768,8 +768,20 @@ END
 GO
 
 -- Update the Season and datetable
-DECLARE @SeasonStartMonth INT = (SELECT [SeasonStartMonth] FROM [dbo].[AppSettings])
-EXEC [dbo].[sp_UpdateSeasonTable] @SeasonStartMonth;
+-- Een scalar subquery zonder aggregatie faalt met Msg 512 zodra dbo.AppSettings meer dan één rij
+-- heeft — en dat is altijd het geval nadat de AllStars FC demo-club verderop in dit script is
+-- geseed. Gevolg: vanaf de tweede deploy brak dit statement en werd dbo.Season/dbo.DateTable niet
+-- meer bijgewerkt, waardoor een nieuw seizoen niet automatisch werd aangemaakt. Zelfde klasse
+-- fout als #435.
+--
+-- MIN() is hier de juiste keuze: dbo.Season en dbo.DateTable zijn clubneutraal (geen ClubCode),
+-- dus het bereik moet de vroegst startende club omvatten. Bewust géén filter op SyncEnabled of
+-- ORDER BY [Id]: SyncEnabled wordt pas verderop in dit script toegevoegd en een Id-kolom bestaat
+-- niet in dbo.AppSettings — beide zouden een compile-fout geven op oudere installaties.
+DECLARE @SeasonStartMonth INT = (SELECT MIN([SeasonStartMonth]) FROM [dbo].[AppSettings]);
+
+IF @SeasonStartMonth IS NOT NULL
+    EXEC [dbo].[sp_UpdateSeasonTable] @SeasonStartMonth;
 GO
 -- ============================================================
 -- #30: Multi-club fundament — ClubCode + Accommodatie
@@ -1167,16 +1179,33 @@ GO
 -- ============================================================
 -- #428: ClubCode in planner.GeplandeWedstrijden + unique constraint
 -- ============================================================
+-- Deze migratie was permanent gebroken: SQL Server compileert een batch volledig vóór uitvoering,
+-- dus de UPDATE en ALTER COLUMN die [ClubCode] noemen faalden op naam-binding (Msg 207/1911/1750)
+-- terwijl de kolom in diezelfde batch nog moest worden toegevoegd. Omdat een batch die niet
+-- compileert in zijn geheel niet draait, werd de kolom ook nooit aangemaakt — bij elke deploy
+-- opnieuw. Opgelost door de DDL af te sluiten met GO en de DML in een aparte batch te zetten.
+-- Ook verwijderd: ORDER BY [Id] — dbo.AppSettings heeft geen Id-kolom.
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('planner.GeplandeWedstrijden') AND name = 'ClubCode')
-BEGIN
     ALTER TABLE [planner].[GeplandeWedstrijden] ADD [ClubCode] NVARCHAR(20) NULL;
-    -- Backfill: koppel bestaande rijen aan de primaire club
+GO
+
+-- Backfill: koppel bestaande rijen aan de primaire club (de enige met SyncEnabled = 1).
+-- SyncEnabled bestaat op dit punt zeker — het wordt hierboven toegevoegd.
+IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('planner.GeplandeWedstrijden') AND name = 'ClubCode')
+   AND EXISTS (SELECT 1 FROM [planner].[GeplandeWedstrijden] WHERE [ClubCode] IS NULL)
+BEGIN
     UPDATE [planner].[GeplandeWedstrijden]
-    SET [ClubCode] = (SELECT TOP 1 [ClubCode] FROM [dbo].[AppSettings] WHERE [SyncEnabled] = 1 ORDER BY [Id])
+    SET [ClubCode] = (SELECT TOP 1 [ClubCode] FROM [dbo].[AppSettings] WHERE [SyncEnabled] = 1)
     WHERE [ClubCode] IS NULL;
-    -- NOT NULL na backfill
-    ALTER TABLE [planner].[GeplandeWedstrijden] ALTER COLUMN [ClubCode] NVARCHAR(20) NOT NULL;
 END
+GO
+
+-- NOT NULL na backfill — alleen als er geen NULL's meer over zijn (anders faalt de ALTER)
+IF EXISTS (SELECT 1 FROM sys.columns
+           WHERE object_id = OBJECT_ID('planner.GeplandeWedstrijden')
+             AND name = 'ClubCode' AND is_nullable = 1)
+   AND NOT EXISTS (SELECT 1 FROM [planner].[GeplandeWedstrijden] WHERE [ClubCode] IS NULL)
+    ALTER TABLE [planner].[GeplandeWedstrijden] ALTER COLUMN [ClubCode] NVARCHAR(20) NOT NULL;
 GO
 
 -- Update unique constraint om ClubCode op te nemen (drop + recreate, idempotent)

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.16.2.0</Version>
-    <AssemblyVersion>2.16.2.0</AssemblyVersion>
-    <FileVersion>2.16.2.0</FileVersion>
+    <Version>2.16.2.1</Version>
+    <AssemblyVersion>2.16.2.1</AssemblyVersion>
+    <FileVersion>2.16.2.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->


### PR DESCRIPTION
Closes #564

## Waarom

Bij de verificatie van de 2026/'27-seed heb ik het PostDeployment-script voor het eerst daadwerkelijk **tegen een database uitgevoerd** in plaats van alleen geparseerd. Daarbij kwamen vier foutmeldingen naar boven, met twee onafhankelijke oorzaken. Beide treden op bij **elke** deploy zodra `dbo.AppSettings` meer dan één rij heeft — en dat is altijd zo, want dit script seedt zelf de AllStars FC democlub.

## Oorzaak 1 — `Msg 512`: de seizoensrollover stond stil

```sql
DECLARE @SeasonStartMonth INT = (SELECT [SeasonStartMonth] FROM [dbo].[AppSettings])
```

Een scalar subquery zonder aggregatie accepteert maximaal één rij.

| Uitvoering | `AppSettings` | Resultaat |
|---|---|---|
| 1e keer (verse DB) | 1 rij | slaagt — daarna wordt AllStars geseed |
| 2e keer en daarna | 2 rijen | **Msg 512** |

`sp_UpdateSeasonTable` is precies de procedure die twee maanden vóór een nieuw seizoen automatisch de nieuwe rij in `dbo.Season` aanmaakt en `dbo.DateTable` bijwerkt. Die liep dus na de eerste deploy nooit meer — stil, zonder zichtbaar symptoom tot iets een seizoensgrens nodig heeft. Precies relevant nu we het nieuwe seizoen ingaan.

Bovendien: als de migratiestap op fouten afbreekt, draait alles ná dit statement niet meer — het grootste deel van het script.

**Fix:** `MIN([SeasonStartMonth])` met een `IS NOT NULL`-guard vóór de `EXEC`. `dbo.Season` en `dbo.DateTable` zijn clubneutraal (geen `ClubCode`), dus het bereik moet de vroegst startende club omvatten — `MIN` is semantisch juist én deterministisch. Bewust **geen** filter op `SyncEnabled` en **geen** `ORDER BY [Id]`: `SyncEnabled` wordt pas verderop in dit script toegevoegd en een `Id`-kolom bestaat niet in `dbo.AppSettings`. Beide zouden op oudere installaties opnieuw een compile-fout geven — dezelfde valkuil als oorzaak 2.

Dit is dezelfde klasse fout die #435 bovenaan het script al oploste; deze plek was toen gemist.

## Oorzaak 2 — `Msg 207/1911/1750`: migratie #428 kon nooit slagen

`ALTER TABLE … ADD [ClubCode]` stond in **dezelfde batch** als de `UPDATE` en `ALTER COLUMN` die `[ClubCode]` noemen. SQL Server compileert een batch volledig vóór uitvoering, dus de naam-binding faalde — en omdat een batch die niet compileert in zijn geheel niet draait, werd ook de `ALTER TABLE … ADD` nooit uitgevoerd.

Netto: de migratie was **permanent gebroken**. Geverifieerd op een database die alle eerdere migraties heeft doorlopen:

```
planner.GeplandeWedstrijden bestaat: JA
  .ClubCode: ONTBREEKT
```

`ClubCode` op deze tabel is de multi-club data-isolatie voor geplande wedstrijden; zonder die kolom is er geen scheiding tussen productie- en demodata waar de rest van het schema die wel heeft.

Bijkomend: `ORDER BY [Id]` verwees naar een niet-bestaande kolom. Dat bleef onopgemerkt omdat de batch nooit tot uitvoering kwam.

**Fix:** DDL afgesloten met `GO`, backfill en `ALTER COLUMN` in aparte batches met eigen guards (kolom aanwezig / geen `NULL`-rijen meer). `ORDER BY [Id]` verwijderd.

## Zijn er meer van deze gevallen?

Het hele script is op beide foutklassen gescand:

| Patroon | Gevonden |
|---|---|
| Scalar subquery over `dbo.AppSettings` zonder `TOP 1`/aggregatie | 1 — deze plek |
| Batch die een kolom toevoegt en die kolom in dezelfde batch in DML/`ALTER COLUMN` gebruikt | 1 — deze plek |

Beide fouten zijn dus geïsoleerd; geen verdere gevallen.

## Verificatie — nu wél tegen een echte database

De lokale SQL Server is beschikbaar gemaakt, dus de volledige lus uit CLAUDE.md kon voor het eerst deze sessie draaien.

| Check | Resultaat |
|---|---|
| PostDeployment-script tegen DB met 2 clubs | **0 foutmeldingen** (was: 4) |
| Tweede run direct erna (idempotentie) | 0 foutmeldingen |
| `planner.GeplandeWedstrijden.ClubCode` | aangemaakt, `is_nullable = 0` |
| `dbo.KnvbKalenderDag` seizoen 2026/2027 | 319 rijen, 319 unieke (Regio, Datum) |
| `dotnet build` FunctionApp + BlazorAdmin | 0 warnings, 0 errors |
| `Test-App.ps1 -Fix` (schema) | 14 checks groen, exit 0 |
| `Test-App.ps1` met live services | **31 checks groen, exit 0** |
| `GET /api/health` | 200 — `database: online` |
| Blazor fingerprint-consistentie | importmap → `_framework/dotnet.*.js` → 200 |
| Browser render Dashboard + Instellingen | rendert volledig, geen foutbanner, **0 console-errors** |

De regionale seed-data is ook inhoudelijk steekproefgewijs nagelopen. Sprekend voorbeeld: op het carnavalsweekend (6 feb 2027) staat Zuid op `Vrij` terwijl West `Competitie` heeft — precies zoals de districtskalenders verschillen.

**Versie** 2.16.2.0 → 2.16.2.1 (fix → REVISION bump, beide csproj's synchroon)

## Kostenbeleid

Geen nieuwe Azure-resources, geen tierwijziging, geen configuratiewijziging. Kosten blijven €0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)