### PR TITLE
fix(#567): ClubCode-sync + feat(#566): directe veldbezetting in Dagplanning

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.16.2.1</Version>
-    <AssemblyVersion>2.16.2.1</AssemblyVersion>
-    <FileVersion>2.16.2.1</FileVersion>
+    <Version>2.16.3.0</Version>
+    <AssemblyVersion>2.16.3.0</AssemblyVersion>
+    <FileVersion>2.16.3.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -288,6 +288,8 @@ public class VeldbezettingItemDto
     public string? Veld { get; set; }
     public string? Competitiesoort { get; set; }
     public string? LeeftijdsCategorie { get; set; }
+    public int DuurMinuten { get; set; }
+    public decimal Veldafmeting { get; set; }
 }
 
 public class AutoPlanToepassenRequestDto

--- a/BlazorAdmin/Models/AdminModels.cs
+++ b/BlazorAdmin/Models/AdminModels.cs
@@ -277,6 +277,19 @@ public class AutoPlanResponseDto
     public string OptimaleHtml { get; set; } = "";
 }
 
+// Lichtgewicht "wat staat er nu gepland"-weergave (#566) — zonder optimalisatie-berekening.
+public class VeldbezettingItemDto
+{
+    public long? WedstrijdCode { get; set; }
+    public string Wedstrijd { get; set; } = "";
+    public string TeamNaam { get; set; } = "";
+    public string? Uitteam { get; set; }
+    public string? AanvangsTijd { get; set; }
+    public string? Veld { get; set; }
+    public string? Competitiesoort { get; set; }
+    public string? LeeftijdsCategorie { get; set; }
+}
+
 public class AutoPlanToepassenRequestDto
 {
     public string Datum { get; set; } = "";

--- a/BlazorAdmin/Pages/Dagplanning.razor
+++ b/BlazorAdmin/Pages/Dagplanning.razor
@@ -41,17 +41,99 @@
             <span class="spinner-border spinner-border-sm text-secondary ms-2" role="status" aria-hidden="true"></span>
         }
     </div>
-    <div class="card-body p-0">
+    <div class="card-body">
         @if (!string.IsNullOrEmpty(_veldbezettingError))
         {
-            <div class="alert alert-danger m-3 mb-0">@_veldbezettingError</div>
+            <div class="alert alert-danger mb-0">@_veldbezettingError</div>
         }
         else if (!_veldbezettingBezig && _veldbezetting.Count == 0)
         {
-            <p class="text-muted p-3 mb-0">Geen wedstrijden gepland op deze datum.</p>
+            <p class="text-muted mb-0">Geen wedstrijden gepland op deze datum.</p>
         }
         else if (_veldbezetting.Count > 0)
         {
+            var _vGantt = BouwVeldbezettingGanttItems();
+            @if (_vGantt.Any())
+            {
+                var _vVelden = _vGantt
+                    .Select(g => g.VeldNaam).Distinct()
+                    .OrderBy(v => v.StartsWith("Kunstgras", StringComparison.OrdinalIgnoreCase) ? "0" + v : "1" + v)
+                    .ToList();
+                int _vsMin = (_vGantt.Min(g => (int)g.Aanvang.ToTimeSpan().TotalMinutes) / 60) * 60;
+                int _veMin = (((int)_vGantt.Max(g => g.Einde.ToTimeSpan().TotalMinutes) + 59) / 60) * 60;
+                if (_veMin <= _vsMin) _veMin = _vsMin + 60;
+                int _vTotMin = _veMin - _vsMin;
+
+                <div style="overflow-x:auto; min-width:0;" class="mb-3">
+                    @* Tijdas-header *@
+                    <div style="display:flex; margin-bottom:4px;">
+                        <div style="width:120px; flex-shrink:0;"></div>
+                        <div style="flex:1; position:relative; height:22px; min-width:500px;">
+                            @for (int _h = _vsMin; _h <= _veMin; _h += 60)
+                            {
+                                string _lftH = GanttPct(_h - _vsMin, _vTotMin);
+                                <div style="position:absolute; left:@(_lftH)%; transform:translateX(-50%);
+                                            font-size:0.7rem; color:#6c757d; white-space:nowrap; user-select:none;">
+                                    @TimeOnly.FromTimeSpan(TimeSpan.FromMinutes(_h)).ToString("HH:mm")
+                                </div>
+                            }
+                        </div>
+                    </div>
+
+                    @* Veld-rijen *@
+                    @foreach (var _veld in _vVelden)
+                    {
+                        <div style="display:flex; border-top:1px solid #dee2e6;">
+                            <div style="width:120px; flex-shrink:0; padding:6px 8px; font-size:0.8rem;
+                                        font-weight:600; color:#495057; background:#f8f9fa;
+                                        border-right:1px solid #dee2e6; display:flex; align-items:center;">
+                                @_veld
+                            </div>
+                            <div style="flex:1; position:relative; height:72px; min-width:500px; background:#fff;">
+                                @* Uurlijnen *@
+                                @for (int _h = _vsMin + 60; _h < _veMin; _h += 60)
+                                {
+                                    <div style="position:absolute; left:@(GanttPct(_h - _vsMin, _vTotMin))%;
+                                                top:0; bottom:0; width:1px; background:#e9ecef; z-index:0;"></div>
+                                }
+                                @* Wedstrijdblokken *@
+                                @foreach (var gi in _vGantt.Where(g => g.VeldNaam == _veld))
+                                {
+                                    string _lft = GanttPct((int)gi.Aanvang.ToTimeSpan().TotalMinutes - _vsMin, _vTotMin);
+                                    string _wdt = GanttPct(gi.DuurMinuten, _vTotMin);
+                                    string _top = GanttPct((int)GanttTop(gi.SubPos), 100);
+                                    string _hgt = GanttPct((int)GanttHoogte(gi.Fractie), 100);
+                                    string _tooltip = GanttTooltip(gi);
+                                    <div title="@_tooltip"
+                                         style="position:absolute;
+                                                left:calc(@(_lft)% + 2px); width:calc(@(_wdt)% - 4px);
+                                                top:calc(@(_top)% + 2px); height:calc(@(_hgt)% - 4px);
+                                                background:@GanttKleur(gi.Status);
+                                                border-radius:5px; overflow:hidden;
+                                                padding:2px 5px; color:#fff;
+                                                font-size:0.68rem; line-height:1.25;
+                                                z-index:1; cursor:default;
+                                                box-shadow:0 1px 3px rgba(0,0,0,0.2);">
+                                        <div style="overflow:hidden; white-space:nowrap; text-overflow:ellipsis;
+                                                    font-weight:700; font-size:0.7rem;">
+                                            @gi.Aanvang.ToString("HH:mm")
+                                        </div>
+                                        <div style="overflow:hidden; white-space:nowrap; text-overflow:ellipsis;">
+                                            @GanttLabel(gi.Label)
+                                        </div>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+                    }
+                    <div style="height:1px; background:#dee2e6; margin-left:120px;"></div>
+                </div>
+            }
+            else
+            {
+                <p class="text-muted small">Nog geen wedstrijden met veld, tijd én bekende duur voor deze datum — zie de lijst hieronder.</p>
+            }
+
             <div class="table-responsive">
                 <table class="table table-sm table-hover mb-0">
                     <thead class="table-light">
@@ -672,6 +754,24 @@
                     w.Veldafmeting, GanttMatchLabel(w.Wedstrijd, w.TeamNaam), "ongewijzigd", w.DuurMinuten,
                     null, null));
             }
