### PR TITLE
chore(#586): dependabot-updates geverifieerd en samengevoegd

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "nuget"
     directory: "/FunctionApp"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -12,6 +13,7 @@ updates:
 
   - package-ecosystem: "nuget"
     directory: "/BlazorAdmin"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -22,6 +24,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,10 +94,10 @@ jobs:
     if: always() && (needs.db-check.result == 'success' || needs.db-check.result == 'skipped')
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: .NET SDK installeren
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -145,7 +145,7 @@ jobs:
     if: vars.AZURE_SQL_SERVER_NAME != ''
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Azure inloggen
         uses: azure/login@v3
@@ -273,11 +273,11 @@ jobs:
 
       - name: Checkout repository
         if: steps.check.outputs.skip == 'false'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: .NET SDK installeren
         if: steps.check.outputs.skip == 'false'
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '10.0.x'
 

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Azure inloggen
         uses: azure/login@v3

--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: .NET SDK installeren
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout (volledige geschiedenis voor CHANGELOG-parsing)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -28,7 +28,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout (volledige geschiedenis)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Controleer op databestanden met persoonsgegevens
         run: |
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Scan op Nederlandse PII-patronen
         run: |
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 20
 
@@ -176,7 +176,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Scan op Azure resource namen en infrastructuuridentifiers
         env:
@@ -236,7 +236,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -27,9 +27,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Authentication.WebAssembly.Msal" Version="10.0.10" />
   </ItemGroup>
 
 </Project>

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -29,12 +29,12 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.6.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.0" />
     <PackageReference Include="Microsoft.Graph" Version="6.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="OpenAI" Version="2.10.0" />
+    <PackageReference Include="OpenAI" Version="2.12.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Sluit #586.

## Samenvatting
Verifieert 7 openstaande Dependabot-PR's (#545, #547, #552, #553, #554, #555, #556) op `develop`. Dependabot target rechtstreeks `main`, dat momenteel ~9 commits achterloopt op `develop` — een letterlijke `git merge` van elke dependabot-branch gaf daardoor grote conflicten in versienummers en CHANGELOG (ruis, niet de daadwerkelijke dependency-wijziging). In plaats daarvan zijn de doelversies per PR geïsoleerd (`gh pr diff`) en direct toegepast op `develop`.

## Toegepaste bumps
| PR | Package | Van | Naar |
|---|---|---|---|
| #556 | Microsoft.Authentication.WebAssembly.Msal | 10.0.8 | 10.0.10 |
| #554 | Microsoft.AspNetCore.Components.WebAssembly.DevServer | 10.0.8 | 10.0.10 |
| #553 | Microsoft.AspNetCore.Components.WebAssembly | 10.0.8 | 10.0.10 |
| #555 | Microsoft.Extensions.AI.OpenAI / OpenAI | 10.6.0 / 2.10.0 | 10.8.0 / 2.12.0 |
| #547 | Microsoft.Data.SqlClient | 7.0.1 | 7.0.2 |
| #552 | actions/setup-dotnet | v5 | v6 |
| #545 | actions/checkout | v6 | v7 |

(Versienummers "van" wijken af van wat de PR's zelf tonen, omdat `develop` deze packages al eerder onafhankelijk had bijgewerkt t.o.v. `main`.)

## Config-fix
`target-branch: develop` toegevoegd aan `.github/dependabot.yml` voor alle 3 update-blokken. Zonder deze regel targette dependabot altijd `main` rechtstreeks — dat wijkt af van de develop-integratiestrategie die de rest van het project volgt, en veroorzaakte precies de merge-ruis hierboven. Toekomstige dependency-PR's komen nu op `develop` binnen, net als al het andere werk.

## Validatie
- `dotnet build` FunctionApp (`net9.0`) en BlazorAdmin (`net10.0`) — groen, 0 warnings
- `dotnet test` — 77 geslaagd, 0 mislukt, 3 skipped (ongewijzigd t.o.v. baseline)
- `scripts/dev/Test-App.ps1` — 31/31 checks, exit 0, met live services
- Blazor fingerprint-consistency: OK
- `/instellingen` en `/dagplanning` gerenderd via Playwright — geen foutbanner, 0 console-errors, versie zichtbaar
- `actions/checkout@v7` en `actions/setup-dotnet@v6`: release notes gecontroleerd (ESM-migratie + dependency-updates, geen vermelde runner/Node-breaking-changes; GitHub-hosted `ubuntu-latest` ondersteunt dit al sinds v6) — CI-workflows zelf draaien pas echt bij de CI-run van deze PR

## Aanbeveling voor de 7 dependabot-PR's
Deze PR bevat dezelfde eindversies. Na het mergen hiervan zijn de dependabot-PR's #545, #547, #552, #553, #554, #555, #556 overbodig geworden — sluiten in plaats van los mergen naar `main`, om te voorkomen dat een latere `develop` → `main` release deze bumps weer terugdraait naar de oudere main-versies.

**Kosten:** geen nieuwe Azure-resources, geen tier-wijzigingen. €0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)