### PR TITLE
fix(#591): normaliseer Senioren en Senioren Vrouwen naar Speeltijden-sleutels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Dagplanning toont nu direct de wedstrijden die op de gekozen datum gepland staan — zodra je een andere datum kiest, wordt dit meteen bijgewerkt zonder dat je eerst op "Optimaliseer" hoeft te klikken. (#566)
 
 ### Fixed
+- Senioren-categorieen uit Sportlink worden weer correct herkend in plannerberekeningen: `Senioren` normaliseert nu naar speeltijdsleutel `1-99` en `Senioren Vrouwen` naar `VR`. Daardoor vallen seniorenwedstrijden niet meer onterecht in `onbekend-team` bij Optimaliseer/Auto-plan. (#591)
 - De databasemigratie liep bij elke deploy vast zodra er meer dan één club in de instellingen stond — wat altijd het geval is doordat de AllStars FC democlub wordt aangemaakt. Gevolg: het nieuwe seizoen werd niet meer automatisch aangemaakt en een deel van de migratie werd overgeslagen. Beide zijn verholpen.
 - De kolom die geplande wedstrijden aan een club koppelt werd door een fout in het migratiescript nooit aangemaakt. Daardoor ontbrak de scheiding tussen productie- en demogegevens voor geplande wedstrijden. De migratie werkt nu.
 - Nieuw gesynchroniseerde teams en wedstrijden werden niet meer aan de eigen club gekoppeld, waardoor ze onterecht niet zichtbaar waren in de Dagplanner en de teamlijst — ook al stonden ze al in Sportlink gepland. Nieuwe rijen krijgen deze koppeling nu weer automatisch bij elke synchronisatie. (#567)

--- a/FunctionApp.Tests/Email/EmailPersistenceServiceTests.cs
+++ b/FunctionApp.Tests/Email/EmailPersistenceServiceTests.cs
@@ -1,6 +1,6 @@
 using FluentAssertions;
+using FunctionApp.Tests.Email.TestDoubles;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 using SportlinkFunction.Email;
 using Xunit;
 
@@ -11,8 +11,8 @@ public class EmailPersistenceServiceTests
     [Fact]
     public void ResolveClubCode_ZonderProviderWaarde_GooitInvalidOperation()
     {
-        var repo = new Mock<IEmailPersistenceRepository>(MockBehavior.Strict);
-        var service = new EmailPersistenceService(repo.Object, () => null);
+        var repo = new FakeEmailPersistenceRepository();
+        var service = new EmailPersistenceService(repo, () => null);
 
         var act = () => service.ResolveClubCode();
 
@@ -23,49 +23,39 @@ public class EmailPersistenceServiceTests
     [Fact]
     public async Task LaadUitgeslotenAdressenAsync_LeestMetResolvedClubCode()
     {
-        var repo = new Mock<IEmailPersistenceRepository>(MockBehavior.Strict);
         var expected = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "a@x.nl", "b@x.nl" };
-        repo.Setup(r => r.GetExcludedEmailAddressesAsync("VRC")).ReturnsAsync(expected);
-        var service = new EmailPersistenceService(repo.Object, () => "VRC");
+        var repo = new FakeEmailPersistenceRepository();
+        foreach (var address in expected)
+            repo.ExcludedAddressesToReturn.Add(address);
+        var service = new EmailPersistenceService(repo, () => "VRC");
 
         var result = await service.LaadUitgeslotenAdressenAsync(NullLogger.Instance);
 
         result.Should().BeEquivalentTo(expected);
-        repo.VerifyAll();
+        repo.LastExcludedClubCode.Should().Be("VRC");
     }
 
     [Fact]
     public async Task DetecteerReplyOpOnsAntwoordAsync_GeeftClubCodeDoorAanRepository()
     {
-        var repo = new Mock<IEmailPersistenceRepository>(MockBehavior.Strict);
         var expected = (true, (int?)77, "HerplanVerzoek", "samenvatting");
-        repo.Setup(r => r.DetecteerReplyOpOnsAntwoordAsync("conv-1", "VRC", It.IsAny<Microsoft.Extensions.Logging.ILogger>()))
-            .ReturnsAsync(expected);
-        var service = new EmailPersistenceService(repo.Object, () => "VRC");
+        var repo = new FakeEmailPersistenceRepository { DetecteerResult = expected };
+        var service = new EmailPersistenceService(repo, () => "VRC");
 
         var result = await service.DetecteerReplyOpOnsAntwoordAsync("conv-1", NullLogger.Instance);
 
         result.Should().Be(expected);
-        repo.VerifyAll();
+        repo.LastDetecteerCall.Should().Be(("conv-1", "VRC"));
     }
 
     [Fact]
     public async Task InsertClassificatieCorrectieAsync_GebruiktResolvedClubCode()
     {
-        var repo = new Mock<IEmailPersistenceRepository>(MockBehavior.Strict);
-        repo.Setup(r => r.InsertClassificatieCorrectieAsync(
-                1,
-                2,
-                "Origineel",
-                "Juist",
-                "orig",
-                "corr",
-                "VRC"))
-            .Returns(Task.CompletedTask);
-        var service = new EmailPersistenceService(repo.Object, () => "VRC");
+        var repo = new FakeEmailPersistenceRepository();
+        var service = new EmailPersistenceService(repo, () => "VRC");
 
         await service.InsertClassificatieCorrectieAsync(1, 2, "Origineel", "Juist", "orig", "corr");
 
-        repo.VerifyAll();
+        repo.LastCorrectieCall.Should().Be((1, 2, "Origineel", "Juist", "orig", "corr", "VRC"));
     }
 }

--- a/FunctionApp.Tests/Email/EmailReplyPolicyServiceTests.cs
+++ b/FunctionApp.Tests/Email/EmailReplyPolicyServiceTests.cs
@@ -1,7 +1,6 @@
 using FluentAssertions;
 using FunctionApp.Tests.Email.TestDoubles;
 using Microsoft.Extensions.Logging.Abstractions;
-using Moq;
 using Newtonsoft.Json;
 using SportlinkFunction.Email;
 using SportlinkFunction.Planner;
@@ -16,7 +15,7 @@ public class EmailReplyPolicyServiceTests
     {
         var service = new EmailReplyPolicyService();
         var graph = new FakeEmailGraphService();
-        var persistence = new Mock<IEmailPersistenceService>(MockBehavior.Strict);
+        var persistence = new RecordingEmailPersistenceService();
         var buildCalled = false;
 
         var result = await service.HandelReplyFlowAfAsync(
@@ -26,7 +25,7 @@ public class EmailReplyPolicyServiceTests
             plannerResponseJson: JsonConvert.SerializeObject(new CheckAvailabilityResponse { Beschikbaar = true }),
             reviewMode: true,
             graphService: graph,
-            persistenceService: persistence.Object,
+            persistenceService: persistence,
             bouwTemplateAntwoordAsync: () =>
             {
                 buildCalled = true;
@@ -47,10 +46,7 @@ public class EmailReplyPolicyServiceTests
     {
         var service = new EmailReplyPolicyService();
         var graph = new FakeEmailGraphService();
-        var persistence = new Mock<IEmailPersistenceService>(MockBehavior.Strict);
-        persistence
-            .Setup(p => p.UpdateStatusAsync(100, EmailStatus.GeenAntwoordNodig, null))
-            .Returns(Task.CompletedTask);
+        var persistence = new RecordingEmailPersistenceService();
 
         var result = await service.HandelReplyFlowAfAsync(
             verwerkingId: 100,
@@ -59,7 +55,7 @@ public class EmailReplyPolicyServiceTests
             plannerResponseJson: JsonConvert.SerializeObject(new CheckAvailabilityResponse { Beschikbaar = true }),
             reviewMode: false,
             graphService: graph,
-            persistenceService: persistence.Object,
+            persistenceService: persistence,
             bouwTemplateAntwoordAsync: () => Task.FromResult(("subj", "body")),
             sanitizeFoutMelding: s => s,
             log: NullLogger.Instance);
@@ -68,7 +64,8 @@ public class EmailReplyPolicyServiceTests
         graph.SentReplies.Should().BeEmpty();
         graph.CategoryUpdates.Should().ContainSingle(c => c.Categories.Contains("Handmatige planning"));
         graph.MarkedAsReadIds.Should().ContainSingle(id => id == "m2");
-        persistence.VerifyAll();
+        persistence.StatusUpdates.Should().ContainSingle(u =>
+            u.VerwerkingId == 100 && u.Status == EmailStatus.GeenAntwoordNodig && u.GeextraheerdeData == null);
     }
 
     [Fact]
@@ -76,10 +73,7 @@ public class EmailReplyPolicyServiceTests
     {
         var service = new EmailReplyPolicyService();
         var graph = new FakeEmailGraphService();
-        var persistence = new Mock<IEmailPersistenceService>(MockBehavior.Strict);
-        persistence
-            .Setup(p => p.UpdateAntwoordVerstuurdAsync(200, "afzender@club.nl", "antwoord-body"))
-            .Returns(Task.CompletedTask);
+        var persistence = new RecordingEmailPersistenceService();
 
         var result = await service.HandelReplyFlowAfAsync(
             verwerkingId: 200,
@@ -88,7 +82,7 @@ public class EmailReplyPolicyServiceTests
             plannerResponseJson: "{}",
             reviewMode: false,
             graphService: graph,
-            persistenceService: persistence.Object,
+            persistenceService: persistence,
             bouwTemplateAntwoordAsync: () => Task.FromResult(("antwoord-subject", "antwoord-body")),
             sanitizeFoutMelding: s => s,
             log: NullLogger.Instance);
@@ -96,7 +90,8 @@ public class EmailReplyPolicyServiceTests
         result.Should().Be(ReplyVerwerkingUitkomst.AntwoordVerstuurd);
         graph.SentReplies.Should().ContainSingle(r => r.To == "afzender@club.nl" && r.Subject == "antwoord-subject");
         graph.MarkedAsReadIds.Should().ContainSingle(id => id == "m3");
-        persistence.VerifyAll();
+        persistence.AntwoordUpdates.Should().ContainSingle(u =>
+            u.VerwerkingId == 200 && u.VerstuurdNaar == "afzender@club.nl" && u.AntwoordEmail == "antwoord-body");
     }
 
     [Fact]
@@ -104,10 +99,7 @@ public class EmailReplyPolicyServiceTests
     {
         var service = new EmailReplyPolicyService();
         var graph = new FakeEmailGraphService { ThrowOnSendReply = true };
-        var persistence = new Mock<IEmailPersistenceService>(MockBehavior.Strict);
-        persistence
-            .Setup(p => p.UpdateFoutAsync("m4", "sanitized"))
-            .Returns(Task.CompletedTask);
+        var persistence = new RecordingEmailPersistenceService();
 
         var result = await service.HandelReplyFlowAfAsync(
             verwerkingId: 300,
@@ -116,12 +108,13 @@ public class EmailReplyPolicyServiceTests
             plannerResponseJson: "{}",
             reviewMode: false,
             graphService: graph,
-            persistenceService: persistence.Object,
+            persistenceService: persistence,
             bouwTemplateAntwoordAsync: () => Task.FromResult(("antwoord-subject", "antwoord-body")),
             sanitizeFoutMelding: _ => "sanitized",
             log: NullLogger.Instance);
 
         result.Should().Be(ReplyVerwerkingUitkomst.VerzendFout);
-        persistence.VerifyAll();
+        persistence.FoutUpdates.Should().ContainSingle(u =>
+            u.MessageId == "m4" && u.FoutMelding == "sanitized");
     }
 }

--- a/FunctionApp.Tests/Email/TestDoubles/FakeEmailPersistenceRepository.cs
+++ b/FunctionApp.Tests/Email/TestDoubles/FakeEmailPersistenceRepository.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Logging;
+using SportlinkFunction.Email;
+
+namespace FunctionApp.Tests.Email.TestDoubles;
+
+internal sealed class FakeEmailPersistenceRepository : IEmailPersistenceRepository
+{
+    public HashSet<string> ExcludedAddressesToReturn { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public string? LastExcludedClubCode { get; private set; }
+
+    public (string ConversationId, string ClubCode)? LastDetecteerCall { get; private set; }
+
+    public (bool IsReply, int? OrigineleVerwerkingId, string? OrigineelType, string? OriginaleSamenvatting)
+        DetecteerResult { get; set; }
+
+    public (
+        int OrigineleVerwerkingId,
+        int CorrectionVerwerkingId,
+        string OrigineelType,
+        string? AfgeleidType,
+        string? OriginaleSamenvatting,
+        string? CorrectieSamenvatting,
+        string ClubCode)? LastCorrectieCall { get; private set; }
+
+    public Task<HashSet<string>> GetExcludedEmailAddressesAsync(string clubCode)
+    {
+        LastExcludedClubCode = clubCode;
+        return Task.FromResult(new HashSet<string>(ExcludedAddressesToReturn, StringComparer.OrdinalIgnoreCase));
+    }
+
+    public Task<(bool IsReply, int? OrigineleVerwerkingId, string? OrigineelType, string? OriginaleSamenvatting)>
+        DetecteerReplyOpOnsAntwoordAsync(string conversationId, string clubCode, ILogger log)
+    {
+        LastDetecteerCall = (conversationId, clubCode);
+        return Task.FromResult(DetecteerResult);
+    }
+
+    public Task InsertClassificatieCorrectieAsync(
+        int origineleVerwerkingId,
+        int correctionVerwerkingId,
+        string origineelType,
+        string? afgeleidType,
+        string? originaleSamenvatting,
+        string? correctieSamenvatting,
+        string clubCode)
+    {
+        LastCorrectieCall = (
+            origineleVerwerkingId,
+            correctionVerwerkingId,
+            origineelType,
+            afgeleidType,
+            originaleSamenvatting,
+            correctieSamenvatting,
+            clubCode);
+        return Task.CompletedTask;
+    }
+
+    public Task<bool> BestaatMessageIdAsync(string messageId) => throw new NotImplementedException();
+
+    public Task<int> InsertEmailVerwerkingAsync(InkomendBericht email) => throw new NotImplementedException();
+
+    public Task UpdateStatusAsync(int verwerkingId, EmailStatus status, string? geextraheerdeData) => throw new NotImplementedException();
+
+    public Task UpdatePlannerResponseAsync(int verwerkingId, string plannerResponseJson) => throw new NotImplementedException();
+
+    public Task UpdateAntwoordVerstuurdAsync(int verwerkingId, string verstuurdNaar, string antwoordEmail) => throw new NotImplementedException();
+
+    public Task UpdateFoutAsync(string messageId, string foutMelding) => throw new NotImplementedException();
+
+    public Task UpdateReplyStatusAsync(int verwerkingId, bool isReply, int replyOpVerwerkingId) => throw new NotImplementedException();
+
+    public Task<List<ClassificatieCorrectieVoorbeeld>> HaalLeermomentVoorbeeldenOpAsync(string clubCode, ILogger log)
+        => throw new NotImplementedException();
+}

--- a/FunctionApp.Tests/Email/TestDoubles/RecordingEmailPersistenceService.cs
+++ b/FunctionApp.Tests/Email/TestDoubles/RecordingEmailPersistenceService.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Logging;
+using SportlinkFunction.Email;
+
+namespace FunctionApp.Tests.Email.TestDoubles;
+
+internal sealed class RecordingEmailPersistenceService : IEmailPersistenceService
+{
+    public List<(int VerwerkingId, EmailStatus Status, string? GeextraheerdeData)> StatusUpdates { get; } = new();
+
+    public List<(int VerwerkingId, string VerstuurdNaar, string AntwoordEmail)> AntwoordUpdates { get; } = new();
+
+    public List<(string MessageId, string FoutMelding)> FoutUpdates { get; } = new();
+
+    public Task<HashSet<string>> LaadUitgeslotenAdressenAsync(ILogger log)
+        => Task.FromResult(new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+
+    public Task<bool> BestaatMessageIdAsync(string messageId)
+        => Task.FromResult(false);
+
+    public Task<int> InsertEmailVerwerkingAsync(InkomendBericht email)
+        => Task.FromResult(1);
+
+    public Task UpdateStatusAsync(int verwerkingId, EmailStatus status, string? geextraheerdeData)
+    {
+        StatusUpdates.Add((verwerkingId, status, geextraheerdeData));
+        return Task.CompletedTask;
+    }
+
+    public Task UpdatePlannerResponseAsync(int verwerkingId, string plannerResponseJson)
+        => Task.CompletedTask;
+
+    public Task UpdateAntwoordVerstuurdAsync(int verwerkingId, string verstuurdNaar, string antwoordEmail)
+    {
+        AntwoordUpdates.Add((verwerkingId, verstuurdNaar, antwoordEmail));
+        return Task.CompletedTask;
+    }
+
+    public Task UpdateFoutAsync(string messageId, string foutMelding)
+    {
+        FoutUpdates.Add((messageId, foutMelding));
+        return Task.CompletedTask;
+    }
+
+    public Task<(bool IsReply, int? OrigineleVerwerkingId, string? OrigineelType, string? OriginaleSamenvatting)>
+        DetecteerReplyOpOnsAntwoordAsync(string conversationId, ILogger log)
+        => Task.FromResult((false, (int?)null, (string?)null, (string?)null));
+
+    public Task UpdateReplyStatusAsync(int verwerkingId, bool isReply, int replyOpVerwerkingId)
+        => Task.CompletedTask;
+
+    public Task InsertClassificatieCorrectieAsync(
+        int origineleVerwerkingId,
+        int correctionVerwerkingId,
+        string origineelType,
+        string? afgeleidType,
+        string? originaleSamenvatting,
+        string? correctieSamenvatting)
+        => Task.CompletedTask;
+
+    public Task<List<ClassificatieCorrectieVoorbeeld>> HaalLeermomentVoorbeeldenOpAsync(ILogger log)
+        => Task.FromResult(new List<ClassificatieCorrectieVoorbeeld>());
+
+    public string ResolveClubCode() => "VRC";
+}

--- a/FunctionApp.Tests/Planner/LeeftijdNormalisatieTests.cs
+++ b/FunctionApp.Tests/Planner/LeeftijdNormalisatieTests.cs
@@ -1,0 +1,37 @@
+using FluentAssertions;
+using SportlinkFunction.Planner;
+using Xunit;
+
+namespace FunctionApp.Tests.Planner;
+
+public class LeeftijdNormalisatieTests
+{
+    [Fact]
+    public void Normaliseer_Senioren_MaptNaarEenTotNegenennegentig()
+    {
+        LeeftijdNormalisatie.Normaliseer("Senioren").Should().Be("1-99");
+    }
+
+    [Fact]
+    public void Normaliseer_SeniorenVrouwen_MaptNaarVr()
+    {
+        LeeftijdNormalisatie.Normaliseer("Senioren Vrouwen").Should().Be("VR");
+    }
+
+    [Fact]
+    public void Normaliseer_BestaandeJeugdFormaten_BlijvenOngewijzigd()
+    {
+        LeeftijdNormalisatie.Normaliseer("JO15 Meiden").Should().Be("MO15");
+        LeeftijdNormalisatie.Normaliseer("Onder 13").Should().Be("JO13");
+    }
+
+    [Fact]
+    public void SqlExpr_BevatExplicieteSeniorenCases()
+    {
+        var expr = LeeftijdNormalisatie.SqlExpr("t.[leeftijdscategorie]");
+
+        expr.Should().Contain("SENIOREN");
+        expr.Should().Contain("'1-99'");
+        expr.Should().Contain("'VR'");
+    }
+}

--- a/FunctionApp/Planner/LeeftijdNormalisatie.cs
+++ b/FunctionApp/Planner/LeeftijdNormalisatie.cs
@@ -20,10 +20,20 @@ internal static class LeeftijdNormalisatie
     {
         if (string.IsNullOrWhiteSpace(cat)) return "";
 
+        var trimmed = cat.Trim();
+
+        // Senioren-categorieen gebruiken vaste Speeltijden-sleutels.
+        if (trimmed.Equals("Senioren", StringComparison.OrdinalIgnoreCase))
+            return "1-99";
+
+        if (trimmed.Equals("Senioren Vrouwen", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("Senioren VR", StringComparison.OrdinalIgnoreCase))
+            return "VR";
+
         // "JO{n} Meiden" → "MO{n}" (Sportlink-specifiek formaat voor meisjesteams)
-        if (cat.Contains("Meiden", StringComparison.OrdinalIgnoreCase))
+        if (trimmed.Contains("Meiden", StringComparison.OrdinalIgnoreCase))
         {
-            var num = cat
+            var num = trimmed
                 .Replace("JO", "", StringComparison.OrdinalIgnoreCase)
                 .Replace("MO", "", StringComparison.OrdinalIgnoreCase)
                 .Replace("Meiden", "", StringComparison.OrdinalIgnoreCase)
@@ -31,7 +41,7 @@ internal static class LeeftijdNormalisatie
             return $"MO{num}";
         }
 
-        return cat
+        return trimmed
             .Replace("Onder ", "JO")
             .Replace("Meisjes ", "MO")
             .Replace("Vrouwen", "VR");
@@ -43,6 +53,10 @@ internal static class LeeftijdNormalisatie
     /// </summary>
     internal static string SqlExpr(string kolom) => $@"
         CASE
+            WHEN UPPER(LTRIM(RTRIM({kolom}))) = 'SENIOREN'
+                THEN '1-99'
+            WHEN UPPER(LTRIM(RTRIM({kolom}))) IN ('SENIOREN VROUWEN', 'SENIOREN VR')
+                THEN 'VR'
             WHEN {kolom} LIKE '%Meiden'
                 THEN 'MO' + LTRIM(RTRIM(REPLACE(REPLACE(REPLACE({kolom}, 'JO', ''), 'MO', ''), ' Meiden', '')))
             ELSE


### PR DESCRIPTION
## Wat doet deze PR?\n\nDeze PR voert de structurele codefix uit die losgetrokken is uit #581: seniorencategorieen worden in de centrale normalisatie weer correct gemapt naar bestaande Speeltijden-sleutels, zodat seniorenwedstrijden niet meer als onbekend-team uitvallen in plannerflows.\n\nCloses #591\n\n## Type wijziging\n\n- [x] ix — bugfix\n\n## Checklist\n\n### Code\n- [x] dotnet build slaagt zonder warnings (FunctionApp)\n- [ ] dotnet build slaagt zonder warnings (BlazorAdmin)\n- [x] .\\scripts\\dev\\Test-App.ps1 slaagt (met live services; SWA niet gestart)\n- [x] Geen club-specifieke strings in code (geen hardcoded clubnamen, -IDs of -URLs)\n- [x] UTC in database, ToLocalTime() in Blazor voor datumweergave\n- [x] GUI en code synchroon — nieuwe enum/key/type ook in de UI bijgewerkt\n\n### Security & AVG\n- [x] Geen secrets, wachtwoorden of tokens in code of commits\n- [x] Geen persoonsgegevens in code, logs, comments of dit PR\n- [x] Git hooks geactiveerd en groen (git config core.hooksPath .githooks)\n- [ ] Security Gate in CI is groen\n\n### Documentatie\n- [x] CHANGELOG.md bijgewerkt onder ## [Unreleased]\n- [x] Relevante docs bijgewerkt waar nodig\n\n## Testbeschrijving\n\n- dotnet build FunctionApp/fa-dev-sportlink-01.csproj -c Debug\n- dotnet test FunctionApp.Tests/FunctionApp.Tests.csproj -c Debug\n- scripts/dev/Start-Debug.ps1\n- scripts/dev/Test-App.ps1\n- scripts/dev/Test-App.ps1 -Fix\n\n## Screenshots (indien van toepassing)\n\nN.v.t.\n