+        }
+        return items;
+    }
+
+    // Gantt-blokken voor de directe veldbezetting-weergave (#566) — geen optimalisatie,
+    // alleen wat er al gepland staat. Hergebruikt dezelfde GanttItem/helpers als de
+    // Optimaliseer-Gantt hierboven.
+    private List<GanttItem> BouwVeldbezettingGanttItems()
+    {
+        var items = new List<GanttItem>();
+        foreach (var w in _veldbezetting.Where(w => w.DuurMinuten > 0))
+        {
+            if (string.IsNullOrWhiteSpace(w.Veld) || string.IsNullOrWhiteSpace(w.AanvangsTijd)) continue;
+            if (!TimeOnly.TryParse(w.AanvangsTijd, out var t)) continue;
+            var (veldBase, sub) = GanttSplitVeld(w.Veld);
+            items.Add(new GanttItem(veldBase, sub, t, t.AddMinutes(w.DuurMinuten),
+                w.Veldafmeting, GanttMatchLabel(w.Wedstrijd, w.TeamNaam), "ongewijzigd", w.DuurMinuten,
+                null, null));
         }
         return items;
     }

--- a/BlazorAdmin/Pages/Dagplanning.razor
+++ b/BlazorAdmin/Pages/Dagplanning.razor
@@ -16,7 +16,7 @@
         <div class="row g-3 align-items-end">
             <div class="col-md-3">
                 <label class="form-label">Datum</label>
-                <input type="date" class="form-control" @bind="_datumDt" />
+                <input type="date" class="form-control" @bind="_datumDt" @bind:after="OnDatumChanged" />
             </div>
             <div class="col-md-2">
                 <label class="form-label">Buffer (min)</label>
@@ -29,6 +29,55 @@
             </div>
             <div class="col-md-5"></div>
         </div>
+    </div>
+</div>
+
+@* ── Directe veldbezetting: wat staat er nu al gepland op deze datum (#566) ── *@
+<div class="card mb-3">
+    <div class="card-header d-flex align-items-center gap-2">
+        <span class="fw-semibold">Veldbezetting op @_datumDt.ToString("dd-MM-yyyy")</span>
+        @if (_veldbezettingBezig)
+        {
+            <span class="spinner-border spinner-border-sm text-secondary ms-2" role="status" aria-hidden="true"></span>
+        }
+    </div>
+    <div class="card-body p-0">
+        @if (!string.IsNullOrEmpty(_veldbezettingError))
+        {
+            <div class="alert alert-danger m-3 mb-0">@_veldbezettingError</div>
+        }
+        else if (!_veldbezettingBezig && _veldbezetting.Count == 0)
+        {
+            <p class="text-muted p-3 mb-0">Geen wedstrijden gepland op deze datum.</p>
+        }
+        else if (_veldbezetting.Count > 0)
+        {
+            <div class="table-responsive">
+                <table class="table table-sm table-hover mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Tijd</th>
+                            <th>Team</th>
+                            <th>Tegenstander</th>
+                            <th>Veld</th>
+                            <th>Competitie</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in _veldbezetting)
+                        {
+                            <tr>
+                                <td>@(item.AanvangsTijd ?? "—")</td>
+                                <td>@item.TeamNaam</td>
+                                <td>@(item.Uitteam ?? "—")</td>
+                                <td>@(item.Veld ?? "—")</td>
+                                <td>@(item.Competitiesoort ?? "—")</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
     </div>
 </div>
 
@@ -394,6 +443,11 @@
     private string _visTab = "optimaal";
     private AutoPlanResponseDto? _plan;
 
+    // Directe veldbezetting (#566)
+    private List<VeldbezettingItemDto> _veldbezetting = new();
+    private bool _veldbezettingBezig;
+    private string? _veldbezettingError;
+
     // Klassiek optimaliseer-flow
     private string _doel = "";
     private string _gewensteEindtijdStr = "16:15";
@@ -413,12 +467,45 @@
         ClubSelector.OnChange += OnClubChanged;
     }
 
-    private void OnClubChanged() => InvokeAsync(() =>
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadVeldbezettingAsync();
+    }
+
+    private async Task OnDatumChanged()
     {
         _plan = null;
         _klassiekResultaat = null;
         _errorMessage = null;
         _toepassenMelding = null;
+        await LoadVeldbezettingAsync();
+    }
+
+    private async Task LoadVeldbezettingAsync()
+    {
+        _veldbezettingBezig = true;
+        _veldbezettingError = null;
+        try
+        {
+            var result = await Api.GetVeldbezettingAsync(DatumStr);
+            if (result.Success)
+                _veldbezetting = result.Data ?? new();
+            else
+            {
+                _veldbezetting = new();
+                _veldbezettingError = result.ErrorMessage ?? "Ophalen veldbezetting mislukt.";
+            }
+        }
+        finally { _veldbezettingBezig = false; }
+    }
+
+    private void OnClubChanged() => InvokeAsync(async () =>
+    {
+        _plan = null;
+        _klassiekResultaat = null;
+        _errorMessage = null;
+        _toepassenMelding = null;
+        await LoadVeldbezettingAsync();
         StateHasChanged();
     });
 

--- a/BlazorAdmin/Services/AdminApiClient.cs
+++ b/BlazorAdmin/Services/AdminApiClient.cs
@@ -145,6 +145,9 @@ public class AdminApiClient
     public async Task<ApiResult<AutoPlanToepassenResponseDto>> AutoPlanToepassenAsync(AutoPlanToepassenRequestDto req)
         => await PostAsync<AutoPlanToepassenResponseDto>("api/planner/auto-plan/toepassen", req);
 
+    public async Task<ApiResult<List<VeldbezettingItemDto>>> GetVeldbezettingAsync(string datum)
+        => await GetAsync<List<VeldbezettingItemDto>>($"api/planner/veldbezetting?datum={Uri.EscapeDataString(datum)}");
+
     // ── Teambegeleiding ──
 
     public async Task<ApiResult<List<string>>> GetTeambegeleidingTeamsAsync()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ### Added
 - KNVB-speeldagenkalender voor seizoen 2026/'27 is opgenomen in de database voor **alle zes districten**: West, Noord, Oost, Zuid, Landelijk en Landelijk jeugd. Per speeldatum is nu bekend of het een competitie-, beker-, inhaal-, nacompetitie- of vrije dag is, welke leeftijdscategorieën actief zijn, en welke schoolvakanties of feestdagen spelen. Clubs buiten district West kunnen de kalender daarmee ook gebruiken.
+- Dagplanning toont nu direct de wedstrijden die op de gekozen datum gepland staan — zodra je een andere datum kiest, wordt dit meteen bijgewerkt zonder dat je eerst op "Optimaliseer" hoeft te klikken. (#566)
 
 ### Fixed
 - De databasemigratie liep bij elke deploy vast zodra er meer dan één club in de instellingen stond — wat altijd het geval is doordat de AllStars FC democlub wordt aangemaakt. Gevolg: het nieuwe seizoen werd niet meer automatisch aangemaakt en een deel van de migratie werd overgeslagen. Beide zijn verholpen.
 - De kolom die geplande wedstrijden aan een club koppelt werd door een fout in het migratiescript nooit aangemaakt. Daardoor ontbrak de scheiding tussen productie- en demogegevens voor geplande wedstrijden. De migratie werkt nu.
+- Nieuw gesynchroniseerde teams en wedstrijden werden niet meer aan de eigen club gekoppeld, waardoor ze onterecht niet zichtbaar waren in de Dagplanner en de teamlijst — ook al stonden ze al in Sportlink gepland. Nieuwe rijen krijgen deze koppeling nu weer automatisch bij elke synchronisatie. (#567)
 
 ### Changed
 - De KNVB-verplaatsingsregels waarop de AI herplanverzoeken beoordeelt zijn bijgewerkt naar seizoen 2026/'27. Verzoeken worden niet langer getoetst aan de verlopen deadlines van seizoen 2025/'26. Nieuw toegevoegd: de seizoensdata (competitiestart, winterstop, laatste speelronde, nacompetitie) en de verplaatsingsdeadlines voor de landelijke divisies.

--- a/FunctionApp.Tests/Sync/MatchDetailsFetchTests.cs
+++ b/FunctionApp.Tests/Sync/MatchDetailsFetchTests.cs
@@ -61,7 +61,7 @@ public class MatchDetailsFetchTests
         var log    = NullLogger.Instance;
 
         var result = await SportlinkSyncPipeline.FetchAndStoreMatchDetailsAsync(
-            "http://test/wedstrijd-informatie?wedstrijdcode=1", log, client);
+            "http://test/wedstrijd-informatie?wedstrijdcode=1", "TEST", log, client);
 
         result.Should().BeFalse("een HTTP-fout moet false teruggeven zodat de caller partialFailure zet (#464)");
     }
@@ -73,7 +73,7 @@ public class MatchDetailsFetchTests
         var log    = NullLogger.Instance;
 
         var result = await SportlinkSyncPipeline.FetchAndStoreMatchDetailsAsync(
-            "http://test/wedstrijd-informatie?wedstrijdcode=2", log, client);
+            "http://test/wedstrijd-informatie?wedstrijdcode=2", "TEST", log, client);
 
         result.Should().BeFalse("HTTP 500 moet false teruggeven (#464)");
     }
@@ -85,7 +85,7 @@ public class MatchDetailsFetchTests
         var log    = NullLogger.Instance;
 
         var result = await SportlinkSyncPipeline.FetchAndStoreMatchDetailsAsync(
-            "http://test/wedstrijd-informatie?wedstrijdcode=3", log, client);
+            "http://test/wedstrijd-informatie?wedstrijdcode=3", "TEST", log, client);
 
         // JSON-deserialisatiefout geeft false (#464 — JSON-fouten tellen als failure)
         result.Should().BeFalse("een JSON-deserialisatiefout moet false teruggeven (#464)");

--- a/FunctionApp/CreateTable.cs
+++ b/FunctionApp/CreateTable.cs
@@ -41,7 +41,8 @@ namespace SportlinkFunction
 	                        [kalespelsoort]			[nvarchar](50)      NULL,
 	                        [speeldag]				[nvarchar](50)      NULL,
 	                        [speeldagteam]			[nvarchar](100)     NULL,
-	                        [more]					[nvarchar](200)     NULL
+	                        [more]					[nvarchar](200)     NULL,
+	                        [ClubCode]				[nvarchar](20)      NULL
                         ) ON [PRIMARY] ;";
                         break;
 
@@ -98,7 +99,8 @@ namespace SportlinkFunction
                             [competitienaam]            NVARCHAR(200)   NULL,
                             [eigenteam]                 NVARCHAR(50)    NULL,
                             [sportomschrijving]         NVARCHAR(100)   NULL,
-                            [verenigingswedstrijd]      NVARCHAR(50)    NULL
+                            [verenigingswedstrijd]      NVARCHAR(50)    NULL,
+                            [ClubCode]                  NVARCHAR(20)    NULL
                         ) ON [PRIMARY];";
                         break;
 
@@ -166,8 +168,9 @@ namespace SportlinkFunction
                             UitTeamShirtKleur NVARCHAR(200), 
                             UitTeamStraat NVARCHAR(150), 
                             UitTeamPostcodePlaats NVARCHAR(150), 
-                            UitTeamTelefoon NVARCHAR(200), 
-                            UitTeamEmail NVARCHAR(200) );
+                            UitTeamTelefoon NVARCHAR(200),
+                            UitTeamEmail NVARCHAR(200),
+                            ClubCode NVARCHAR(20) NULL );
                         ";
                         break;
                     default:

--- a/FunctionApp/Planner/PlannerFunction.cs
+++ b/FunctionApp/Planner/PlannerFunction.cs
@@ -469,6 +469,37 @@ namespace SportlinkFunction.Planner
             }
         }
 
+        // Lichtgewicht "wat staat er nu gepland"-weergave (#566) — zonder FieldScheduler-berekening.
+        [Function("Veldbezetting")]
+        public static async Task<IActionResult> Veldbezetting(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "planner/veldbezetting")] HttpRequest req,
+            FunctionContext context)
+        {
+            var log = context.GetLogger("Veldbezetting");
+            var authResult = EasyAuthHelper.RequireAdmin(req);
+            if (authResult != null) return authResult;
+            try
+            {
+                var datumParam = req.Query["datum"].ToString();
+                if (string.IsNullOrWhiteSpace(datumParam) || !DateOnly.TryParse(datumParam, out var datum))
+                    return new BadRequestObjectResult(new { error = "Query parameter 'datum' (yyyy-MM-dd) is verplicht." });
+
+                await SystemUtilities.WaitForDatabaseAsync(log);
+
+                var clubCode = EasyAuthHelper.GetClubCodeFromRequest(req)
+                    ?? throw new InvalidOperationException("ClubCode kon niet worden bepaald uit de request — controleer Easy Auth configuratie.");
+                log.LogInformation("Veldbezetting: datum={Datum}, club={Club}", datumParam, clubCode);
+
+                var items = await PlannerService.VeldbezettingAsync(datum, clubCode);
+                return new OkObjectResult(items);
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "Veldbezetting failed");
+                return new ObjectResult(new { error = "Verzoek mislukt" }) { StatusCode = 500 };
+            }
+        }
+
         [Function("GetTeamSchedule")]
         public static async Task<IActionResult> GetTeamSchedule(
             [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "planner/team-schedule")] HttpRequest req,

--- a/FunctionApp/Planner/PlannerModels.cs
+++ b/FunctionApp/Planner/PlannerModels.cs
@@ -331,6 +331,8 @@ namespace SportlinkFunction.Planner
         public string? Veld { get; set; }
         public string? Competitiesoort { get; set; }
         public string? LeeftijdsCategorie { get; set; }
+        public int DuurMinuten { get; set; }
+        public decimal Veldafmeting { get; set; }
     }
 
     public class AutoPlanWedstrijdItem

--- a/FunctionApp/Planner/PlannerModels.cs
+++ b/FunctionApp/Planner/PlannerModels.cs
@@ -319,6 +319,20 @@ namespace SportlinkFunction.Planner
         public int? BufferMinuten { get; set; }
     }
 
+    // ── Veldbezetting: lichtgewicht "wat staat er nu gepland"-weergave (#566) ──
+    // Bewust zonder FieldScheduler-berekening — puur een projectie van WedstrijdRaw.
+    public class VeldbezettingItem
+    {
+        public long? WedstrijdCode { get; set; }
+        public string Wedstrijd { get; set; } = string.Empty;
+        public string TeamNaam { get; set; } = string.Empty;
+        public string? Uitteam { get; set; }
+        public string? AanvangsTijd { get; set; }
+        public string? Veld { get; set; }
+        public string? Competitiesoort { get; set; }
+        public string? LeeftijdsCategorie { get; set; }
+    }
+
     public class AutoPlanWedstrijdItem
     {
         public long? WedstrijdCode { get; set; }

--- a/FunctionApp/Planner/PlannerService.cs
+++ b/FunctionApp/Planner/PlannerService.cs
@@ -34,6 +34,9 @@ namespace SportlinkFunction.Planner
             AutoPlanToepassenRequest request, string clubCode, ILogger log)
             => AutoPlanService.AutoPlanToepassenAsync(request, clubCode, log);
 
+        public static Task<List<VeldbezettingItem>> VeldbezettingAsync(DateOnly datum, string clubCode)
+            => AutoPlanService.VeldbezettingAsync(datum, clubCode);
+
         public static Task<OptimaliseerResponse> OptimaliseerAsync(
             OptimaliseerRequest request, string? clubCode, ILogger log)
             => OptimizationService.OptimaliseerAsync(request, clubCode, log);

--- a/FunctionApp/Planner/Repositories/AllstarsTestDataRepository.cs
+++ b/FunctionApp/Planner/Repositories/AllstarsTestDataRepository.cs
@@ -53,7 +53,11 @@ internal static class AllstarsTestDataRepository
                        m.[aanvangstijd], m.[veld], m.[competitiesoort],
                        {LeeftijdNormalisatie.SqlExpr("ISNULL(t.[leeftijdscategorie], '')")} AS leeftijdscategorie
                 FROM [his].[matches] m
-                LEFT JOIN [his].[teams] t ON t.[teamnaam] = m.[teamnaam] AND t.[ClubCode] = m.[ClubCode]
+                OUTER APPLY (
+                    SELECT TOP 1 [leeftijdscategorie]
+                    FROM [his].[teams]
+                    WHERE [teamnaam] = m.[teamnaam] AND [ClubCode] = m.[ClubCode]
+                ) t
                 WHERE CAST(m.[kaledatum] AS DATE) = @date
                   AND m.[ClubCode] = @clubCode
                   AND m.[status] <> 'Afgelast'

--- a/FunctionApp/Planner/Services/AutoPlanService.cs
+++ b/FunctionApp/Planner/Services/AutoPlanService.cs
@@ -222,20 +222,35 @@ internal static class AutoPlanService
 
     // Lichtgewicht "wat staat er nu gepland"-weergave (#566): geen FieldScheduler-berekening,
     // alleen de ruwe wedstrijddata die AutoPlanAsync anders ook al zonder optimalisatie zou tonen.
+    // Duur/veldafmeting komen uit de goedkope speeltijden-lookup (één simpele SELECT) — niet uit
+    // de FieldScheduler, die pas nodig is zodra er ook daadwerkelijk geoptimaliseerd wordt.
     public static async Task<List<VeldbezettingItem>> VeldbezettingAsync(DateOnly datum, string clubCode)
     {
+        bool isAllstars = clubCode.Equals("ALLSTARS", StringComparison.OrdinalIgnoreCase);
         var wedstrijden = await PlannerDataAccess.GetAllMatchesForDatumAsync(datum, clubCode);
+        var speeltijden = await PlannerDataAccess.GetSpeeltijdenLookupAsync();
+
         return wedstrijden
-            .Select(w => new VeldbezettingItem
+            .Select(w =>
             {
-                WedstrijdCode = w.WedstrijdCode,
-                Wedstrijd = w.Wedstrijd,
-                TeamNaam = w.TeamNaam,
-                Uitteam = w.Uitteam,
-                AanvangsTijd = w.AanvangsTijd,
-                Veld = w.Veld,
-                Competitiesoort = w.Competitiesoort,
-                LeeftijdsCategorie = w.LeeftijdsCategorie
+                var leeftijd = (!string.IsNullOrWhiteSpace(w.LeeftijdsCategorie))
+                    ? w.LeeftijdsCategorie
+                    : (isAllstars ? ExtractLeeftijdFromTeamNaam(w.TeamNaam) ?? "" : "");
+                speeltijden.TryGetValue(leeftijd, out var speeltijdInfo);
+
+                return new VeldbezettingItem
+                {
+                    WedstrijdCode = w.WedstrijdCode,
+                    Wedstrijd = w.Wedstrijd,
+                    TeamNaam = w.TeamNaam,
+                    Uitteam = w.Uitteam,
+                    AanvangsTijd = w.AanvangsTijd,
+                    Veld = w.Veld,
+                    Competitiesoort = w.Competitiesoort,
+                    LeeftijdsCategorie = w.LeeftijdsCategorie,
+                    DuurMinuten = speeltijdInfo?.WedstrijdTotaal ?? 0,
+                    Veldafmeting = speeltijdInfo?.Veldafmeting ?? 1.00m
+                };
             })
             .OrderBy(w => string.IsNullOrWhiteSpace(w.AanvangsTijd) ? "99:99" : w.AanvangsTijd)
             .ToList();

--- a/FunctionApp/Planner/Services/AutoPlanService.cs
+++ b/FunctionApp/Planner/Services/AutoPlanService.cs
@@ -220,6 +220,27 @@ internal static class AutoPlanService
         };
     }
 
+    // Lichtgewicht "wat staat er nu gepland"-weergave (#566): geen FieldScheduler-berekening,
+    // alleen de ruwe wedstrijddata die AutoPlanAsync anders ook al zonder optimalisatie zou tonen.
+    public static async Task<List<VeldbezettingItem>> VeldbezettingAsync(DateOnly datum, string clubCode)
+    {
+        var wedstrijden = await PlannerDataAccess.GetAllMatchesForDatumAsync(datum, clubCode);
+        return wedstrijden
+            .Select(w => new VeldbezettingItem
+            {
+                WedstrijdCode = w.WedstrijdCode,
+                Wedstrijd = w.Wedstrijd,
+                TeamNaam = w.TeamNaam,
+                Uitteam = w.Uitteam,
+                AanvangsTijd = w.AanvangsTijd,
+                Veld = w.Veld,
+                Competitiesoort = w.Competitiesoort,
+                LeeftijdsCategorie = w.LeeftijdsCategorie
+            })
+            .OrderBy(w => string.IsNullOrWhiteSpace(w.AanvangsTijd) ? "99:99" : w.AanvangsTijd)
+            .ToList();
+    }
+
     public static async Task<AutoPlanToepassenResponse> AutoPlanToepassenAsync(
         AutoPlanToepassenRequest request, string clubCode, ILogger log)
     {

--- a/FunctionApp/Sync/SportlinkStagingRepository.cs
+++ b/FunctionApp/Sync/SportlinkStagingRepository.cs
@@ -27,7 +27,7 @@ internal static class SportlinkStagingRepository
         return list;
     }
 
-    internal static async Task SaveTeamsAsync(List<Team> teams, ILogger log)
+    internal static async Task SaveTeamsAsync(List<Team> teams, string clubCode, ILogger log)
     {
         using var conn = new SqlConnection(Cs);
         await conn.OpenAsync();
@@ -37,11 +37,12 @@ internal static class SportlinkStagingRepository
                 INSERT INTO [stg].[teams]
                     ([teamcode],[lokaleteamcode],[poulecode],[teamnaam],[competitienaam],[klasse],
                      [poule],[klassepoule],[spelsoort],[competitiesoort],[geslacht],[teamsoort],
-                     [leeftijdscategorie],[kalespelsoort],[speeldag],[speeldagteam],[more])
+                     [leeftijdscategorie],[kalespelsoort],[speeldag],[speeldagteam],[more],[ClubCode])
                 VALUES
                     (@teamcode,@lokaleteamcode,@poulecode,@teamnaam,@competitienaam,@klasse,
                      @poule,@klassepoule,@spelsoort,@competitiesoort,@geslacht,@teamsoort,
-                     @leeftijdscategorie,@kalespelsoort,@speeldag,@speeldagteam,@more)", conn);
+                     @leeftijdscategorie,@kalespelsoort,@speeldag,@speeldagteam,@more,@ClubCode)", conn);
+            cmd.Parameters.AddWithValue("@ClubCode",          clubCode ?? (object)DBNull.Value);
             cmd.Parameters.AddWithValue("@teamcode",          team.teamcode);
             cmd.Parameters.AddWithValue("@lokaleteamcode",    team.lokaleteamcode);
             cmd.Parameters.AddWithValue("@poulecode",         team.poulecode         ?? (object)DBNull.Value);
@@ -64,7 +65,7 @@ internal static class SportlinkStagingRepository
         log.LogInformation("TEAMS - {Count} rows inserted into staging.", teams.Count);
     }
 
-    internal static async Task<int> SaveProgrammaAsync(List<Match> matches, ILogger log)
+    internal static async Task<int> SaveProgrammaAsync(List<Match> matches, string clubCode, ILogger log)
     {
         using var conn = new SqlConnection(Cs);
         await conn.OpenAsync();
@@ -82,6 +83,7 @@ internal static class SportlinkStagingRepository
                     ,[kaledatum],[vertrektijd],[verzameltijd],[scheidsrechters],[scheidsrechter]
                     ,[veld],[locatie],[plaats],[rijders]
                     ,[kleedkamerthuisteam],[kleedkameruitteam],[kleedkamerscheidsrechter]
+                    ,[ClubCode]
                 ) VALUES (
                      @wedstrijddatum,@wedstrijdcode,@wedstrijdnummer,@datum,@wedstrijd
                     ,@accommodatie,@aanvangstijd,@thuisteam,@thuisteamid,@thuisteamlogo
@@ -91,8 +93,10 @@ internal static class SportlinkStagingRepository
                     ,@kaledatum,@vertrektijd,@verzameltijd,@scheidsrechters,@scheidsrechter
                     ,@veld,@locatie,@plaats,@rijders
                     ,@kleedkamerthuisteam,@kleedkameruitteam,@kleedkamerscheidsrechter
+                    ,@ClubCode
                 )", conn);
             AddMatchParams(cmd, match);
+            cmd.Parameters.AddWithValue("@ClubCode",                   clubCode                         ?? (object)DBNull.Value);
             cmd.Parameters.AddWithValue("@teamnaam",                   match.teamnaam                  ?? (object)DBNull.Value);
             cmd.Parameters.AddWithValue("@teamvolgorde",               match.teamvolgorde);
             cmd.Parameters.AddWithValue("@competitie",                 match.competitie                ?? (object)DBNull.Value);
@@ -117,7 +121,7 @@ internal static class SportlinkStagingRepository
         return inserted;
     }
 
-    internal static async Task<int> MergeUitslagenAsync(List<Match> matches, ILogger log)
+    internal static async Task<int> MergeUitslagenAsync(List<Match> matches, string clubCode, ILogger log)
     {
         using var conn = new SqlConnection(Cs);
         await conn.OpenAsync();
@@ -146,6 +150,7 @@ internal static class SportlinkStagingRepository
                         ,[uitteamlogo],[competitiesoort],[status],[meer]
                         ,[datumopgemaakt],[uitslag],[uitslag-regulier],[uitslag-nv],[uitslag-s]
                         ,[competitienaam],[eigenteam],[sportomschrijving],[verenigingswedstrijd]
+                        ,[ClubCode]
                     ) VALUES (
                          @wedstrijddatum,@wedstrijdcode,@wedstrijdnummer,@datum,@wedstrijd
                         ,@accommodatie,@aanvangstijd,@thuisteam,@thuisteamid,@thuisteamlogo
@@ -153,8 +158,10 @@ internal static class SportlinkStagingRepository
                         ,@uitteamlogo,@competitiesoort,@status,@meer
                         ,@datumopgemaakt,@uitslag,@uitslagregulier,@uitslagnv,@uitslags
                         ,@competitienaam,@eigenteam,@sportomschrijving,@verenigingswedstrijd
+                        ,@ClubCode
                     )", conn);
             AddMatchParams(cmd, match);
+            cmd.Parameters.AddWithValue("@ClubCode",            clubCode                 ?? (object)DBNull.Value);
             cmd.Parameters.AddWithValue("@datumopgemaakt",      match.datumopgemaakt     ?? (object)DBNull.Value);
             cmd.Parameters.AddWithValue("@uitslag",             match.uitslag            ?? (object)DBNull.Value);
             cmd.Parameters.AddWithValue("@uitslagregulier",     match.uitslag_regulier   ?? (object)DBNull.Value);
@@ -170,7 +177,7 @@ internal static class SportlinkStagingRepository
         return updated;
     }
 
-    internal static async Task SaveMatchDetailsAsync(MatchDetails matchDetails, ILogger log)
+    internal static async Task SaveMatchDetailsAsync(MatchDetails matchDetails, string clubCode, ILogger log)
     {
         using var conn = new SqlConnection(Cs);
         await conn.OpenAsync();
@@ -186,7 +193,8 @@ internal static class SportlinkStagingRepository
                 AccommodatieNaam, AccommodatieStraat, AccommodatiePlaats, AccommodatieTelefoon, AccommodatieRouteplanner,
                 ThuisTeamNaam, ThuisTeamCode, ThuisTeamWebsite, ThuisTeamShirtKleur, ThuisTeamStraat,
                 ThuisTeamPostcodePlaats, ThuisTeamTelefoon, ThuisTeamEmail, UitTeamNaam, UitTeamCode,
-                UitTeamWebsite, UitTeamShirtKleur, UitTeamStraat, UitTeamPostcodePlaats, UitTeamTelefoon, UitTeamEmail
+                UitTeamWebsite, UitTeamShirtKleur, UitTeamStraat, UitTeamPostcodePlaats, UitTeamTelefoon, UitTeamEmail,
+                ClubCode
             ) VALUES (
                 @WedstrijdCode, @InternCode, @VeldNaam, @VeldLocatie, @VertrekTijd, @Rijder,
                 @ThuisScore, @ThuisScoreRegulier, @ThuisScoreNV, @ThuisScoreS, @UitScore, @UitScoreRegulier,
@@ -197,8 +205,10 @@ internal static class SportlinkStagingRepository
                 @AccommodatieNaam, @AccommodatieStraat, @AccommodatiePlaats, @AccommodatieTelefoon, @AccommodatieRouteplanner,
                 @ThuisTeamNaam, @ThuisTeamCode, @ThuisTeamWebsite, @ThuisTeamShirtKleur, @ThuisTeamStraat,
                 @ThuisTeamPostcodePlaats, @ThuisTeamTelefoon, @ThuisTeamEmail, @UitTeamNaam, @UitTeamCode,
-                @UitTeamWebsite, @UitTeamShirtKleur, @UitTeamStraat, @UitTeamPostcodePlaats, @UitTeamTelefoon, @UitTeamEmail
+                @UitTeamWebsite, @UitTeamShirtKleur, @UitTeamStraat, @UitTeamPostcodePlaats, @UitTeamTelefoon, @UitTeamEmail,
+                @ClubCode
             )", conn);
+        cmd.Parameters.AddWithValue("@ClubCode", clubCode ?? (object)DBNull.Value);
 
         var wi = matchDetails.Wedstrijdinformatie;
         cmd.Parameters.AddWithValue("@WedstrijdCode",               wi.Wedstrijdnummer);

--- a/FunctionApp/Sync/SportlinkSyncPipeline.cs
+++ b/FunctionApp/Sync/SportlinkSyncPipeline.cs
@@ -19,11 +19,14 @@ internal static class SportlinkSyncPipeline
         ILogger log)
     {
         var partialFailure = false;
+        var clubCode = AppSettings.GetSetting("clubCode");
+        if (string.IsNullOrWhiteSpace(clubCode))
+            throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings — sync kan niet doorgaan zonder ClubCode.");
 
         await CreateStagingTable.ExecuteAsync("teams");
         try
         {
-            await FetchAndStoreTeamsAsync($"{sportlinkApiUrl}/teams?{sportlinkClientId}", log);
+            await FetchAndStoreTeamsAsync($"{sportlinkApiUrl}/teams?{sportlinkClientId}", clubCode, log);
             log.LogInformation("TEAMS - GET endpoint=/teams");
         }
         catch (Exception ex)
@@ -40,7 +43,7 @@ internal static class SportlinkSyncPipeline
             try
             {
                 await FetchAndStoreProgrammaAsync(
-                    $"{sportlinkApiUrl}/programma?{sportlinkClientId}&weekoffset={weekOffset}", log);
+                    $"{sportlinkApiUrl}/programma?{sportlinkClientId}&weekoffset={weekOffset}", clubCode, log);
                 log.LogInformation("MATCHES/PROGRAMMA - GET weekOffset={WeekOffset}", weekOffset);
             }
             catch (Exception ex)
@@ -57,7 +60,7 @@ internal static class SportlinkSyncPipeline
             try
             {
                 await FetchAndStoreUitslagenAsync(
-                    $"{sportlinkApiUrl}/uitslagen?{sportlinkClientId}&weekoffset={weekOffset}", log);
+                    $"{sportlinkApiUrl}/uitslagen?{sportlinkClientId}&weekoffset={weekOffset}", clubCode, log);
                 log.LogInformation("MATCHES/UITSLAGEN - GET weekOffset={WeekOffset}", weekOffset);
             }
             catch (Exception ex)
@@ -74,7 +77,7 @@ internal static class SportlinkSyncPipeline
         {
             if (await FetchAndStoreMatchDetailsAsync(
                     $"{sportlinkApiUrl}/wedstrijd-informatie?{sportlinkClientId}&wedstrijdcode={wedstrijdcode}",
-                    log))
+                    clubCode, log))
             {
                 mdOk++;
                 log.LogInformation("MATCHDETAILS - GET wedstrijdcode={Code}", wedstrijdcode);
@@ -100,7 +103,7 @@ internal static class SportlinkSyncPipeline
             log.LogWarning("Sync gedeeltelijk mislukt — LastSyncTimestamp NIET bijgewerkt");
     }
 
-    private static async Task FetchAndStoreTeamsAsync(string apiUrl, ILogger log)
+    private static async Task FetchAndStoreTeamsAsync(string apiUrl, string clubCode, ILogger log)
     {
         var response = await _client.GetAsync(apiUrl);
         response.EnsureSuccessStatusCode();
@@ -109,7 +112,7 @@ internal static class SportlinkSyncPipeline
         if (teams != null)
         {
             log.LogInformation("TEAMS - {Count} gevonden.", teams.Count);
-            await SportlinkStagingRepository.SaveTeamsAsync(teams, log);
+            await SportlinkStagingRepository.SaveTeamsAsync(teams, clubCode, log);
         }
         else
         {
@@ -117,7 +120,7 @@ internal static class SportlinkSyncPipeline
         }
     }
 
-    private static async Task FetchAndStoreProgrammaAsync(string apiUrl, ILogger log)
+    private static async Task FetchAndStoreProgrammaAsync(string apiUrl, string clubCode, ILogger log)
     {
         var response = await _client.GetAsync(apiUrl);
         response.EnsureSuccessStatusCode();
@@ -126,11 +129,11 @@ internal static class SportlinkSyncPipeline
         if (matches is { Count: > 0 })
         {
             log.LogInformation("MATCHES/PROGRAMMA - {Count} gevonden.", matches.Count);
-            await SportlinkStagingRepository.SaveProgrammaAsync(matches, log);
+            await SportlinkStagingRepository.SaveProgrammaAsync(matches, clubCode, log);
         }
     }
 
-    private static async Task FetchAndStoreUitslagenAsync(string apiUrl, ILogger log)
+    private static async Task FetchAndStoreUitslagenAsync(string apiUrl, string clubCode, ILogger log)
     {
         var response = await _client.GetAsync(apiUrl);
         response.EnsureSuccessStatusCode();
@@ -139,13 +142,13 @@ internal static class SportlinkSyncPipeline
         if (matches is { Count: > 0 })
         {
             log.LogInformation("MATCHES/UITSLAGEN - {Count} gevonden.", matches.Count);
-            await SportlinkStagingRepository.MergeUitslagenAsync(matches, log);
+            await SportlinkStagingRepository.MergeUitslagenAsync(matches, clubCode, log);
         }
     }
 
     // Retourneert true bij succes, false bij elke fout — zodat de caller partialFailure kan bijhouden. (#464)
     // httpClient is optioneel; standaard wordt de static _client gebruikt. (#476 — testbaar via inject)
-    internal static async Task<bool> FetchAndStoreMatchDetailsAsync(string apiUrl, ILogger log, HttpClient? httpClient = null)
+    internal static async Task<bool> FetchAndStoreMatchDetailsAsync(string apiUrl, string clubCode, ILogger log, HttpClient? httpClient = null)
     {
         var client = httpClient ?? _client;
         try
@@ -157,7 +160,7 @@ internal static class SportlinkSyncPipeline
             {
                 var details = JsonConvert.DeserializeObject<MatchDetails>(json, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
                 if (details != null)
-                    await SportlinkStagingRepository.SaveMatchDetailsAsync(details, log);
+                    await SportlinkStagingRepository.SaveMatchDetailsAsync(details, clubCode, log);
                 else
                     log.LogWarning("MATCHDETAILS - geen data gevonden.");
             }

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.16.2.1</Version>
-    <AssemblyVersion>2.16.2.1</AssemblyVersion>
-    <FileVersion>2.16.2.1</FileVersion>
+    <Version>2.16.3.0</Version>
+    <AssemblyVersion>2.16.3.0</AssemblyVersion>
+    <FileVersion>2.16.3.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/docs/API.md
+++ b/docs/API.md
@@ -597,7 +597,9 @@ gesynchroniseerde Sportlink-data — **zonder** de scheduling-optimalisatie te d
     "aanvangsTijd": "13:00",
     "veld": "veld 3",
     "competitiesoort": "Oefenwedstrijd",
-    "leeftijdsCategorie": null
+    "leeftijdsCategorie": null,
+    "duurMinuten": 90,
+    "veldafmeting": 1.00
   }
 ]
 ```

--- a/docs/API.md
+++ b/docs/API.md
@@ -28,6 +28,7 @@ Zonder geldige sleutel → 401 Unauthorized (kost niets, geen verwerking).
 | `POST` | `/planner/herplan-check` | Function | Herplan-alternatieven simuleren |
 | `POST` | `/planner/herplan-bevestig` | Function | Herplanverzoek registreren |
 | `POST` | `/planner/optimaliseer` | Easy Auth (admin) | Planning optimaliseren (HTML/email/JSON) |
+| `GET` | `/planner/veldbezetting?datum=` | Easy Auth (admin) | Wedstrijden op een datum, zonder optimalisatie-berekening |
 | `GET` | `/beheer/teambegeleiding` | **Admin+User** | Alle teams met begeleiding in database |
 | `GET` | `/beheer/teambegeleiding/{team}` | **Admin+User** | Begeleiders van team (naam + rol, nooit e-mail) |
 | `POST` | `/beheer/teambegeleiding/doorsturen` | **Admin+User** | Vraag doorsturen naar coach (BCC coördinator) |
@@ -568,6 +569,40 @@ Versimpelde email-compatibele versie met:
 - Bovenaan: link "Bekijk in browser (meer functies)"
 - Chronologische tabel met kleurcodes (inline CSS)
 - Werkt in alle email-clients (Outlook, Gmail, etc.)
+
+---
+
+## GET /api/planner/veldbezetting
+
+Geeft de wedstrijden terug die op een datum al gepland staan, rechtstreeks uit de laatst
+gesynchroniseerde Sportlink-data — **zonder** de scheduling-optimalisatie te draaien die
+`/planner/auto-plan` en `/planner/optimaliseer` gebruiken. Bedoeld als snelle, goedkope
+"wat staat er nu al gepland"-weergave (zie Dagplanning in de Admin GUI).
+
+### Query-parameters
+
+| Parameter | Type | Verplicht | Beschrijving |
+|-----------|------|-----------|-------------|
+| `datum` | `string` | **Ja** | Datum in `yyyy-MM-dd` formaat |
+
+### Antwoord — JSON (200)
+
+```json
+[
+  {
+    "wedstrijdCode": 20672784,
+    "wedstrijd": "[ClubCode] 6 - Tegenstander 8",
+    "teamNaam": "[ClubCode] 6",
+    "uitteam": "Tegenstander 8",
+    "aanvangsTijd": "13:00",
+    "veld": "veld 3",
+    "competitiesoort": "Oefenwedstrijd",
+    "leeftijdsCategorie": null
+  }
+]
+```
+
+Resultaat is gesorteerd op `aanvangsTijd`. Wedstrijden zonder aanvangstijd staan achteraan.
 
 ---
 

--- a/docs/api-standaarden/openapi.json
+++ b/docs/api-standaarden/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Sportlink Wedstrijdzaken API",
     "description": "API voor het beheer van wedstrijden, veldplanning en club-instellingen.\n\n## Beveiliging\n\nTwee beveiligingsschema's:\n\n- **functionKey** — `?code=` queryparameter, vereist voor planner- en sync-endpoints.\n  Gebruik de Azure Function key (voor planner-endpoints) of de Master key (voor admin sync-matches en\n  populate-sunset).\n- **easyAuth** — Azure Easy Auth Bearer token (Entra ID) in de `Authorization`-header, vereist voor\n  alle `/beheer/`- en `/feedback/`-endpoints. Lokaal omzeild wanneer de omgevingsvariabele\n  `WEBSITE_SITE_NAME` afwezig is.\n\nAlle `/beheer/`- en `/feedback/`-endpoints retourneren de header `x-correlation-id` in het antwoord.\n",
-    "version": "2.7.0",
+    "version": "2.8.0",
     "contact": {
       "name": "Sportlink Wedstrijdzaken",
       "url": "https://github.com/jaapbeus/Sportlink-wedstrijdzaken"
@@ -2090,6 +2090,44 @@
           "actie": {
             "type": "string",
             "description": "Wat het auto-plan doet met deze wedstrijd",
+            "nullable": true
+          }
+        }
+      },
+      "VeldbezettingItem": {
+        "type": "object",
+        "description": "Lichtgewicht projectie van een geplande wedstrijd — zonder scheduling-optimalisatie,\nalleen wat er nu al in Sportlink gepland staat.\n",
+        "properties": {
+          "wedstrijdCode": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "wedstrijd": {
+            "type": "string"
+          },
+          "teamNaam": {
+            "type": "string"
+          },
+          "uitteam": {
+            "type": "string",
+            "nullable": true
+          },
+          "aanvangsTijd": {
+            "type": "string",
+            "nullable": true,
+            "example": "13:00"
+          },
+          "veld": {
+            "type": "string",
+            "nullable": true
+          },
+          "competitiesoort": {
+            "type": "string",
+            "nullable": true
+          },
+          "leeftijdsCategorie": {
+            "type": "string",
             "nullable": true
           }
         }
@@ -5589,6 +5627,61 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AutoPlanToepassenResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/planner/veldbezetting": {
+      "get": {
+        "tags": [
+          "planner"
+        ],
+        "operationId": "veldbezetting",
+        "summary": "Wedstrijden op een datum ophalen, zonder optimalisatie",
+        "description": "Geeft de wedstrijden terug die op een datum al gepland staan, rechtstreeks uit de\nlaatst gesynchroniseerde Sportlink-data — zonder de scheduling-optimalisatie die\n`/planner/auto-plan` en `/planner/optimaliseer` uitvoeren. Bedoeld als snelle,\ngoedkope \"wat staat er nu al gepland\"-weergave.\n",
+        "security": [
+          {
+            "easyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "datum",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
+            "description": "Datum in yyyy-MM-dd formaat",
+            "example": "2026-08-22"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Wedstrijden op deze datum, gesorteerd op aanvangstijd",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/VeldbezettingItem"
+                  }
                 }
               }
             }

--- a/docs/api-standaarden/openapi.json
+++ b/docs/api-standaarden/openapi.json
@@ -2129,6 +2129,15 @@
           "leeftijdsCategorie": {
             "type": "string",
             "nullable": true
+          },
+          "duurMinuten": {
+            "type": "integer",
+            "description": "Wedstrijdduur in minuten uit de speeltijden-configuratie (0 = onbekende leeftijdscategorie)"
+          },
+          "veldafmeting": {
+            "type": "number",
+            "format": "decimal",
+            "description": "Aandeel van een heel veld dat deze wedstrijd gebruikt (1.00 = heel veld)"
           }
         }
       },

--- a/docs/api-standaarden/openapi.yaml
+++ b/docs/api-standaarden/openapi.yaml
@@ -1647,6 +1647,13 @@ components:
         leeftijdsCategorie:
           type: string
           nullable: true
+        duurMinuten:
+          type: integer
+          description: Wedstrijdduur in minuten uit de speeltijden-configuratie (0 = onbekende leeftijdscategorie)
+        veldafmeting:
+          type: number
+          format: decimal
+          description: Aandeel van een heel veld dat deze wedstrijd gebruikt (1.00 = heel veld)
 
     AutoPlanResponse:
       type: object

--- a/docs/api-standaarden/openapi.yaml
+++ b/docs/api-standaarden/openapi.yaml
@@ -16,7 +16,7 @@ info:
       `WEBSITE_SITE_NAME` afwezig is.
 
     Alle `/beheer/`- en `/feedback/`-endpoints retourneren de header `x-correlation-id` in het antwoord.
-  version: 2.7.0
+  version: 2.8.0
   contact:
     name: Sportlink Wedstrijdzaken
     url: https://github.com/jaapbeus/Sportlink-wedstrijdzaken
@@ -1615,6 +1615,37 @@ components:
         actie:
           type: string
           description: Wat het auto-plan doet met deze wedstrijd
+          nullable: true
+
+    VeldbezettingItem:
+      type: object
+      description: |
+        Lichtgewicht projectie van een geplande wedstrijd — zonder scheduling-optimalisatie,
+        alleen wat er nu al in Sportlink gepland staat.
+      properties:
+        wedstrijdCode:
+          type: integer
+          format: int64
+          nullable: true
+        wedstrijd:
+          type: string
+        teamNaam:
+          type: string
+        uitteam:
+          type: string
+          nullable: true
+        aanvangsTijd:
+          type: string
+          nullable: true
+          example: "13:00"
+        veld:
+          type: string
+          nullable: true
+        competitiesoort:
+          type: string
+          nullable: true
+        leeftijdsCategorie:
+          type: string
           nullable: true
 
     AutoPlanResponse:
@@ -3886,6 +3917,45 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AutoPlanResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /planner/veldbezetting:
+    get:
+      tags: [planner]
+      operationId: veldbezetting
+      summary: Wedstrijden op een datum ophalen, zonder optimalisatie
+      description: |
+        Geeft de wedstrijden terug die op een datum al gepland staan, rechtstreeks uit de
+        laatst gesynchroniseerde Sportlink-data — zonder de scheduling-optimalisatie die
+        `/planner/auto-plan` en `/planner/optimaliseer` uitvoeren. Bedoeld als snelle,
+        goedkope "wat staat er nu al gepland"-weergave.
+      security:
+        - easyAuth: []
+      parameters:
+        - name: datum
+          in: query
+          required: true
+          schema:
+            type: string
+            format: date
+          description: Datum in yyyy-MM-dd formaat
+          example: "2026-08-22"
+      responses:
+        '200':
+          description: Wedstrijden op deze datum, gesorteerd op aanvangstijd
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/VeldbezettingItem'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':


### PR DESCRIPTION
## Samenvatting

**Bugfix (#567):** nieuw gesynchroniseerde teams, wedstrijden en wedstrijddetails kregen
`ClubCode = NULL` in plaats van de eigen club. Root cause: de staging-tabellen en de generieke
merge-procedure kenden de kolom niet — alleen een eenmalige migratie (#324) had bestaande rijen
ooit gebackfilld, maar nieuwe rijen bleven daarna permanent zonder ClubCode. Gevolg: recent
gesynchroniseerde wedstrijden verdwenen stilzwijgend uit de Dagplanner en de teamlijst, ook al
stonden ze gewoon in Sportlink gepland.

- `ClubCode` toegevoegd aan `stg.teams`/`stg.matches`/`stg.matchdetails`
- `ClubCode` wordt nu expliciet vanuit `dbo.AppSettings` meegegeven bij elke staging-insert
- De bestaande generieke `sp_MergeStgToHis` neemt de kolom daardoor automatisch mee in zowel INSERT
  als UPDATE — dit repareert ook meteen de rijen die al met `ClubCode = NULL` in de database stonden
- Geen aparte migratie nodig: `Script.PostDeployment1.sql` bevat al een onvoorwaardelijke
  `UPDATE ... WHERE ClubCode IS NULL` die op elke deploy opnieuw draait

**Feature (#566):** Dagplanning toont nu direct de wedstrijden die op de gekozen datum gepland
staan — inclusief de visuele veldplanner-grid (tijdas + velden + blokken) zoals in de oorspronkelijke
aanvraag gevraagd — via een nieuw lichtgewicht `GET /api/planner/veldbezetting`-endpoint zonder
scheduling-berekening. Duur/veldafmeting komen uit de bestaande, goedkope speeltijden-lookup, niet
uit de FieldScheduler. Geen klik op "Optimaliseer" meer nodig.

**Bugfix (#569, gedeeltelijk):** de query achter de Dagplanner deed een `LEFT JOIN` op `his.teams`
puur om de leeftijdscategorie op te halen. Doordat `his.teams` momenteel duplicaten bevat per team,
vermenigvuldigde die JOIN elke wedstrijdrij mee (zichtbaar als 3x dezelfde wedstrijd). Vervangen
door een `OUTER APPLY` met `TOP 1`, zodat de rijenlijst nooit meer kan fan-outen ongeacht duplicaten
in de brondata. Dit lost het zichtbare symptoom op; de onderliggende oorzaak (Sportlink levert
dezelfde team meerdere keren) staat nog open in #569.

## Losstaande bevindingen tijdens verificatie

- **#569** — de teams-merge (`sp_MergeStgToHis` voor `stg.teams` → `his.teams`) crasht zodra
  Sportlink hetzelfde team meerdere keren teruggeeft (duplicaten op de merge-sleutel). Root cause
  nog niet gefixt in deze PR (zie hierboven voor de tijdelijke mitigatie van het zichtbare gevolg).

## Test plan

- [x] `dotnet build` FunctionApp + BlazorAdmin — 0 errors, 0 warnings
- [x] `dotnet test` FunctionApp.Tests — 24 passed, 3 skipped (DB-integratietests, verwacht zonder live DB)
- [x] `Test-App.ps1` — 31/31 geslaagd
- [x] Live sync getriggerd; `ClubCode` correct gevuld in `stg.teams`/`stg.matches` (100%, geen NULL meer)
- [x] `his.matches` na merge: 0 rijen met `ClubCode IS NULL` (was 25)
- [x] Browserverificatie (Playwright): Dagplanning op 22-08-2026 toont nu beide eerder ontbrekende
      thuiswedstrijden, direct bij datumwijziging, zonder duplicatie, zonder op "Optimaliseer" te klikken
- [x] Browserverificatie: visuele veldplanner-grid getest op een datum met meerdere jeugdwedstrijden
      (16-05-2026) — tijdas, veldrijen en blokken renderen correct
- [x] Bestaande "Optimaliseer"-flow (Gantt + vergelijkingstabel) getest — geen regressie
- [x] `docs/API.md`, `openapi.yaml`/`.json`, `CHANGELOG.md` bijgewerkt; versie 2.16.2.1 → 2.16.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)