### PR TITLE
fix: Fable 5-reviewbevindingen #595-#610 (15 van 16)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,114 @@
+name: Build (PR)
+
+# #599: compileercheck op elke PR, zonder enige database-afhankelijkheid.
+#
+# Voorheen was `deploy.yml` de enige workflow die daadwerkelijk bouwde, en die triggerde alleen op
+# push naar main én was gated achter `db-check`. Stond de Free-tier SQL-database gepauzeerd, dan
+# werden build/test/blazor-deploy allemaal 'skipped' en bleven compileerfouten onopgemerkt.
+#
+# Deze workflow bouwt beide projecten en controleert de schema-drift tussen het DB-project en het
+# PostDeployment-script. Geen secrets, geen Azure-login, geen database — draait dus ook op forks.
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build FunctionApp + BlazorAdmin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # FunctionApp target net9.0, BlazorAdmin net10.0 — beide runtimes nodig.
+      # LET OP: FunctionApp mag NOOIT naar net10.0 (Linux Consumption ondersteunt dat niet).
+      - name: .NET SDK installeren
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: |
+            9.0.x
+            10.0.x
+
+      - name: FunctionApp bouwen (net9.0)
+        run: dotnet build FunctionApp/fa-dev-sportlink-01.csproj --configuration Release
+
+      - name: BlazorAdmin bouwen (net10.0)
+        run: dotnet build BlazorAdmin/BlazorAdmin.csproj --configuration Release
+
+      # ──────────────────────────────────────────────────────────────────────
+      # #595: schema-drift guard.
+      #
+      # De deploy-pipeline publiceert geen dacpac — `db-migrate` runt alleen
+      # Database/Script.PostDeployment1.sql. Elk tabel-object uit het DB-project moet daarom ook
+      # idempotent in dat script staan, anders ontbreekt de tabel op een verse deploy en falen
+      # productiefuncties met "Invalid object name" (zo ontbraken avg.ImportLog,
+      # planner.HerplanVerzoeken en dbo.Zonsondergang).
+      #
+      # Deze check faalt zodra iemand een nieuwe tabel aan het DB-project toevoegt zonder de
+      # bijbehorende guard in PostDeployment — het gat kan dus niet opnieuw ontstaan.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: Schema-drift check (DB-project vs PostDeployment)
+        run: |
+          POST_DEPLOY="Database/Script.PostDeployment1.sql"
+          MISSING=0
+
+          # Tabellen die bewust NIET in PostDeployment horen, met de reden erbij.
+          # Elke andere tabel moet er staan — zie de toelichting hierboven.
+          #   stg.*         — dynamisch aangemaakt door FunctionApp/CreateTable.cs op basis van het
+          #                   actuele Sportlink API-schema; een statische DDL zou juist gaan driften
+          #   dbo.DateTable — aangemaakt (DROP + CREATE) door dbo.sp_CreateDateTable, die in
+          #                   PostDeployment wordt gecreëerd én aangeroepen
+          ALLOWLIST="stg.teams stg.matches stg.matchdetails dbo.DateTable"
+
+          while IFS= read -r f; do
+            # Haal de schema- en tabelnaam uit 'CREATE TABLE [schema].[naam]'
+            OBJ=$(grep -ioP 'CREATE\s+TABLE\s+\[?\K\w+\]?\.\[?\w+' "$f" | head -1 \
+                  | tr -d '[]')
+            [ -z "$OBJ" ] && continue
+
+            # Bewuste uitzondering? Dan overslaan.
+            case " $ALLOWLIST " in *" $OBJ "*) continue ;; esac
+
+            # Zoek een referentie naar het object in het PostDeployment-script. Zowel
+            # OBJECT_ID('schema.tabel') als [schema].[tabel] tellen als dekking.
+            SCHEMA_NAME="${OBJ%%.*}"
+            TABLE_NAME="${OBJ##*.}"
+
+            if grep -qiE "(OBJECT_ID\('${SCHEMA_NAME}\.${TABLE_NAME}'\)|\[${SCHEMA_NAME}\]\.\[${TABLE_NAME}\])" "$POST_DEPLOY"; then
+              continue
+            fi
+
+            echo "::error file=$f::Tabel ${OBJ} staat in het DB-project maar wordt niet genoemd in ${POST_DEPLOY} — op een verse deploy ontbreekt deze tabel (#595)."
+            MISSING=1
+          done < <(find Database -path '*/Tables/*.sql' -type f | sort)
+
+          # Zelfde controle voor stored procedures en views. Deze ontbraken óók volledig — inclusief
+          # de vier ETL-procedures, waardoor de hele Sportlink-pipeline op een verse deploy stilstond.
+          while IFS= read -r f; do
+            OBJ=$(grep -ioP 'CREATE\s+(OR\s+ALTER\s+)?(PROCEDURE|VIEW)\s+\[?\K\w+\]?\.\[?\w+' "$f" \
+                  | head -1 | tr -d '[]')
+            [ -z "$OBJ" ] && continue
+
+            SCHEMA_NAME="${OBJ%%.*}"
+            OBJECT_NAME="${OBJ##*.}"
+
+            if grep -qiE "(CREATE\s+(OR\s+ALTER\s+)?(PROCEDURE|VIEW)\s+\[?${SCHEMA_NAME}\]?\.\[?${OBJECT_NAME}\]?|OBJECT_ID\('${SCHEMA_NAME}\.${OBJECT_NAME}'\))" "$POST_DEPLOY"; then
+              continue
+            fi
+
+            echo "::error file=$f::Object ${OBJ} staat in het DB-project maar wordt niet aangemaakt in ${POST_DEPLOY} — op een verse deploy ontbreekt dit object (#595)."
+            MISSING=1
+          done < <(find Database \( -path '*/Stored Procedures/*.sql' -o -path '*/Views/*.sql' \) -type f | sort)
+
+          if [ "$MISSING" -eq 1 ]; then
+            echo "::error::Voeg een idempotente guard toe aan ${POST_DEPLOY}: 'IF NOT EXISTS ... CREATE TABLE' voor tabellen, 'CREATE OR ALTER' voor procedures en views."
+            exit 1
+          fi
+          echo "✅ Alle tabellen, procedures en views uit het DB-project komen voor in het PostDeployment-script."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,10 +88,9 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    # Wacht op db-check. Als db-check FAILED → build wordt overgeslagen (en alles daarna ook).
-    # Als db-check SKIPPED (vars niet ingesteld) → build loopt gewoon door (backward compatible).
-    needs: db-check
-    if: always() && (needs.db-check.result == 'success' || needs.db-check.result == 'skipped')
+    # #599: GEEN db-check-afhankelijkheid. Voorheen blokkeerde een gepauzeerde Free-tier database
+    # de build, waardoor build/blazor-deploy/test allemaal 'skipped' werden en compileerfouten
+    # wekenlang onopgemerkt konden blijven. Bouwen heeft geen database nodig; alleen deployen wel.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -116,9 +115,14 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [build, db-migrate]
-    # Deploy pas na succesvolle migratie — als db-migrate overgeslagen is (geen SQL-vars) mag deploy doorgaan. (#430)
-    if: always() && needs.build.result == 'success' && (needs.db-migrate.result == 'success' || needs.db-migrate.result == 'skipped')
+    needs: [build, db-check, db-migrate]
+    # Deploy pas na succesvolle migratie — als db-migrate overgeslagen is (geen SQL-vars) mag deploy
+    # doorgaan (#430). db-check staat hier expliciet bij sinds #599: build is er niet meer van
+    # afhankelijk, dus de database-gate moet hier alsnog gelden — nooit code deployen naar een
+    # database die niet Online is.
+    if: always() && needs.build.result == 'success'
+        && (needs.db-check.result == 'success' || needs.db-check.result == 'skipped')
+        && (needs.db-migrate.result == 'success' || needs.db-migrate.result == 'skipped')
     steps:
       - name: Artefact downloaden
         uses: actions/download-artifact@v8
@@ -139,10 +143,14 @@ jobs:
 
   db-migrate:
     runs-on: ubuntu-latest
-    needs: build
-    # Wordt overgeslagen als AZURE_SQL_SERVER_NAME niet geconfigureerd is (fork / nieuw project).
-    # Vereiste: secret SQL_CONNECTION_STRING, vars AZURE_SQL_RESOURCE_GROUP + AZURE_SQL_SERVER_NAME.
-    if: vars.AZURE_SQL_SERVER_NAME != ''
+    # #599: hangt nu aan db-check i.p.v. build — de database-gate hoort bij de migratie, niet bij
+    # het compileren. Wordt overgeslagen als AZURE_SQL_SERVER_NAME niet geconfigureerd is
+    # (fork / nieuw project). Vereist: secret SQL_CONNECTION_STRING, vars AZURE_SQL_RESOURCE_GROUP
+    # + AZURE_SQL_SERVER_NAME.
+    needs: [build, db-check]
+    if: always() && vars.AZURE_SQL_SERVER_NAME != ''
+        && needs.build.result == 'success'
+        && (needs.db-check.result == 'success' || needs.db-check.result == 'skipped')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -122,7 +122,14 @@ jobs:
           FOUND=0
           # Documentatiebestanden: strenger dan code — GEEN enkel emailadres toegestaan
           # Gebruik placeholder [emailadres] of example@example.nl in voorbeelden
-          DOC_FILES=$(git ls-files 'docs/*.md' 'CHANGELOG.md' 'README.md' 'SETUP.md' 'CONTRIBUTING.md')
+          # #609: de oude glob 'docs/*.md' dekte de geneste submappen al wél — git's standaard
+          # pathspec-matching laat '*' ook '/' matchen (geen WM_PATHNAME), dus
+          # docs/api-standaarden/openspec/specs/**/*.md werd al gescand. Geverifieerd: 23 bestanden
+          # via beide methoden. find is hier gebruikt omdat het expliciet is en niet afhangt van die
+          # subtiliteit — zet iemand ooit core.globPathspecs=true, dan zou de glob wél gaan lekken.
+          DOC_FILES=$( { find docs -name '*.md' -type f 2>/dev/null || true; \
+                         git ls-files 'CHANGELOG.md' 'README.md' 'SETUP.md' 'CONTRIBUTING.md'; } | sort -u)
+          echo "Aantal te scannen documentatiebestanden: $(echo "$DOC_FILES" | grep -c . || true)"
 
           for f in $DOC_FILES; do
             [ ! -f "$f" ] && continue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -717,7 +717,10 @@ De API-standaarden staan in `docs/api-standaarden/`:
 
 **Nooit een endpoint-wijziging committen zonder de spec bij te werken.** De spec is de contractdefinitie voor andere systemen, consumers en toekomstige Codex-sessies. Een verouderde spec misleidt — dat is erger dan geen spec.
 
-**Huidig bekende gap:** openapi.yaml mist ~22 routes die wel in productie draaien (o.a. /beheer/clubs, /beheer/speeltijden, /beheer/theme, /beheer/leermomenten, /beheer/teambegeleiding, /beheer/testdata, /planner/auto-plan). Dit wordt ingehaald via issue #[zie GitHub].
+**Stand van de spec (bijgewerkt bij #605):** `openapi.yaml`/`.json` dekken alle 51 productieroutes; `info.version` volgt de app-versie. De eerder hier genoemde ~22 ontbrekende routes waren al ingehaald — die notitie was zelf verouderd en misleidde. Regenereer `openapi.json` altijd uit de YAML (nooit beide handmatig bijwerken):
+```powershell
+python -c "import yaml,json,io; s=yaml.safe_load(io.open('docs/api-standaarden/openapi.yaml',encoding='utf-8')); json.dump(s, io.open('docs/api-standaarden/openapi.json','w',encoding='utf-8'), indent=2, ensure_ascii=False)"
+```
 
 ---
 

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.16.4.0</Version>
-    <AssemblyVersion>2.16.4.0</AssemblyVersion>
-    <FileVersion>2.16.4.0</FileVersion>
+    <Version>2.16.5.0</Version>
+    <AssemblyVersion>2.16.5.0</AssemblyVersion>
+    <FileVersion>2.16.5.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/Pages/Dagplanning.razor
+++ b/BlazorAdmin/Pages/Dagplanning.razor
@@ -505,7 +505,11 @@
                     @if (!string.IsNullOrEmpty(_klassiekResultaat.HtmlPlanner))
                     {
                         <div class="border rounded mt-2" style="overflow:hidden;">
+                            @* sandbox zonder allow-scripts: de HTML wordt server-side gegenereerd uit
+                               Sportlink-data (team-/tegenstandernamen). Defense in depth tegen XSS,
+                               onafhankelijk van server-side encoding. (#603) *@
                             <iframe srcdoc="@_klassiekResultaat.HtmlPlanner"
+                                    sandbox="allow-same-origin"
                                     style="width:100%; min-height:700px; border:none; display:block;"
                                     title="Klassieke dagplanning"></iframe>
                         </div>

--- a/BlazorAdmin/Program.cs
+++ b/BlazorAdmin/Program.cs
@@ -49,8 +49,8 @@ if (builder.HostEnvironment.IsProduction())
     var capturedFunctionBaseUrl = functionBaseUrl;
     var capturedScope = apiScope;
 
-    // App.razor injecteert HttpClient voor de health check — registreer plain client zonder auth.
-    // AdminApiClient krijgt een eigen HttpClient mét AuthorizationMessageHandler (zie hieronder).
+    // Plain HttpClient zonder auth — DatabaseStatusService krijgt deze via DI voor de health check.
+    // AdminApiClient krijgt een eigen HttpClient mét AuthorizationMessageHandler (zie hieronder). (#610)
     builder.Services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(capturedFunctionBaseUrl) });
 
     builder.Services.AddScoped<AdminApiClient>(sp =>

--- a/BlazorAdmin/Shared/FeedbackWidget.razor
+++ b/BlazorAdmin/Shared/FeedbackWidget.razor
@@ -2,6 +2,7 @@
 @inject AdminApiClient Api
 @inject IJSRuntime JS
 @inject IAuthService Auth
+@inject NavigationManager Nav
 
 <button class="btn btn-warning btn-sm me-3" @onclick="OpenAsync">FEEDBACK</button>
 
@@ -167,8 +168,11 @@
         _antwoorden = [];
         _foutmelding = null;
 
-        var pagina = await JS.InvokeAsync<string>("eval", "window.location.pathname");
-        var browser = await JS.InvokeAsync<string>("eval", "navigator.userAgent");
+        // Geen JS eval() gebruiken: de productie-CSP staat alleen 'wasm-unsafe-eval' toe, waardoor
+        // eval() een EvalError gooit en de hele widget crasht. Pathname komt uit NavigationManager,
+        // user-agent via een dedicated interop-helper. (#597)
+        var pagina = "/" + Nav.ToBaseRelativePath(Nav.Uri).Split('?')[0].Split('#')[0];
+        var browser = await GetUserAgentAsync();
         var versie = typeof(FeedbackWidget).Assembly.GetName().Version?.ToString(4) ?? "?";
         var rol = Auth.IsAdmin ? "admin" : "gebruiker";
 
@@ -179,6 +183,22 @@
             Rol = rol,
             Browser = browser.Length > 120 ? browser[..120] : browser
         };
+    }
+
+    /// <summary>
+    /// Leest de user-agent via een dedicated interop-helper. Faalt de interop (bijv. helper nog
+    /// niet geladen), dan blijft de widget bruikbaar met een lege browserwaarde. (#597)
+    /// </summary>
+    private async Task<string> GetUserAgentAsync()
+    {
+        try
+        {
+            return await JS.InvokeAsync<string>("blazorHelpers.getUserAgent") ?? "";
+        }
+        catch (JSException)
+        {
+            return "";
+        }
     }
 
     private void Sluit()

--- a/BlazorAdmin/Shared/TimeInput.razor
+++ b/BlazorAdmin/Shared/TimeInput.razor
@@ -3,13 +3,21 @@
 <input class="form-control @Class"
        value="@Value"
        placeholder="@Placeholder"
-       @onchange="OnChange" />
+       @onchange="OnChange"
+       @attributes="AdditionalAttributes" />
 
 @code {
     [Parameter] public string? Value { get; set; }
     [Parameter] public EventCallback<string?> ValueChanged { get; set; }
     [Parameter] public string Placeholder { get; set; } = "HH:mm";
     [Parameter] public string Class { get; set; } = "";
+
+    /// <summary>
+    /// Vangt niet-gedeclareerde attributen (bijv. <c>Style</c>, <c>title</c>, <c>disabled</c>) op en
+    /// splat ze op de onderliggende input. Zonder dit werden ze stilzwijgend genegeerd. (#602)
+    /// </summary>
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object>? AdditionalAttributes { get; set; }
 
     private async Task OnChange(ChangeEventArgs e)
     {

--- a/BlazorAdmin/wwwroot/index.html
+++ b/BlazorAdmin/wwwroot/index.html
@@ -47,6 +47,11 @@
                 a.click();
                 document.body.removeChild(a);
                 URL.revokeObjectURL(url);
+            },
+            // Dedicated helpers i.p.v. JS eval(): de productie-CSP van Azure SWA staat alleen
+            // 'wasm-unsafe-eval' toe, niet 'unsafe-eval'. eval() gooit daar een EvalError. (#597)
+            getUserAgent: function () {
+                return navigator.userAgent || '';
             }
         };
     </script>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,26 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 ### Added
 - KNVB-speeldagenkalender voor seizoen 2026/'27 is opgenomen in de database voor **alle zes districten**: West, Noord, Oost, Zuid, Landelijk en Landelijk jeugd. Per speeldatum is nu bekend of het een competitie-, beker-, inhaal-, nacompetitie- of vrije dag is, welke leeftijdscategorieën actief zijn, en welke schoolvakanties of feestdagen spelen. Clubs buiten district West kunnen de kalender daarmee ook gebruiken.
 - Dagplanning toont nu direct de wedstrijden die op de gekozen datum gepland staan — zodra je een andere datum kiest, wordt dit meteen bijgewerkt zonder dat je eerst op "Optimaliseer" hoeft te klikken. (#566)
+- Het AI-model is nu instelbaar via de app-instelling `AiModelName`. Een model-upgrade vereist daarmee geen nieuwe versie van de software meer. (#604)
+- Elke pull request bouwt nu automatisch beide projecten en controleert of het databaseontwerp en het migratiescript nog gelijk lopen. Fouten worden zo bij het voorstellen van een wijziging gemeld in plaats van pas bij een deploy. (#599, #595)
+- Verlopen KNVB-verplaatsingsregels worden nu actief gemeld in de logging, en het AI-model geeft in dat geval geen KNVB-waarschuwing meer af op basis van verouderde deadlines. Voorheen verouderden die regels stilzwijgend. (#608)
 
 ### Fixed
+- **De FEEDBACK-knop werkte niet in de live omgeving.** Het venster liep vast met "An unhandled error has occurred" doordat de beveiligingsinstellingen van de website een techniek blokkeerden die het venster gebruikte om de paginanaam en browserversie op te halen. Lokaal was dit niet te zien omdat die beveiliging daar niet geldt. (#597)
+- **Een nieuwe installatie van het systeem was onbruikbaar:** twaalf database-onderdelen — waaronder alle vier de procedures die de Sportlink-synchronisatie uitvoeren, de koppeltabel die de synchronisatie stuurt en drie tabellen die door de planner en de teambegeleiding-import worden gebruikt — werden nooit aangemaakt. Clubs die het systeem overnamen kregen daardoor foutmeldingen over ontbrekende tabellen en een synchronisatie die niets deed. Alle onderdelen worden nu bij elke deploy aangemaakt. (#595)
+- **De weekendmarkering in de datumtabel stond verkeerd:** vrijdag werd als weekend gemarkeerd en zondag niet. Ook liep de dagnummering één dag voor op wat de documentatie aangaf. Beide zijn gecorrigeerd. (#610)
+- De clubnaam stond nog als standaardwaarde in vijf database-onderdelen, wat de ondersteuning voor meerdere clubs doorbrak. De standaardwaarden zijn verwijderd; de club wordt nu altijd expliciet vastgelegd. Ook de initiële voorbeeldgegevens (velden, beschikbaarheid, teamregels) gebruiken nu geen clubnaam meer. (#598)
+- Ontbreekt de clubinstelling, dan geeft het systeem nu een duidelijke fout in plaats van een lege clubkoppeling weg te schrijven in de planning. Zo'n lege koppeling was daarna niet meer te herstellen. (#600, #601)
+- Een tijdveld negeerde opmaak-instellingen zoals de kolombreedte stilzwijgend; die worden nu wel toegepast. (#602)
+- Ontbreekt de instelling voor de GitHub-repository, dan meldt het systeem dat nu als configuratiefout in plaats van een onduidelijke "niet gevonden"-melding te geven. Dit raakt clubs die het project onder een andere naam overnemen. (#607)
+- Een gepauzeerde database blokkeert de bouwstap niet langer. Voorheen werden daardoor alle controles overgeslagen en konden programmeerfouten wekenlang onopgemerkt blijven. Deployen naar een gepauzeerde database blijft geblokkeerd. (#599)
+
+### Security
+- Het voorbeeldvenster van de klassieke dagplanning draait nu in een afgeschermde omgeving zonder scriptuitvoering. Extra bescherming tegen kwaadaardige inhoud in namen die uit Sportlink komen. (#603)
+
+### Changed
+- De API-documentatie (`openapi.yaml`/`.json`) is bijgewerkt naar de huidige versie en bevat nu ook de twee endpoints voor het importeren van teambegeleiding en het verschuiven van testwedstrijden. (#605)
+- De geschiedenistabellen hebben nu een index op hun sleutel en op de clubkoppeling. Dat versnelt zoekopdrachten en voorkomt dubbele rijen. Waar de Sportlink-gegevens nu al dubbelingen bevatten (zie #569) wordt de index zonder uniciteitseis aangemaakt, zodat een deploy niet vastloopt. (#606)
 - Senioren-categorieen uit Sportlink worden weer correct herkend in plannerberekeningen: `Senioren` normaliseert nu naar speeltijdsleutel `1-99` en `Senioren Vrouwen` naar `VR`. Daardoor vallen seniorenwedstrijden niet meer onterecht in `onbekend-team` bij Optimaliseer/Auto-plan. (#591)
 - De databasemigratie liep bij elke deploy vast zodra er meer dan één club in de instellingen stond — wat altijd het geval is doordat de AllStars FC democlub wordt aangemaakt. Gevolg: het nieuwe seizoen werd niet meer automatisch aangemaakt en een deel van de migratie werd overgeslagen. Beide zijn verholpen.
 - De kolom die geplande wedstrijden aan een club koppelt werd door een fout in het migratiescript nooit aangemaakt. Daardoor ontbrak de scheiding tussen productie- en demogegevens voor geplande wedstrijden. De migratie werkt nu.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -735,7 +735,10 @@ De API-standaarden staan in `docs/api-standaarden/`:
 
 **Nooit een endpoint-wijziging committen zonder de spec bij te werken.** De spec is de contractdefinitie voor andere systemen, consumers en toekomstige Claude-sessies. Een verouderde spec misleidt — dat is erger dan geen spec.
 
-**Huidig bekende gap:** openapi.yaml mist ~22 routes die wel in productie draaien (o.a. /beheer/clubs, /beheer/speeltijden, /beheer/theme, /beheer/leermomenten, /beheer/teambegeleiding, /beheer/testdata, /planner/auto-plan). Dit wordt ingehaald via issue #[zie GitHub].
+**Stand van de spec (bijgewerkt bij #605):** `openapi.yaml`/`.json` dekken alle 51 productieroutes; `info.version` volgt de app-versie. De eerder hier genoemde ~22 ontbrekende routes waren al ingehaald — die notitie was zelf verouderd en misleidde. Regenereer `openapi.json` altijd uit de YAML (nooit beide handmatig bijwerken):
+```powershell
+python -c "import yaml,json,io; s=yaml.safe_load(io.open('docs/api-standaarden/openapi.yaml',encoding='utf-8')); json.dump(s, io.open('docs/api-standaarden/openapi.json','w',encoding='utf-8'), indent=2, ensure_ascii=False)"
+```
 
 ---
 

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Post-Deployment Script Template							
 --------------------------------------------------------------------------------------
  This file contains SQL statements that will be appended to the build script.		
@@ -10,100 +10,133 @@ Post-Deployment Script Template
 --------------------------------------------------------------------------------------
 */
 -- New setup needed for the first time (#435: gebruik IF NOT EXISTS i.p.v. scalar subquery die faalt bij >1 rij)
+--
+-- #598: ClubCode wordt expliciet meegegeven met de neutrale placeholder 'CLUB'. Voorheen leunde deze
+-- INSERT op een DEFAULT-constraint met een clubnaam erin; op een verse dacpac-deploy (waar
+-- dbo.AppSettings.ClubCode NOT NULL is zonder default) faalde de INSERT juist daardoor.
+-- De beheerder stelt de echte ClubCode in via Beheer → Instellingen.
+--
+-- Dynamische SQL omdat [ClubCode] op een pre-multi-club database nog niet bestaat: SQL Server bindt
+-- kolomnamen bij batch-compilatie, dus een statische verwijzing zou de hele batch laten falen
+-- (zelfde valkuil als #564).
 IF NOT EXISTS (SELECT 1 FROM [dbo].[AppSettings])
 BEGIN
-	INSERT INTO [dbo].[AppSettings]
-		([ClubName]
-		,[SportlinkApiUrl]
-		,[SportlinkClientId]
-		,[SeasonStartMonth]
-		,[FetchSchedule])
-	VALUES
-		('Uw clubnaam'
-		,'https://data.sportlink.com'
-		,'APIKEY'
-		,7
-		,'0 0 4 * * *')
+    IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.AppSettings') AND name = 'ClubCode')
+        EXEC('
+            INSERT INTO [dbo].[AppSettings]
+                ([ClubName], [ClubCode], [SportlinkApiUrl], [SportlinkClientId], [SeasonStartMonth], [FetchSchedule])
+            VALUES
+                (''Uw clubnaam'', ''CLUB'', ''https://data.sportlink.com'', ''APIKEY'', 7, ''0 0 4 * * *'');
+        ');
+    ELSE
+        INSERT INTO [dbo].[AppSettings]
+            ([ClubName], [SportlinkApiUrl], [SportlinkClientId], [SeasonStartMonth], [FetchSchedule])
+        VALUES
+            ('Uw clubnaam', 'https://data.sportlink.com', 'APIKEY', 7, '0 0 4 * * *');
 END
 GO
 
+-- ============================================================
+-- Initiële referentie-/voorbeelddata voor de primaire club.
+--
+-- #598: alle onderstaande seeds geven [ClubCode] expliciet mee, gelezen uit dbo.AppSettings.
+-- Voorheen leunden ze op een DEFAULT-constraint met een clubnaam erin — dat brak de multi-club
+-- invariant én faalde op een verse dacpac-deploy waar die default niet bestaat.
+--
+-- Alles staat in dynamische SQL: op een pre-multi-club database bestaat de kolom [ClubCode] nog
+-- niet en zou een statische verwijzing de hele batch laten falen op naam-binding (vgl. #564).
+-- Op zulke databases zijn de tabellen al gevuld, dus de seeds worden overgeslagen.
+-- ============================================================
 -- Speeltijden: insert static reference data once
 IF NOT EXISTS (SELECT 1 FROM [dbo].[Speeltijden])
-BEGIN
-    INSERT INTO [dbo].[Speeltijden] ([Leeftijd], [Veldafmeting], [WedstrijdTotaal], [WedstrijdHelft], [WedstrijdRust])
-    VALUES
-        ('JO7',  0.25, 50,  20, 10),
-        ('JO8',  0.25, 50,  20, 10),
-        ('JO9',  0.25, 50,  20, 10),
-        ('JO10', 0.25, 65,  25, 15),
-        ('JO11', 0.50, 75,  30, 15),
-        ('JO12', 0.50, 75,  30, 15),
-        ('JO13', 1.00, 75,  30, 15),
-        ('JO14', 1.00, 85,  35, 15),
-        ('JO15', 1.00, 85,  35, 15),
-        ('JO16', 1.00, 95,  40, 15),
-        ('JO17', 1.00, 95,  40, 15),
-        ('JO18', 1.00, 105, 45, 15),
-        ('JO19', 1.00, 105, 45, 15),
-        ('JO23', 1.00, 105, 45, 15),
-        ('MO13', 1.00, 75,  30, 15),
-        ('MO15', 1.00, 85,  35, 15),
-        ('MO17', 1.00, 95,  40, 15),
-        ('MO19', 1.00, 105, 45, 15),
-        ('MO20', 1.00, 105, 45, 15),
-        ('VR',   1.00, 115, 45, 15),
-        ('G',    0.50, 75,  30, 15),
-        ('1-99', 1.00, 115, 45, 15)
-END
+   AND EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Speeltijden') AND name = 'ClubCode')
+    EXEC('
+    INSERT INTO [dbo].[Speeltijden] ([Leeftijd], [Veldafmeting], [WedstrijdTotaal], [WedstrijdHelft], [WedstrijdRust], [ClubCode])
+    SELECT v.[Leeftijd], v.[Veldafmeting], v.[WedstrijdTotaal], v.[WedstrijdHelft], v.[WedstrijdRust], a.[ClubCode]
+    FROM (VALUES
+        (''JO7'',  0.25, 50,  20, 10),
+        (''JO8'',  0.25, 50,  20, 10),
+        (''JO9'',  0.25, 50,  20, 10),
+        (''JO10'', 0.25, 65,  25, 15),
+        (''JO11'', 0.50, 75,  30, 15),
+        (''JO12'', 0.50, 75,  30, 15),
+        (''JO13'', 1.00, 75,  30, 15),
+        (''JO14'', 1.00, 85,  35, 15),
+        (''JO15'', 1.00, 85,  35, 15),
+        (''JO16'', 1.00, 95,  40, 15),
+        (''JO17'', 1.00, 95,  40, 15),
+        (''JO18'', 1.00, 105, 45, 15),
+        (''JO19'', 1.00, 105, 45, 15),
+        (''JO23'', 1.00, 105, 45, 15),
+        (''MO13'', 1.00, 75,  30, 15),
+        (''MO15'', 1.00, 85,  35, 15),
+        (''MO17'', 1.00, 95,  40, 15),
+        (''MO19'', 1.00, 105, 45, 15),
+        (''MO20'', 1.00, 105, 45, 15),
+        (''VR'',   1.00, 115, 45, 15),
+        (''G'',    0.50, 75,  30, 15),
+        (''1-99'', 1.00, 115, 45, 15)
+    ) AS v([Leeftijd], [Veldafmeting], [WedstrijdTotaal], [WedstrijdHelft], [WedstrijdRust])
+    CROSS APPLY (SELECT TOP 1 [ClubCode] FROM [dbo].[AppSettings] ORDER BY [ClubCode]) a;
+    ');
 GO
 
--- Velden: field definitions (ClubCode via DEFAULT 'VRC' — single-club initiële seed; bij multi-club handmatig per club inserten)
+-- Velden: voorbeeld-velddefinities voor de primaire club (bij multi-club handmatig per club inserten)
 IF NOT EXISTS (SELECT 1 FROM [dbo].[Velden])
-BEGIN
-    INSERT INTO [dbo].[Velden] ([VeldNummer], [VeldNaam], [VeldType], [HeeftKunstlicht], [Actief])
-    VALUES
-        (1, 'veld 1', 'kunstgras', 1, 1),
-        (2, 'veld 2', 'kunstgras', 1, 1),
-        (3, 'veld 3', 'kunstgras', 1, 1),
-        (4, 'veld 4', 'kunstgras', 1, 1),
-        (5, 'veld 5', 'natuurgras', 0, 1),
-        (6, 'veld 6', 'natuurgras', 0, 0)  -- niet functioneel
-END
+   AND EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Velden') AND name = 'ClubCode')
+    EXEC('
+    INSERT INTO [dbo].[Velden] ([VeldNummer], [VeldNaam], [VeldType], [HeeftKunstlicht], [Actief], [ClubCode])
+    SELECT v.[VeldNummer], v.[VeldNaam], v.[VeldType], v.[HeeftKunstlicht], v.[Actief], a.[ClubCode]
+    FROM (VALUES
+        (1, ''veld 1'', ''kunstgras'',  1, 1),
+        (2, ''veld 2'', ''kunstgras'',  1, 1),
+        (3, ''veld 3'', ''kunstgras'',  1, 1),
+        (4, ''veld 4'', ''kunstgras'',  1, 1),
+        (5, ''veld 5'', ''natuurgras'', 0, 1),
+        (6, ''veld 6'', ''natuurgras'', 0, 0)   -- niet functioneel
+    ) AS v([VeldNummer], [VeldNaam], [VeldType], [HeeftKunstlicht], [Actief])
+    CROSS APPLY (SELECT TOP 1 [ClubCode] FROM [dbo].[AppSettings] ORDER BY [ClubCode]) a;
+    ');
 GO
 
--- VeldBeschikbaarheid: field availability per day-of-week (ClubCode via DEFAULT 'VRC' — single-club initiële seed)
+-- VeldBeschikbaarheid: voorbeeld-beschikbaarheid per dag van de week
 -- DagVanWeek: 1=Monday, 2=Tuesday, ..., 6=Saturday, 7=Sunday
+-- Vrijdag (5) en zondag (7): geen rijen = geen wedstrijden
 IF NOT EXISTS (SELECT 1 FROM [dbo].[VeldBeschikbaarheid])
-BEGIN
-    -- Monday-Thursday (1-4): only veld 5, until sunset
-    INSERT INTO [dbo].[VeldBeschikbaarheid] ([VeldNummer], [DagVanWeek], [BeschikbaarVanaf], [BeschikbaarTot], [GebruikZonsondergang])
-    VALUES
-        (5, 1, '18:00', '22:00', 1),
-        (5, 2, '18:00', '22:00', 1),
-        (5, 3, '18:00', '22:00', 1),
-        (5, 4, '18:00', '22:00', 1)
-    -- Friday (5): no rows = no matches
-    -- Sunday (7): no rows = no matches
-
-    -- Saturday (6): all fields
-    INSERT INTO [dbo].[VeldBeschikbaarheid] ([VeldNummer], [DagVanWeek], [BeschikbaarVanaf], [BeschikbaarTot], [GebruikZonsondergang])
-    VALUES
-        (1, 6, '08:30', '22:00', 0),
-        (2, 6, '08:30', '22:00', 0),
-        (3, 6, '08:30', '22:00', 0),
-        (4, 6, '08:30', '22:00', 0),
-        (5, 6, '08:30', '17:00', 0)
-END
+   AND EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.VeldBeschikbaarheid') AND name = 'ClubCode')
+    EXEC('
+    INSERT INTO [dbo].[VeldBeschikbaarheid] ([VeldNummer], [DagVanWeek], [BeschikbaarVanaf], [BeschikbaarTot], [GebruikZonsondergang], [ClubCode])
+    SELECT v.[VeldNummer], v.[DagVanWeek], v.[BeschikbaarVanaf], v.[BeschikbaarTot], v.[GebruikZonsondergang], a.[ClubCode]
+    FROM (VALUES
+        -- maandag t/m donderdag: alleen veld 5, tot zonsondergang
+        (5, 1, ''18:00'', ''22:00'', 1),
+        (5, 2, ''18:00'', ''22:00'', 1),
+        (5, 3, ''18:00'', ''22:00'', 1),
+        (5, 4, ''18:00'', ''22:00'', 1),
+        -- zaterdag: alle velden
+        (1, 6, ''08:30'', ''22:00'', 0),
+        (2, 6, ''08:30'', ''22:00'', 0),
+        (3, 6, ''08:30'', ''22:00'', 0),
+        (4, 6, ''08:30'', ''22:00'', 0),
+        (5, 6, ''08:30'', ''17:00'', 0)
+    ) AS v([VeldNummer], [DagVanWeek], [BeschikbaarVanaf], [BeschikbaarTot], [GebruikZonsondergang])
+    CROSS APPLY (SELECT TOP 1 [ClubCode] FROM [dbo].[AppSettings] ORDER BY [ClubCode]) a;
+    ');
 GO
 
--- TeamRegels: team-specific scheduling exceptions (ClubCode via DEFAULT 'VRC' — single-club initiële seed)
+-- TeamRegels: voorbeeld-uitzonderingen voor het standaardteam van de primaire club.
+-- #598: de teamnaam wordt club-neutraal opgebouwd als "<ClubCode> 1" — nooit een hardcoded clubnaam.
 IF NOT EXISTS (SELECT 1 FROM [dbo].[TeamRegels])
-BEGIN
-    INSERT INTO [dbo].[TeamRegels] ([TeamNaam], [RegelType], [WaardeMinuten], [Prioriteit], [Actief], [Opmerking])
-    VALUES
-        ('VRC 1', 'BufferVoor', 60, 10, 1, '1 uur voor de wedstrijd geen andere wedstrijden op hetzelfde veld'),
-        ('VRC 1', 'BufferNa',   30, 10, 1, '30 min na de wedstrijd geen andere wedstrijden op hetzelfde veld')
-END
+   AND EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.TeamRegels') AND name = 'ClubCode')
+    EXEC('
+    INSERT INTO [dbo].[TeamRegels] ([TeamNaam], [RegelType], [WaardeMinuten], [Prioriteit], [Actief], [Opmerking], [ClubCode])
+    SELECT a.[ClubCode] + '' 1'', v.[RegelType], v.[WaardeMinuten], v.[Prioriteit], v.[Actief], v.[Opmerking], a.[ClubCode]
+    FROM (VALUES
+        (''BufferVoor'', 60, 10, 1, ''1 uur voor de wedstrijd geen andere wedstrijden op hetzelfde veld''),
+        (''BufferNa'',   30, 10, 1, ''30 min na de wedstrijd geen andere wedstrijden op hetzelfde veld'')
+    ) AS v([RegelType], [WaardeMinuten], [Prioriteit], [Actief], [Opmerking])
+    CROSS APPLY (SELECT TOP 1 [ClubCode] FROM [dbo].[AppSettings] ORDER BY [ClubCode]) a;
+    ');
 GO
 
 -- AppSettings: UseRealtimeApi kolom toevoegen (idempotent)
@@ -785,26 +818,27 @@ IF @SeasonStartMonth IS NOT NULL
 GO
 -- ============================================================
 -- #30: Multi-club fundament — ClubCode + Accommodatie
--- DEFAULT 'VRC' is uitsluitend voor migratie-backwards-compat (bestaande rijen krijgen hier een waarde).
+-- De DEFAULT is uitsluitend migratie-backwards-compat (bestaande rijen krijgen hier een waarde) en
+-- gebruikt de neutrale placeholder 'CLUB' — nooit een clubnaam (#598). Constraints worden hierna gedropt.
 -- Alle nieuwe inserts geven ClubCode altijd expliciet mee vanuit AppSettings.
 -- ============================================================
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.AppSettings') AND name = 'ClubCode')
-    ALTER TABLE [dbo].[AppSettings] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_AppSettings_ClubCode] DEFAULT 'VRC'; -- migratie-backwards-compat
+    ALTER TABLE [dbo].[AppSettings] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_AppSettings_ClubCode] DEFAULT 'CLUB'; -- neutrale placeholder, constraint wordt direct hierna gedropt (#598/#610)
 GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.AppSettings') AND name = 'Accommodatie')
     ALTER TABLE [dbo].[AppSettings] ADD [Accommodatie] NVARCHAR(200) NULL; -- geen default — in te stellen via Beheer → Instellingen per club
 GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Velden') AND name = 'ClubCode')
-    ALTER TABLE [dbo].[Velden] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_Velden_ClubCode] DEFAULT 'VRC'; -- migratie-backwards-compat
+    ALTER TABLE [dbo].[Velden] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_Velden_ClubCode] DEFAULT 'CLUB'; -- neutrale placeholder, constraint wordt direct hierna gedropt (#598/#610)
 GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Speeltijden') AND name = 'ClubCode')
-    ALTER TABLE [dbo].[Speeltijden] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_Speeltijden_ClubCode] DEFAULT 'VRC'; -- migratie-backwards-compat
+    ALTER TABLE [dbo].[Speeltijden] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_Speeltijden_ClubCode] DEFAULT 'CLUB'; -- neutrale placeholder, constraint wordt direct hierna gedropt (#598/#610)
 GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.TeamRegels') AND name = 'ClubCode')
-    ALTER TABLE [dbo].[TeamRegels] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_TeamRegels_ClubCode] DEFAULT 'VRC'; -- migratie-backwards-compat
+    ALTER TABLE [dbo].[TeamRegels] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_TeamRegels_ClubCode] DEFAULT 'CLUB'; -- neutrale placeholder, constraint wordt direct hierna gedropt (#598/#610)
 GO
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.VeldBeschikbaarheid') AND name = 'ClubCode')
-    ALTER TABLE [dbo].[VeldBeschikbaarheid] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_VeldBeschikbaarheid_ClubCode] DEFAULT 'VRC'; -- migratie-backwards-compat
+    ALTER TABLE [dbo].[VeldBeschikbaarheid] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_VeldBeschikbaarheid_ClubCode] DEFAULT 'CLUB'; -- neutrale placeholder, constraint wordt direct hierna gedropt (#598/#610)
 GO
 
 -- #435: verwijder VRC-default constraints — clubnaam heeft geen plek als DB-default
@@ -890,7 +924,7 @@ BEGIN
         [Veld]          NVARCHAR(100) NOT NULL,
         [OudeWaarde]    NVARCHAR(MAX) NULL,
         [NieuweWaarde]  NVARCHAR(MAX) NULL,
-        [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_AppSettingsAudit_ClubCode] DEFAULT 'VRC',
+        [ClubCode]      NVARCHAR(20) NOT NULL, -- geen DEFAULT: clubnaam hoort niet in het schema (#598)
         CONSTRAINT [PK_AppSettingsAudit] PRIMARY KEY CLUSTERED ([Id] ASC)
     );
 END
@@ -906,7 +940,7 @@ BEGIN
         [VoorkeurTijd]  TIME NOT NULL,
         [Prioriteit]    INT NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Prioriteit] DEFAULT 5,
         [Actief]        BIT NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Actief] DEFAULT 1,
-        [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_ClubCode] DEFAULT 'VRC',
+        [ClubCode]      NVARCHAR(20) NOT NULL, -- geen DEFAULT: clubnaam hoort niet in het schema (#598)
         [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Inserted] DEFAULT GETUTCDATE(),
         [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Modified] DEFAULT GETUTCDATE(),
         CONSTRAINT [PK_TeamVoorkeurTijden] PRIMARY KEY CLUSTERED ([Id] ASC)
@@ -922,7 +956,7 @@ BEGIN
         [EmailAdres]   NVARCHAR(200) NOT NULL,
         [Omschrijving] NVARCHAR(500) NULL,
         [Actief]       BIT NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Actief]    DEFAULT 1,
-        [ClubCode]     NVARCHAR(20) NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_ClubCode]  DEFAULT 'VRC',
+        [ClubCode]     NVARCHAR(20) NOT NULL, -- geen DEFAULT: clubnaam hoort niet in het schema (#598)
         [mta_inserted] DATETIME2 NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Inserted] DEFAULT GETUTCDATE(),
         CONSTRAINT [PK_UitgeslotenEmailAdressen] PRIMARY KEY CLUSTERED ([Id] ASC),
         CONSTRAINT [UQ_UitgeslotenEmailAdressen_Adres] UNIQUE ([EmailAdres], [ClubCode])
@@ -932,7 +966,7 @@ GO
 
 -- v2 — #119: ClubCode toevoegen aan planner.EmailVerwerking (multi-club isolatie email-log)
 IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('planner.EmailVerwerking') AND name = 'ClubCode')
-    ALTER TABLE [planner].[EmailVerwerking] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_EmailVerwerking_ClubCode] DEFAULT 'VRC';
+    ALTER TABLE [planner].[EmailVerwerking] ADD [ClubCode] NVARCHAR(20) NOT NULL CONSTRAINT [DF_EmailVerwerking_ClubCode] DEFAULT 'CLUB'; -- neutrale placeholder, constraint wordt bij #242 gedropt
 GO
 
 -- ============================================================
@@ -968,7 +1002,7 @@ END;
 END
 GO
 
--- #242: Verwijder club-specifieke DEFAULT 'VRC' uit EmailVerwerking.ClubCode
+-- #242: Verwijder de placeholder-DEFAULT uit EmailVerwerking.ClubCode
 IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_EmailVerwerking_ClubCode')
     ALTER TABLE [planner].[EmailVerwerking] DROP CONSTRAINT [DF_EmailVerwerking_ClubCode];
 GO
@@ -1158,7 +1192,7 @@ BEGIN
         [Onderwerp]     NVARCHAR(500) NOT NULL,
         [BodyTemplate]  NVARCHAR(MAX) NOT NULL,
         [Actief]        BIT NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Actief] DEFAULT 1,
-        [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_ClubCode] DEFAULT 'VRC',
+        [ClubCode]      NVARCHAR(20) NOT NULL, -- geen DEFAULT: clubnaam hoort niet in het schema (#598)
         [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Inserted] DEFAULT GETUTCDATE(),
         [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Modified] DEFAULT GETUTCDATE(),
         CONSTRAINT [PK_EmailTemplateInstellingen] PRIMARY KEY CLUSTERED ([Id] ASC),
@@ -1299,4 +1333,839 @@ SELECT
 FROM [planner].[GeplandeWedstrijden]
 WHERE [Status] <> 'Geannuleerd'
   AND [IsVervallen] = 0;
+GO
+
+-- ============================================================
+-- #598: verwijder de resterende club-specifieke DEFAULT-constraints op ClubCode.
+--
+-- Een clubnaam als DB-default breekt de multi-club architectuur voor elke fork. Deze vijf objecten
+-- zijn bij eerdere opschoonrondes (#435 voor Speeltijden/TeamRegels/VeldBeschikbaarheid/Velden,
+-- #242 voor EmailVerwerking) gemist. Patroon gelijk aan #242: DROP DEFAULT + CHECK (LEN > 0),
+-- zodat de NOT NULL-garantie blijft maar er geen waarde meer stilzwijgend wordt ingevuld.
+-- ============================================================
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_AppSettings_ClubCode')
+    ALTER TABLE [dbo].[AppSettings] DROP CONSTRAINT [DF_AppSettings_ClubCode];
+GO
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_AppSettingsAudit_ClubCode')
+    ALTER TABLE [dbo].[AppSettingsAudit] DROP CONSTRAINT [DF_AppSettingsAudit_ClubCode];
+GO
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_TeamVoorkeurTijden_ClubCode')
+    ALTER TABLE [dbo].[TeamVoorkeurTijden] DROP CONSTRAINT [DF_TeamVoorkeurTijden_ClubCode];
+GO
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_UitgeslotenEmailAdressen_ClubCode')
+    ALTER TABLE [dbo].[UitgeslotenEmailAdressen] DROP CONSTRAINT [DF_UitgeslotenEmailAdressen_ClubCode];
+GO
+IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_EmailTemplateInstellingen_ClubCode')
+    ALTER TABLE [dbo].[EmailTemplateInstellingen] DROP CONSTRAINT [DF_EmailTemplateInstellingen_ClubCode];
+GO
+
+-- Onbedoeld naamloze DEFAULT op dbo.AppSettings.ClubCode (uit de oudere ADD COLUMN-migratie zonder
+-- expliciete constraintnaam) — opzoeken via de kolom i.p.v. de naam.
+DECLARE @dfNaam SYSNAME = (
+    SELECT dc.name FROM sys.default_constraints dc
+    JOIN sys.columns c ON c.object_id = dc.parent_object_id AND c.column_id = dc.parent_column_id
+    WHERE dc.parent_object_id = OBJECT_ID('dbo.AppSettings') AND c.name = 'ClubCode');
+IF @dfNaam IS NOT NULL
+    EXEC('ALTER TABLE [dbo].[AppSettings] DROP CONSTRAINT [' + @dfNaam + ']');
+GO
+
+-- NOT NULL-garantie behouden zonder default: lege ClubCode expliciet verbieden.
+IF NOT EXISTS (SELECT 1 FROM sys.check_constraints WHERE name = 'CK_AppSettings_ClubCode')
+    ALTER TABLE [dbo].[AppSettings] ADD CONSTRAINT [CK_AppSettings_ClubCode] CHECK (LEN([ClubCode]) > 0);
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.check_constraints WHERE name = 'CK_AppSettingsAudit_ClubCode')
+    ALTER TABLE [dbo].[AppSettingsAudit] ADD CONSTRAINT [CK_AppSettingsAudit_ClubCode] CHECK (LEN([ClubCode]) > 0);
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.check_constraints WHERE name = 'CK_TeamVoorkeurTijden_ClubCode')
+    ALTER TABLE [dbo].[TeamVoorkeurTijden] ADD CONSTRAINT [CK_TeamVoorkeurTijden_ClubCode] CHECK (LEN([ClubCode]) > 0);
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.check_constraints WHERE name = 'CK_UitgeslotenEmailAdressen_ClubCode')
+    ALTER TABLE [dbo].[UitgeslotenEmailAdressen] ADD CONSTRAINT [CK_UitgeslotenEmailAdressen_ClubCode] CHECK (LEN([ClubCode]) > 0);
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.check_constraints WHERE name = 'CK_EmailTemplateInstellingen_ClubCode')
+    ALTER TABLE [dbo].[EmailTemplateInstellingen] ADD CONSTRAINT [CK_EmailTemplateInstellingen_ClubCode] CHECK (LEN([ClubCode]) > 0);
+GO
+
+-- ============================================================
+-- #595: tabellen die alleen in het DB-project (.sqlproj) bestonden en daardoor ontbraken op een
+-- verse deploy. De deploy-pipeline publiceerde nooit een dacpac, dus elk schema-object moet ook
+-- hier idempotent staan. Zonder deze guards faalden productiefuncties met "Invalid object name":
+--   - avg.ImportLog          — exports/import-teambegeleiding-to-sql.ps1, avg.sp_CleanupImportLog
+--   - planner.HerplanVerzoeken — PlannerMatchRepository.cs (mist bovendien ClubCode)
+--   - dbo.Zonsondergang      — AutoPlanService.cs e.a.
+-- Definities gelijk houden aan Database/{avg,planner,dbo}/Tables/*.sql.
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'avg')
+    EXEC('CREATE SCHEMA [avg]');
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('avg.ImportLog'))
+BEGIN
+    CREATE TABLE [avg].[ImportLog] (
+        [Id]               INT            IDENTITY (1, 1) NOT NULL,
+        [ImportDatum]      DATETIME       CONSTRAINT [DF_avg_ImportLog_ImportDatum] DEFAULT (GETUTCDATE()) NOT NULL,
+        [AantalRijen]      INT            NOT NULL,
+        [CsvBestand]       NVARCHAR (500) NULL,
+        [ImporterendeDoor] NVARCHAR (200) NULL,
+        [Duur_ms]          INT            NULL,
+        [ClubCode]         NVARCHAR (20)  NOT NULL CONSTRAINT [DF_avg_ImportLog_ClubCode] DEFAULT '',
+        CONSTRAINT [PK_avg_ImportLog] PRIMARY KEY CLUSTERED ([Id] ASC)
+    );
+END
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'planner')
+    EXEC('CREATE SCHEMA [planner]');
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('planner.HerplanVerzoeken'))
+BEGIN
+    CREATE TABLE [planner].[HerplanVerzoeken] (
+        [Id]                    INT            IDENTITY(1,1) NOT NULL,
+        [Wedstrijdcode]         BIGINT         NOT NULL,
+        [HuidigeWedstrijd]      NVARCHAR(200)  NOT NULL,
+        [HuidigeDatum]          DATE           NOT NULL,
+        [HuidigeAanvangsTijd]   TIME           NOT NULL,
+        [HuidigeVeldNaam]       NVARCHAR(50)   NULL,
+        [GewensteAanvangsTijd]  TIME           NOT NULL,
+        [GewenstVeldNummer]     INT            NULL,
+        [Status]                NVARCHAR(20)   NOT NULL CONSTRAINT [DF_HerplanVerzoeken_Status] DEFAULT 'Aangevraagd',
+        [AangevraagdDoor]       NVARCHAR(200)  NULL,
+        [Opmerking]             NVARCHAR(500)  NULL,
+        [mta_inserted]          DATETIME       NOT NULL CONSTRAINT [DF_HerplanVerzoeken_Ins] DEFAULT GETUTCDATE(),
+        [mta_modified]          DATETIME       NOT NULL CONSTRAINT [DF_HerplanVerzoeken_Mod] DEFAULT GETUTCDATE(),
+        CONSTRAINT [PK_HerplanVerzoeken] PRIMARY KEY CLUSTERED ([Id] ASC)
+    );
+END
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.Zonsondergang'))
+BEGIN
+    CREATE TABLE [dbo].[Zonsondergang] (
+        [Datum]         DATE  NOT NULL,
+        [Zonsondergang] TIME  NOT NULL,
+        CONSTRAINT [PK_Zonsondergang] PRIMARY KEY CLUSTERED ([Datum] ASC)
+    );
+END
+GO
+
+-- #595: ClubCode-discriminator op planner.HerplanVerzoeken (multi-club invariant).
+-- Zelfde nullable -> backfill -> NOT NULL patroon als planner.GeplandeWedstrijden (#428), en om
+-- dezelfde reden in aparte batches: SQL Server bindt kolomnamen bij batch-compilatie, dus DML die
+-- de nieuwe kolom noemt moet ná een GO staan (vgl. #564).
+IF NOT EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('planner.HerplanVerzoeken') AND name = 'ClubCode')
+    ALTER TABLE [planner].[HerplanVerzoeken] ADD [ClubCode] NVARCHAR(20) NULL;
+GO
+
+IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('planner.HerplanVerzoeken') AND name = 'ClubCode')
+   AND EXISTS (SELECT 1 FROM [planner].[HerplanVerzoeken] WHERE [ClubCode] IS NULL)
+    UPDATE [planner].[HerplanVerzoeken]
+    SET [ClubCode] = (SELECT TOP 1 [ClubCode] FROM [dbo].[AppSettings] WHERE [SyncEnabled] = 1)
+    WHERE [ClubCode] IS NULL;
+GO
+
+IF EXISTS (SELECT 1 FROM sys.columns
+           WHERE object_id = OBJECT_ID('planner.HerplanVerzoeken')
+             AND name = 'ClubCode' AND is_nullable = 1)
+   AND NOT EXISTS (SELECT 1 FROM [planner].[HerplanVerzoeken] WHERE [ClubCode] IS NULL)
+    ALTER TABLE [planner].[HerplanVerzoeken] ALTER COLUMN [ClubCode] NVARCHAR(20) NOT NULL;
+GO
+
+-- ============================================================
+-- #606: indexen op de his.*-tabellen (business key + ClubCode).
+--
+-- De his-tabellen zijn heaps: elke join/filter op de business key of ClubCode doet een full scan.
+-- Er is bovendien geen enkele schema-garantie tegen duplicaten als de MERGE ON-matching ooit
+-- misaligneert (type-cast/whitespace) — een stil datakwaliteitsrisico.
+--
+-- De unieke index wordt alleen aangemaakt als de data dat toestaat. De Sportlink /teams-feed
+-- levert aantoonbaar duplicaten (#569, nog open), en een mislukte CREATE UNIQUE INDEX zou de
+-- volledige deploy laten falen. Blijven er duplicaten staan, dan komt er een niet-unieke index —
+-- de performancewinst is er dan wel, en de uniciteit volgt zodra #569 is opgelost.
+-- ============================================================
+DECLARE @hisTabellen TABLE ([Tabel] SYSNAME, [Bk] SYSNAME);
+INSERT INTO @hisTabellen ([Tabel], [Bk]) VALUES
+    ('teams',        'bk_teams'),
+    ('matches',      'bk_matches'),
+    ('matchdetails', 'bk_WedstrijdCode');
+
+DECLARE @tabel SYSNAME, @bk SYSNAME, @sql NVARCHAR(MAX), @objId INT, @duplicaten INT;
+DECLARE hisCur CURSOR LOCAL FAST_FORWARD FOR SELECT [Tabel], [Bk] FROM @hisTabellen;
+OPEN hisCur;
+FETCH NEXT FROM hisCur INTO @tabel, @bk;
+
+WHILE @@FETCH_STATUS = 0
+BEGIN
+    SET @objId = OBJECT_ID('his.' + @tabel);
+
+    -- Alleen als de tabel én de business-key-kolom bestaan, en er nog geen bk-index is.
+    IF @objId IS NOT NULL
+       AND EXISTS (SELECT 1 FROM sys.columns WHERE object_id = @objId AND name = @bk)
+       AND NOT EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = @objId AND name = 'UQ_' + @tabel + '_bk')
+       AND NOT EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = @objId AND name = 'IX_' + @tabel + '_bk')
+    BEGIN
+        -- Duplicaten tellen; bepaalt of de index uniek kan zijn.
+        SET @sql = N'SELECT @cnt = COUNT(*) FROM (SELECT ' + QUOTENAME(@bk) +
+                   N' FROM [his].' + QUOTENAME(@tabel) +
+                   N' GROUP BY ' + QUOTENAME(@bk) + N' HAVING COUNT(*) > 1) d;';
+        EXEC sp_executesql @sql, N'@cnt INT OUTPUT', @cnt = @duplicaten OUTPUT;
+
+        IF @duplicaten = 0
+        BEGIN
+            SET @sql = N'CREATE UNIQUE NONCLUSTERED INDEX ' + QUOTENAME('UQ_' + @tabel + '_bk') +
+                       N' ON [his].' + QUOTENAME(@tabel) + N' (' + QUOTENAME(@bk) + N');';
+            EXEC sp_executesql @sql;
+            PRINT 'his.' + @tabel + ': unieke index op ' + @bk + ' aangemaakt.';
+        END
+        ELSE
+        BEGIN
+            SET @sql = N'CREATE NONCLUSTERED INDEX ' + QUOTENAME('IX_' + @tabel + '_bk') +
+                       N' ON [his].' + QUOTENAME(@tabel) + N' (' + QUOTENAME(@bk) + N');';
+            EXEC sp_executesql @sql;
+            PRINT 'his.' + @tabel + ': ' + CAST(@duplicaten AS VARCHAR(10)) +
+                  ' dubbele business keys gevonden (zie #569) — niet-unieke index aangemaakt.';
+        END
+    END
+
+    -- Ondersteunende index op ClubCode.
+    IF @objId IS NOT NULL
+       AND EXISTS (SELECT 1 FROM sys.columns WHERE object_id = @objId AND name = 'ClubCode')
+       AND NOT EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = @objId AND name = 'IX_' + @tabel + '_ClubCode')
+    BEGIN
+        SET @sql = N'CREATE NONCLUSTERED INDEX ' + QUOTENAME('IX_' + @tabel + '_ClubCode') +
+                   N' ON [his].' + QUOTENAME(@tabel) + N' ([ClubCode]);';
+        EXEC sp_executesql @sql;
+    END
+
+    FETCH NEXT FROM hisCur INTO @tabel, @bk;
+END
+
+CLOSE hisCur;
+DEALLOCATE hisCur;
+GO
+
+-- ============================================================
+-- #595 (uitbreiding): dbo.Season en mta.source_target_mapping ontbraken om dezelfde reden.
+--
+-- Gevonden door de nieuwe schema-drift check in .github/workflows/build.yml. Beide tabellen stonden
+-- alleen in het DB-project:
+--   - dbo.Season               — sp_UpdateSeasonTable doet alleen INSERT, maakt de tabel niet aan
+--   - mta.source_target_mapping — stuurt sp_CreateTargetTableFromSource + sp_MergeStgToHis; zonder
+--                                 deze tabel (of zonder rijen) doet de volledige ETL stilzwijgend niets
+--
+-- De seed-rijen stonden in Database/mta/Tables/source_target_mapping.sql uitsluitend als SQL-comment,
+-- dus zelfs een dacpac-publish liet de tabel leeg achter. De drie rijen hieronder zijn exact de
+-- configuratie die in productie draait. Alle waarden zijn clubneutraal.
+-- ============================================================
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.Season'))
+BEGIN
+    CREATE TABLE [dbo].[Season] (
+        [Name]      NCHAR(9) NULL,
+        [DateFrom]  DATE     NULL,
+        [DateUntil] DATE     NULL
+    );
+END
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = 'mta')
+    EXEC('CREATE SCHEMA [mta]');
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('mta.source_target_mapping'))
+BEGIN
+    CREATE TABLE [mta].[source_target_mapping] (
+        [Id]            INT IDENTITY(1,1) NOT NULL,
+        [source_type]   INT            NULL,
+        [source_root]   NVARCHAR(250)  NULL,
+        [source_schema] NVARCHAR(10)   NULL,
+        [source_entity] NVARCHAR(250)  NULL,
+        [source_pk]     NVARCHAR(250)  NULL,
+        [target_type]   INT            NULL,
+        [target_root]   NVARCHAR(250)  NULL,
+        [target_schema] NVARCHAR(10)   NULL,
+        [target_entity] NVARCHAR(250)  NULL,
+        [target_pk]     NVARCHAR(250)  NULL
+    );
+END
+GO
+
+-- Seed per rij idempotent: bestaande installaties houden hun eigen aanpassingen.
+INSERT INTO [mta].[source_target_mapping]
+    ([source_type], [source_root], [source_schema], [source_entity], [source_pk],
+     [target_type], [target_root], [target_schema], [target_entity], [target_pk])
+SELECT v.* FROM (VALUES
+    (0, 'SportlinkSqlDb', 'stg', 'teams',        '[teamcode],[lokaleteamcode],[poulecode]', 0, 'SportlinkSqlDb', 'his', 'teams',        'bk_teams NVARCHAR(100)'),
+    (0, 'SportlinkSqlDb', 'stg', 'matches',      '[wedstrijdcode]',                         0, 'SportlinkSqlDb', 'his', 'matches',      'bk_matches NVARCHAR(100)'),
+    (0, 'SportlinkSqlDb', 'stg', 'matchdetails', '[WedstrijdCode]',                         0, 'SportlinkSqlDb', 'his', 'matchdetails', 'bk_WedstrijdCode INT')
+) AS v([source_type], [source_root], [source_schema], [source_entity], [source_pk],
+       [target_type], [target_root], [target_schema], [target_entity], [target_pk])
+WHERE NOT EXISTS (
+    SELECT 1 FROM [mta].[source_target_mapping] m
+    WHERE m.[source_schema] = v.[source_schema] AND m.[source_entity] = v.[source_entity]
+      AND m.[target_schema] = v.[target_schema] AND m.[target_entity] = v.[target_entity]
+);
+GO
+
+-- ============================================================
+-- #595 (uitbreiding): stored procedures en views uit het DB-project.
+--
+-- Ook deze objecten stonden alleen in het DB-project en ontbraken dus volledig op een verse deploy.
+-- Dat trof de kern van de ETL: Script.PostDeployment1.sql riep dbo.sp_UpdateSeasonTable al aan
+-- zonder die procedure ooit aan te maken, en zonder sp_CreateTargetTableFromSource /
+-- sp_MergeStgToHis draait de hele Sportlink-pipeline niet.
+--
+-- Gevonden door de uitgebreide schema-drift check in .github/workflows/build.yml.
+--
+-- CREATE OR ALTER is idempotent en houdt de definitie gelijk aan de bronbestanden onder
+-- Database/. Wijzig een object dus altijd op BEIDE plekken, of genereer dit blok opnieuw.
+-- ============================================================
+
+-- Bron: Database/dbo/System Stored Procedures/sp_CreateDateTable.sql
+CREATE OR ALTER PROCEDURE [dbo].[sp_CreateDateTable]
+	@YearStart as int,
+	@YearEnd   as int 
+AS
+
+IF  EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[dbo].[DateTable]') AND type in (N'U'))
+	DROP TABLE [dbo].[DateTable]
+
+CREATE TABLE dbo.DateTable (
+    Date DATE PRIMARY KEY,
+    Day INT NOT NULL,
+    Month INT NOT NULL,
+    Year INT NOT NULL,
+    Quarter INT NOT NULL,
+    DayOfWeek INT NOT NULL, -- 1 = Monday, 7 = Sunday
+    DayName VARCHAR(10) NOT NULL,
+    MonthName VARCHAR(15) NOT NULL,
+	IsWeekend BIT NOT NULL
+);
+
+-- Populate the table with dates
+WITH RecursiveDates AS (
+    SELECT DATEFROMPARTS(@YearStart,1,1) AS Date -- Starting date
+    UNION ALL
+    SELECT DATEADD(DAY, 1, Date) 
+    FROM RecursiveDates
+    WHERE Date < DATEFROMPARTS(@YearEnd,12,31) -- Ending date
+)
+
+INSERT INTO dbo.DateTable (Date, Day, Month, Year, Quarter, DayOfWeek, DayName, MonthName, IsWeekend)
+SELECT
+    d.Date,
+    DAY(d.Date) AS Day,
+    MONTH(d.Date) AS Month,
+    YEAR(d.Date) AS Year,
+    DATEPART(QUARTER, d.Date) AS Quarter,
+    -- DATEPART(WEEKDAY) is afhankelijk van de sessie-instelling DATEFIRST (default 7 = zondag bij
+    -- us_english). Daardoor gaf de oude berekening Monday = 2 in plaats van de gedocumenteerde 1,
+    -- en markeerde IsWeekend vrijdag als weekend en zondag NIET als weekend.
+    -- DATEDIFF vanaf 1900-01-01 (een maandag) is DATEFIRST-onafhankelijk en dus deterministisch.
+    (DATEDIFF(DAY, '19000101', d.Date) % 7) + 1 AS DayOfWeek,
+    DATENAME(WEEKDAY, d.Date) AS DayName,
+    DATENAME(MONTH, d.Date) AS MonthName,
+    CASE WHEN ((DATEDIFF(DAY, '19000101', d.Date) % 7) + 1) IN (6, 7) THEN 1 ELSE 0 END AS IsWeekend
+FROM    RecursiveDates d
+OPTION (MAXRECURSION 0); -- Allows for recursive CTE to handle larger datasets
+GO
+
+-- Bron: Database/dbo/System Stored Procedures/sp_UpdateSeasonTable.sql
+CREATE OR ALTER PROCEDURE [dbo].[sp_UpdateSeasonTable]
+    @SeasonStartMonth INT
+AS
+BEGIN
+	DECLARE @YearStart INT;
+	DECLARE @YearEnd   INT;
+
+	-- No seasons found! Add last two seasons
+	IF (SELECT YEAR(MAX(DateUntil)) FROM [dbo].[Season]) IS NULL 
+	BEGIN
+		INSERT INTO [dbo].[Season]
+			(
+			[Name],
+			[DateFrom],
+			[DateUntil]
+			)
+		VALUES 
+			(
+			CONCAT(YEAR(GETDATE())-2,'-',YEAR(GETDATE())-1),
+			DATEFROMPARTS(YEAR(GETDATE())-2,@SeasonStartMonth,1),
+			EOMONTH(DATEFROMPARTS(YEAR(GETDATE())-1,@SeasonStartMonth-1,1))
+			),
+			(
+			CONCAT(YEAR(GETDATE())-1,'-',YEAR(GETDATE())),
+			DATEFROMPARTS(YEAR(GETDATE())-1,@SeasonStartMonth,1),
+			EOMONTH(DATEFROMPARTS(YEAR(GETDATE()),@SeasonStartMonth-1,1))
+			);
+	END
+
+	-- Create 2 months before start of a new season a new record in season table
+	IF (SELECT YEAR(MAX(DateUntil)) FROM [dbo].[Season]) <> YEAR(GETDATE()) +1
+		AND GETDATE() >= DATEFROMPARTS(YEAR(GETDATE()),@SeasonStartMonth-2,1)  
+	BEGIN
+		INSERT INTO [dbo].[Season]
+			(
+			[Name],
+			[DateFrom],
+			[DateUntil]
+			)
+		 VALUES 
+			(
+			CONCAT(YEAR(GETDATE()),'-',YEAR(GETDATE())+1),
+			DATEFROMPARTS(YEAR(GETDATE()),@SeasonStartMonth,1),
+			EOMONTH(DATEFROMPARTS(YEAR(GETDATE())+1,@SeasonStartMonth-1,1))
+			)
+	END;
+
+	-- Create a new DateTable based on the new start and enddate in seasons table
+	SELECT @YearStart = YEAR(MIN(DateFrom))  FROM [dbo].[Season];
+	SELECT @YearEnd   = YEAR(MAX(DateUntil)) FROM [dbo].[Season];
+	EXEC [dbo].[sp_CreateDateTable] @YearStart, @YearEnd;
+END;
+GO
+
+-- Bron: Database/dbo/System Stored Procedures/sp_CreateTargetTableFromSource.sql
+CREATE OR ALTER PROCEDURE [dbo].[sp_CreateTargetTableFromSource]
+	@SourceSchema NVARCHAR(128),
+	@SourceName   NVARCHAR(128),
+	@TargetSchema NVARCHAR(128),
+	@TargetName   NVARCHAR(128)
+AS
+BEGIN
+	/*
+	version | date			| name					| description
+	1.0		| 12-01-2025	| Jaap van Beusekom		| Initial setup
+	1.1		| 2025			| Jaap van Beusekom		| Fixed target table name using @TargetName instead of @SourceName
+	*/
+
+	IF NOT EXISTS (SELECT * FROM sys.objects WHERE object_id = OBJECT_ID(N'[' + @TargetSchema + '].[' + @TargetName +']') AND type in (N'U'))
+	BEGIN
+		SET NOCOUNT ON;
+		DECLARE @SqlString NVARCHAR(MAX) = 'CREATE TABLE ' + QUOTENAME(@TargetSchema) + '.' + QUOTENAME(@TargetName) + ' (';
+
+		-- Fetch the primary key field from the mapping table
+		DECLARE @MtaTargetKey NVARCHAR(128);
+    
+		SELECT @MtaTargetKey = stm.target_pk
+		  FROM mta.source_target_mapping stm
+		 WHERE stm.source_entity = @SourceName 
+		   AND stm.source_schema = @SourceSchema 
+		   AND stm.target_entity = @TargetName
+		   AND stm.target_schema = @TargetSchema;
+
+		-- Add keyfield if exist at first
+		IF @MtaTargetKey IS NOT NULL
+			SET @SqlString += '' + @MtaTargetKey + ' NOT NULL,'		
+
+		-- Fetch metadata sourcetable columns
+		SELECT @SqlString += 
+			QUOTENAME(c.name) + ' ' + 
+			t.name + 
+			CASE 
+			WHEN t.name IN ('varchar', 'nvarchar', 'char', 'nchar') 
+			THEN '(' + 
+				CASE 
+				WHEN c.max_length = -1 THEN 'MAX' 
+				WHEN t.name IN ('nvarchar','nchar') THEN CAST(c.max_length / 2 AS VARCHAR) 
+				ELSE CAST(c.max_length AS VARCHAR) 
+				END + ')'
+			ELSE '' 
+			END + ' ' +
+			CASE WHEN c.is_nullable = 1 THEN 'NULL' ELSE 'NOT NULL' END + ', '
+		FROM sys.tables st
+		INNER JOIN sys.schemas ss ON ss.schema_id = st.schema_id
+		INNER JOIN sys.all_columns c ON c.object_id = st.object_id
+		LEFT JOIN sys.types t ON c.user_type_id = t.user_type_id
+		WHERE ss.name = @SourceSchema 
+		  AND st.name = @SourceName;
+
+		-- Add additional metadata columns
+		SET @SqlString += '
+			mta_inserted DATETIME NULL,
+			mta_modified DATETIME NULL,
+			mta_deleted  DATETIME NULL
+		);';
+
+		-- Execute this SQL command
+		EXEC sp_executesql @SqlString;
+		-- Output the generated SQL for verification
+		-- PRINT @SqlString;
+
+		/*
+			#606: index op de business key en op ClubCode.
+
+			Zonder index doet elke join/filter op de business key of ClubCode een full heap scan, en
+			niets in het schema voorkomt duplicaten als de MERGE ON-matching ooit misaligneert.
+
+			De business-key-index is UNIEK omdat de tabel hier net leeg is aangemaakt — dat kan dus
+			niet falen. Voor bestaande tabellen gebeurt hetzelfde in Script.PostDeployment1.sql, daar
+			wél voorwaardelijk: de Sportlink-feed levert aantoonbaar duplicaten (#569), en een
+			mislukte CREATE UNIQUE INDEX zou de hele deploy laten falen.
+
+			@MtaTargetKey heeft de vorm 'kolomnaam DATATYPE' — zelfde parsing als sp_MergeStgToHis.
+		*/
+		IF @MtaTargetKey IS NOT NULL
+		BEGIN
+			DECLARE @BkColumn NVARCHAR(128) =
+				CASE WHEN CHARINDEX(' ', @MtaTargetKey) > 0
+					 THEN LEFT(@MtaTargetKey, CHARINDEX(' ', @MtaTargetKey) - 1)
+					 ELSE @MtaTargetKey END;
+
+			DECLARE @IndexSql NVARCHAR(MAX) =
+				'CREATE UNIQUE NONCLUSTERED INDEX ' + QUOTENAME('UQ_' + @TargetName + '_bk') +
+				' ON ' + QUOTENAME(@TargetSchema) + '.' + QUOTENAME(@TargetName) +
+				' (' + QUOTENAME(@BkColumn) + ');';
+			EXEC sp_executesql @IndexSql;
+		END
+
+		-- Ondersteunende index op ClubCode voor his-tabellen die de discriminator hebben.
+		IF EXISTS (SELECT 1 FROM sys.columns
+				   WHERE object_id = OBJECT_ID(QUOTENAME(@TargetSchema) + '.' + QUOTENAME(@TargetName))
+					 AND name = 'ClubCode')
+		BEGIN
+			DECLARE @ClubIndexSql NVARCHAR(MAX) =
+				'CREATE NONCLUSTERED INDEX ' + QUOTENAME('IX_' + @TargetName + '_ClubCode') +
+				' ON ' + QUOTENAME(@TargetSchema) + '.' + QUOTENAME(@TargetName) +
+				' ([ClubCode]);';
+			EXEC sp_executesql @ClubIndexSql;
+		END
+	END
+	--ELSE
+	--BEGIN
+	--	PRINT '[' + @TargetSchema + '].[' + @TargetName +'] already exists'
+	--END
+END;
+GO
+
+-- Bron: Database/dbo/System Stored Procedures/sp_MergeStgToHis.sql
+CREATE OR ALTER PROCEDURE [dbo].[sp_MergeStgToHis]
+    @SourceSchema nvarchar(128),
+    @SourceName   nvarchar(128),
+    @TargetSchema nvarchar(128),
+    @TargetName   nvarchar(128)
+AS
+BEGIN
+    /*
+    version | date       | name              | description
+    1.0     | 12-01-2025 | Jaap van Beusekom | Initial setup
+    1.1     | 25-01-2025 | Jaap van Beusekom | NULL handling for non-string columns using CAST AS NVARCHAR(MAX)
+    1.2     | 2025       | Jaap van Beusekom | Multi-column business key support using CONCAT
+    */
+    SET NOCOUNT ON;
+    -- Create the target table from source structure if it does not yet exist
+    EXECUTE [dbo].[sp_CreateTargetTableFromSource] @SourceSchema, @SourceName, @TargetSchema, @TargetName;
+
+    DECLARE @ColName        NVARCHAR(MAX);
+    DECLARE @Index          INT = 1;
+    DECLARE @SqlString      NVARCHAR(MAX) = '';
+    DECLARE @SqlStringTmp   NVARCHAR(MAX) = '';
+
+    SET @SqlString +=
+'MERGE [' + @TargetSchema + '].[' + @TargetName + '] AS target
+USING [' + @SourceSchema + '].[' + @SourceName + '] AS source
+';
+    -- Retrieve primary key columns and target key definition from metadata
+    DECLARE @SourcePk       VARCHAR(255);
+    DECLARE @SourcePkColumns VARCHAR(MAX);
+    DECLARE @TargetPk       VARCHAR(255);
+    DECLARE @TargetPkFull   VARCHAR(255);
+
+    SELECT @SourcePk     = source_pk
+         , @TargetPkFull = target_pk
+      FROM mta.source_target_mapping
+     WHERE source_entity = @SourceName
+       AND source_schema = @SourceSchema
+       AND target_schema = @TargetSchema
+       AND target_entity = @TargetName;
+
+    -- Extract just the column name from target_pk (format: 'columnname DATATYPE')
+    IF @TargetPkFull IS NOT NULL
+    BEGIN
+        IF CHARINDEX(' ', @TargetPkFull) > 0
+            SET @TargetPk = LTRIM(RTRIM(SUBSTRING(@TargetPkFull, 1, CHARINDEX(' ', @TargetPkFull) - 1)));
+        ELSE
+            SET @TargetPk = @TargetPkFull;
+    END
+    ELSE
+        SET @TargetPk = 'bk_' + @TargetName;
+
+    IF @SourcePk IS NULL
+        RETURN;
+
+    -- Build the ON clause using source PK columns, casting to NVARCHAR to support any data type
+    DECLARE @ColNames TABLE (ColName NVARCHAR(MAX));
+    INSERT INTO @ColNames (ColName)
+        SELECT TRIM(value) FROM STRING_SPLIT(@SourcePk, ',');
+
+    WHILE EXISTS (SELECT 1 FROM @ColNames WHERE ColName IS NOT NULL)
+    BEGIN
+        SELECT TOP 1 @ColName = ColName FROM @ColNames WHERE ColName IS NOT NULL;
+        IF @Index = 1
+        BEGIN
+            SET @SqlString +=
+'ON ISNULL(CAST(target.' + @ColName + ' AS NVARCHAR(MAX)), '''') = ISNULL(CAST(source.' + @ColName + ' AS NVARCHAR(MAX)), '''') ';
+            SET @SourcePkColumns = 'source.' + @ColName + ' ';
+        END
+        ELSE
+        BEGIN
+            SET @SqlString +=
+'AND ISNULL(CAST(target.' + @ColName + ' AS NVARCHAR(MAX)), '''') = ISNULL(CAST(source.' + @ColName + ' AS NVARCHAR(MAX)), '''') ';
+            SET @SourcePkColumns += ', source.' + @ColName + ' ';
+        END
+        DELETE FROM @ColNames WHERE ColName = @ColName;
+        SET @Index += 1;
+    END
+
+    SET @SqlString += '
+WHEN MATCHED AND (';
+
+    -- Build all source columns and non-PK source columns
+    DECLARE @SourceTableColumns TABLE (TableColumn NVARCHAR(MAX));
+    INSERT INTO @SourceTableColumns (TableColumn)
+        SELECT '[' + c.name + ']'
+        FROM sys.tables st
+        INNER JOIN sys.schemas ss ON ss.schema_id = st.schema_id
+        INNER JOIN sys.all_columns c ON c.object_id = st.object_id
+        WHERE ss.name = @SourceSchema AND st.name = @SourceName;
+
+    DECLARE @SourceTableColumnsNoPk TABLE (TableColumn NVARCHAR(MAX));
+    INSERT INTO @SourceTableColumnsNoPk (TableColumn)
+        SELECT '[' + c.name + ']'
+        FROM sys.tables st
+        INNER JOIN sys.schemas ss ON ss.schema_id = st.schema_id
+        INNER JOIN sys.all_columns c ON c.object_id = st.object_id
+        WHERE ss.name = @SourceSchema AND st.name = @SourceName
+          AND '[' + c.name + ']' NOT IN (SELECT '[' + TRIM(value) + ']' FROM STRING_SPLIT(@SourcePk, ','));
+
+    -- Build the WHEN MATCHED condition and UPDATE SET clause
+    SET @Index = 1;
+    WHILE EXISTS (SELECT 1 FROM @SourceTableColumnsNoPk WHERE TableColumn IS NOT NULL)
+    BEGIN
+        SELECT TOP 1 @ColName = TableColumn FROM @SourceTableColumnsNoPk WHERE TableColumn IS NOT NULL;
+        IF @Index = 1
+        BEGIN
+            SET @SqlString  += '
+    COALESCE(CAST(target.' + @ColName + ' AS NVARCHAR(MAX)), '''') <> COALESCE(CAST(source.' + @ColName + ' AS NVARCHAR(MAX)), '''') ';
+            SET @SqlStringTmp += '
+    target.' + @ColName + ' = source.' + @ColName + ',';
+        END
+        ELSE
+        BEGIN
+            SET @SqlString  += '
+ OR COALESCE(CAST(target.' + @ColName + ' AS NVARCHAR(MAX)), '''') <> COALESCE(CAST(source.' + @ColName + ' AS NVARCHAR(MAX)), '''') ';
+            SET @SqlStringTmp += '
+    target.' + @ColName + ' = source.' + @ColName + ',';
+        END
+        DELETE FROM @SourceTableColumnsNoPk WHERE TableColumn = @ColName;
+        SET @Index += 1;
+    END
+
+    SET @SqlString += ')
+THEN UPDATE SET '
+        + @SqlStringTmp + '
+    target.mta_modified = GETUTCDATE()';
+
+    SET @SqlString += '
+WHEN NOT MATCHED BY TARGET THEN ';
+
+    -- Build the INSERT column list and VALUES for new records
+    DECLARE @SqlStringTargets NVARCHAR(MAX) = '';
+    DECLARE @SqlStringValues  NVARCHAR(MAX) = '';
+
+    WHILE EXISTS (SELECT 1 FROM @SourceTableColumns WHERE TableColumn IS NOT NULL)
+    BEGIN
+        SELECT TOP 1 @ColName = TableColumn FROM @SourceTableColumns WHERE TableColumn IS NOT NULL;
+        SET @SqlStringTargets += ', ' + @ColName;
+        SET @SqlStringValues  += ', source.' + @ColName;
+        DELETE FROM @SourceTableColumns WHERE TableColumn = @ColName;
+    END
+
+    -- CONCAT supports both single and multi-column source keys
+    SET @SqlString += '
+INSERT (' + @TargetPk + @SqlStringTargets + ', mta_inserted, mta_modified)
+VALUES (CONCAT('''', ' + @SourcePkColumns + ')' + @SqlStringValues + ', GETUTCDATE(), GETUTCDATE());';
+
+    EXEC sp_executesql @SqlString;
+
+    PRINT 'Merged ' + @SourceName + ' into ' + @TargetName;
+END;
+GO
+
+-- Bron: Database/pub/Views/DateTable.sql
+CREATE OR ALTER VIEW [pub].[DateTable]
+	AS 
+SELECT dt.[Date]
+      ,dt.[Day]
+      ,dt.[Month]
+      ,dt.[Year]
+      ,dt.[Quarter]
+      ,dt.[DayOfWeek]
+      ,dt.[DayName]
+      ,dt.[MonthName]
+      ,dt.[IsWeekend]
+	  ,s.Name           As Season
+  FROM [dbo].[DateTable] dt
+  INNER JOIN [dbo].[Season] s
+	ON dt.Date BETWEEN s.DateFrom AND s.DateUntil;
+GO
+
+-- Bron: Database/pub/Views/Teams.sql
+CREATE OR ALTER VIEW [pub].[Teams]
+	AS 
+SELECT [bk_teams]			AS [TeamBk]
+      ,[teamcode]			AS [TeamCode]
+      ,[lokaleteamcode]		AS [TeamCodeLokaal]
+      ,[teamnaam]			AS [TeamNaam]
+      ,[teamsoort]			AS [TeamSoort]
+      ,[geslacht]			AS [Geslacht]
+      ,[leeftijdscategorie]	AS [LeeftijdsCategorie]
+      ,[competitiesoort]	AS [CompetitieSoort]
+      ,[competitienaam]		AS [CompetitieNaam]
+      ,[klasse]				AS [CompetitieKlasse]
+      ,[poule]				AS [Poule]
+      ,[klassepoule]		AS [PouleKlasse]
+      ,[poulecode]			AS [PouleCode]
+      ,[spelsoort]			AS [SpelSoort]
+      ,[speeldag]			AS [Speeldag]
+      ,[ClubCode]			AS [ClubCode]
+  FROM [his].[teams];
+GO
+
+-- Bron: Database/pub/Views/Matches.sql
+CREATE OR ALTER VIEW [pub].[Matches]
+	AS 
+SELECT m.[wedstrijdcode]					AS WedstrijdCode
+	,tt.teamnaam							AS VerenigingsTeam
+	,md.Categorie							AS CompetitieCategorie
+	,m.[competitienaam]						AS CompetitieNaam
+	,m.[competitiesoort]					AS CompetitieSoort
+	,md.[PouleCode]							AS CompetitiePouleCode
+	,m.[wedstrijdnummer]					AS WedstrijdNummer
+	,m.[wedstrijd]							AS Wedstrijd
+	,md.[WedstrijdType]						AS WestrijdType
+	,CAST(m.[datum] AS date)				AS WedstrijdDatum
+	,CAST(m.[aanvangstijd] AS time)			AS WedstrijdAanvangsTijd
+	,md.[Duration]							AS WestrijdDuur
+	,m.[status]								AS WedstrijdStatus
+	,md.[VeldNaam]							AS VeldNaam
+	,md.[VeldLocatie]						AS VeldLocatie
+	,m.[thuisteam]							AS TeamThuis
+	,m.[thuisteamid]						AS TeamThuisId
+	,m.[uitteam]							AS TeamUit
+	,m.[uitteamid]							AS TeamUitId
+	,m.[uitslag]							AS Uitslag
+	,m.[uitslag-regulier]					AS UitslagRegulier
+	,m.[uitslag-nv]							AS UitslagNv
+	,m.[uitslag-s]							AS UitslagS
+	,md.[ThuisScore]						AS UitslagThuisScore
+	,md.[ThuisScoreRegulier]				AS UitslagThuisScoreRegulier
+	,md.[ThuisScoreNV]						AS UitslagThuisScoreNv
+	,md.[ThuisScoreS]						AS UitslagThuisScoreS
+	,md.[UitScore]							AS UitslagUitScore
+	,md.[UitScoreRegulier]					AS UitslagUitScoreRegulier
+	,md.[UitScoreNV]						AS UitslagUitScoreNv
+	,md.[UitScoreS]							AS UitslagUitScoreS
+	,m.[verenigingswedstrijd]				AS IsVerenigingsWedstrijd
+	,'Thuis'								AS IsThuisUitWedstrijd
+	,md.[Opmerkingen]						AS DivOpmerkingen
+	,md.[VerenigingScheidsrechterCode]		AS DivOfficialScheidsrechterCode
+	,md.[VerenigingScheidsrechter]			AS DivOfficialScheidsrechter
+	,md.[OverigeOfficialCode]				AS DivOfficialOverigeCode
+	,md.[OverigeOfficial]					AS DivOfficialOverige
+	,m.[ClubCode]							AS ClubCode
+FROM [his].[matches] m
+LEFT JOIN [his].[matchdetails] md ON CAST(md.InternCode AS bigint)=CAST(m.wedstrijdcode AS bigint)
+LEFT JOIN [his].[teams] tt ON tt.teamcode = m.thuisteamid AND (LEFT(tt.competitienaam,6) = LEFT(md.competitietype,6) OR md.PouleCode=tt.poulecode)
+WHERE tt.teamnaam IS NOT NULL
+
+UNION ALL
+
+SELECT m.[wedstrijdcode]					AS WedstrijdCode
+	,tu.teamnaam							AS VerenigingsTeam
+	,md.Categorie							AS CompetitieCategorie
+	,m.[competitienaam]						AS CompetitieNaam
+	,m.[competitiesoort]					AS CompetitieSoort
+	,md.[PouleCode]							AS CompetitiePouleCode
+	,m.[wedstrijdnummer]					AS WedstrijdNummer
+	,m.[wedstrijd]							AS Wedstrijd
+	,md.[WedstrijdType]						AS WestrijdType
+	,CAST(m.[datum] AS date)				AS WedstrijdDatum
+	,CAST(m.[aanvangstijd] AS time)			AS WedstrijdAanvangsTijd
+	,md.[Duration]							AS WestrijdDuur
+	,m.[status]								AS WedstrijdStatus
+	,md.[VeldNaam]							AS VeldNaam
+	,md.[VeldLocatie]						AS VeldLocatie
+	,m.[thuisteam]							AS TeamThuis
+	,m.[thuisteamid]						AS TeamThuisId
+	,m.[uitteam]							AS TeamUit
+	,m.[uitteamid]							AS TeamUitId
+	,m.[uitslag]							AS Uitslag
+	,m.[uitslag-regulier]					AS UitslagRegulier
+	,m.[uitslag-nv]							AS UitslagNv
+	,m.[uitslag-s]							AS UitslagS
+	,md.[ThuisScore]						AS UitslagThuisScore
+	,md.[ThuisScoreRegulier]				AS UitslagThuisScoreRegulier
+	,md.[ThuisScoreNV]						AS UitslagThuisScoreNv
+	,md.[ThuisScoreS]						AS UitslagThuisScoreS
+	,md.[UitScore]							AS UitslagUitScore
+	,md.[UitScoreRegulier]					AS UitslagUitScoreRegulier
+	,md.[UitScoreNV]						AS UitslagUitScoreNv
+	,md.[UitScoreS]							AS UitslagUitScoreS
+	,m.[verenigingswedstrijd]				AS IsVerenigingsWedstrijd
+	,'Uit'								AS IsThuisUitWedstrijd
+	,md.[Opmerkingen]						AS DivOpmerkingen
+	,md.[VerenigingScheidsrechterCode]		AS DivOfficialScheidsrechterCode
+	,md.[VerenigingScheidsrechter]			AS DivOfficialScheidsrechter
+	,md.[OverigeOfficialCode]				AS DivOfficialOverigeCode
+	,md.[OverigeOfficial]					AS DivOfficialOverige
+	,m.[ClubCode]							AS ClubCode
+  FROM [his].[matches] m
+  LEFT JOIN [his].[matchdetails] md ON CAST(md.InternCode AS bigint)=CAST(m.wedstrijdcode AS bigint)
+  LEFT JOIN [his].[teams] tu ON tu.teamcode = m.uitteamid   AND (LEFT(tu.competitienaam,6) = LEFT(md.competitietype,6) OR md.PouleCode=tu.poulecode)
+  WHERE tu.teamnaam IS NOT NULL
+
+  UNION ALL
+
+  SELECT m.[wedstrijdcode]					AS WedstrijdCode
+	,tu.teamnaam							AS VerenigingsTeam
+	,md.Categorie							AS CompetitieCategorie
+	,m.[competitienaam]						AS CompetitieNaam
+	,m.[competitiesoort]					AS CompetitieSoort
+	,md.[PouleCode]							AS CompetitiePouleCode
+	,m.[wedstrijdnummer]					AS WedstrijdNummer
+	,m.[wedstrijd]							AS Wedstrijd
+	,md.[WedstrijdType]						AS WestrijdType
+	,CAST(m.[datum] AS date)				AS WedstrijdDatum
+	,CAST(m.[aanvangstijd] AS time)			AS WedstrijdAanvangsTijd
+	,md.[Duration]							AS WestrijdDuur
+	,m.[status]								AS WedstrijdStatus
+	,md.[VeldNaam]							AS VeldNaam
+	,md.[VeldLocatie]						AS VeldLocatie
+	,m.[thuisteam]							AS TeamThuis
+	,m.[thuisteamid]						AS TeamThuisId
+	,m.[uitteam]							AS TeamUit
+	,m.[uitteamid]							AS TeamUitId
+	,m.[uitslag]							AS Uitslag
+	,m.[uitslag-regulier]					AS UitslagRegulier
+	,m.[uitslag-nv]							AS UitslagNv
+	,m.[uitslag-s]							AS UitslagS
+	,md.[ThuisScore]						AS UitslagThuisScore
+	,md.[ThuisScoreRegulier]				AS UitslagThuisScoreRegulier
+	,md.[ThuisScoreNV]						AS UitslagThuisScoreNv
+	,md.[ThuisScoreS]						AS UitslagThuisScoreS
+	,md.[UitScore]							AS UitslagUitScore
+	,md.[UitScoreRegulier]					AS UitslagUitScoreRegulier
+	,md.[UitScoreNV]						AS UitslagUitScoreNv
+	,md.[UitScoreS]							AS UitslagUitScoreS
+	,m.[verenigingswedstrijd]				AS IsVerenigingsWedstrijd
+	,NULL								    AS IsThuisUitWedstrijd
+	,md.[Opmerkingen]						AS DivOpmerkingen
+	,md.[VerenigingScheidsrechterCode]		AS DivOfficialScheidsrechterCode
+	,md.[VerenigingScheidsrechter]			AS DivOfficialScheidsrechter
+	,md.[OverigeOfficialCode]				AS DivOfficialOverigeCode
+	,md.[OverigeOfficial]					AS DivOfficialOverige
+	,m.[ClubCode]							AS ClubCode
+  FROM [his].[matches] m
+  LEFT JOIN [his].[matchdetails] md ON CAST(md.InternCode AS bigint)=CAST(m.wedstrijdcode AS bigint)
+  LEFT JOIN [his].[teams] tt ON tt.teamcode = m.thuisteamid AND (LEFT(tt.competitienaam,6) = LEFT(md.competitietype,6) OR md.PouleCode=tt.poulecode)
+  LEFT JOIN [his].[teams] tu ON tu.teamcode = m.uitteamid   AND (LEFT(tu.competitienaam,6) = LEFT(md.competitietype,6) OR md.PouleCode=tu.poulecode)
+  WHERE tt.teamnaam IS NULL
+	AND tu.teamnaam IS NULL
 GO

--- a/Database/dbo/System Stored Procedures/sp_CreateDateTable.sql
+++ b/Database/dbo/System Stored Procedures/sp_CreateDateTable.sql
@@ -34,10 +34,14 @@ SELECT
     MONTH(d.Date) AS Month,
     YEAR(d.Date) AS Year,
     DATEPART(QUARTER, d.Date) AS Quarter,
-    DATEPART(WEEKDAY, d.Date) AS DayOfWeek,
+    -- DATEPART(WEEKDAY) is afhankelijk van de sessie-instelling DATEFIRST (default 7 = zondag bij
+    -- us_english). Daardoor gaf de oude berekening Monday = 2 in plaats van de gedocumenteerde 1,
+    -- en markeerde IsWeekend vrijdag als weekend en zondag NIET als weekend.
+    -- DATEDIFF vanaf 1900-01-01 (een maandag) is DATEFIRST-onafhankelijk en dus deterministisch.
+    (DATEDIFF(DAY, '19000101', d.Date) % 7) + 1 AS DayOfWeek,
     DATENAME(WEEKDAY, d.Date) AS DayName,
     DATENAME(MONTH, d.Date) AS MonthName,
-    CASE WHEN DATEPART(WEEKDAY, d.Date) IN (6, 7) THEN 1 ELSE 0 END AS IsWeekend
+    CASE WHEN ((DATEDIFF(DAY, '19000101', d.Date) % 7) + 1) IN (6, 7) THEN 1 ELSE 0 END AS IsWeekend
 FROM    RecursiveDates d
 OPTION (MAXRECURSION 0); -- Allows for recursive CTE to handle larger datasets
 

--- a/Database/dbo/System Stored Procedures/sp_CreateTargetTableFromSource.sql
+++ b/Database/dbo/System Stored Procedures/sp_CreateTargetTableFromSource.sql
@@ -63,7 +63,46 @@ BEGIN
 		EXEC sp_executesql @SqlString;
 		-- Output the generated SQL for verification
 		-- PRINT @SqlString;
-	END	
+
+		/*
+			#606: index op de business key en op ClubCode.
+
+			Zonder index doet elke join/filter op de business key of ClubCode een full heap scan, en
+			niets in het schema voorkomt duplicaten als de MERGE ON-matching ooit misaligneert.
+
+			De business-key-index is UNIEK omdat de tabel hier net leeg is aangemaakt — dat kan dus
+			niet falen. Voor bestaande tabellen gebeurt hetzelfde in Script.PostDeployment1.sql, daar
+			wél voorwaardelijk: de Sportlink-feed levert aantoonbaar duplicaten (#569), en een
+			mislukte CREATE UNIQUE INDEX zou de hele deploy laten falen.
+
+			@MtaTargetKey heeft de vorm 'kolomnaam DATATYPE' — zelfde parsing als sp_MergeStgToHis.
+		*/
+		IF @MtaTargetKey IS NOT NULL
+		BEGIN
+			DECLARE @BkColumn NVARCHAR(128) =
+				CASE WHEN CHARINDEX(' ', @MtaTargetKey) > 0
+					 THEN LEFT(@MtaTargetKey, CHARINDEX(' ', @MtaTargetKey) - 1)
+					 ELSE @MtaTargetKey END;
+
+			DECLARE @IndexSql NVARCHAR(MAX) =
+				'CREATE UNIQUE NONCLUSTERED INDEX ' + QUOTENAME('UQ_' + @TargetName + '_bk') +
+				' ON ' + QUOTENAME(@TargetSchema) + '.' + QUOTENAME(@TargetName) +
+				' (' + QUOTENAME(@BkColumn) + ');';
+			EXEC sp_executesql @IndexSql;
+		END
+
+		-- Ondersteunende index op ClubCode voor his-tabellen die de discriminator hebben.
+		IF EXISTS (SELECT 1 FROM sys.columns
+				   WHERE object_id = OBJECT_ID(QUOTENAME(@TargetSchema) + '.' + QUOTENAME(@TargetName))
+					 AND name = 'ClubCode')
+		BEGIN
+			DECLARE @ClubIndexSql NVARCHAR(MAX) =
+				'CREATE NONCLUSTERED INDEX ' + QUOTENAME('IX_' + @TargetName + '_ClubCode') +
+				' ON ' + QUOTENAME(@TargetSchema) + '.' + QUOTENAME(@TargetName) +
+				' ([ClubCode]);';
+			EXEC sp_executesql @ClubIndexSql;
+		END
+	END
 	--ELSE
 	--BEGIN
 	--	PRINT '[' + @TargetSchema + '].[' + @TargetName +'] already exists'

--- a/Database/dbo/Tables/AppSettingsAudit.sql
+++ b/Database/dbo/Tables/AppSettingsAudit.sql
@@ -5,6 +5,6 @@ CREATE TABLE [dbo].[AppSettingsAudit] (
     [Veld]          NVARCHAR(100) NOT NULL,
     [OudeWaarde]    NVARCHAR(MAX) NULL,
     [NieuweWaarde]  NVARCHAR(MAX) NULL,
-    [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_AppSettingsAudit_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
+    [ClubCode]      NVARCHAR(20) NOT NULL, -- geen DEFAULT: clubnaam hoort niet in het schema (#598); inserts geven ClubCode altijd expliciet mee
     CONSTRAINT [PK_AppSettingsAudit] PRIMARY KEY CLUSTERED ([Id] ASC)
 );

--- a/Database/dbo/Tables/EmailTemplateInstellingen.sql
+++ b/Database/dbo/Tables/EmailTemplateInstellingen.sql
@@ -4,7 +4,7 @@ CREATE TABLE [dbo].[EmailTemplateInstellingen] (
     [Onderwerp]     NVARCHAR(500) NOT NULL,
     [BodyTemplate]  NVARCHAR(MAX) NOT NULL,
     [Actief]        BIT NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Actief] DEFAULT 1,
-    [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
+    [ClubCode]      NVARCHAR(20) NOT NULL, -- geen DEFAULT: clubnaam hoort niet in het schema (#598); inserts geven ClubCode altijd expliciet mee
     [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Inserted] DEFAULT GETUTCDATE(),
     [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_EmailTemplateInstellingen_Modified] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_EmailTemplateInstellingen] PRIMARY KEY CLUSTERED ([Id] ASC),

--- a/Database/dbo/Tables/TeamVoorkeurTijden.sql
+++ b/Database/dbo/Tables/TeamVoorkeurTijden.sql
@@ -5,7 +5,7 @@ CREATE TABLE [dbo].[TeamVoorkeurTijden] (
     [VoorkeurTijd]  TIME NOT NULL,
     [Prioriteit]    INT NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Prioriteit] DEFAULT 5,
     [Actief]        BIT NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Actief] DEFAULT 1,
-    [ClubCode]      NVARCHAR(20) NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
+    [ClubCode]      NVARCHAR(20) NOT NULL, -- geen DEFAULT: clubnaam hoort niet in het schema (#598); inserts geven ClubCode altijd expliciet mee
     [mta_inserted]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Inserted] DEFAULT GETUTCDATE(),
     [mta_modified]  DATETIME2 NOT NULL CONSTRAINT [DF_TeamVoorkeurTijden_Modified] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_TeamVoorkeurTijden] PRIMARY KEY CLUSTERED ([Id] ASC)

--- a/Database/dbo/Tables/UitgeslotenEmailAdressen.sql
+++ b/Database/dbo/Tables/UitgeslotenEmailAdressen.sql
@@ -3,7 +3,7 @@ CREATE TABLE [dbo].[UitgeslotenEmailAdressen] (
     [EmailAdres]   NVARCHAR (200) NOT NULL,
     [Omschrijving] NVARCHAR (500) NULL,
     [Actief]       BIT            NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Actief]    DEFAULT 1,
-    [ClubCode]     NVARCHAR (20)  NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_ClubCode]  DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
+    [ClubCode]     NVARCHAR (20)  NOT NULL, -- geen DEFAULT: clubnaam hoort niet in het schema (#598); inserts geven ClubCode altijd expliciet mee
     [mta_inserted] DATETIME2 (7)  NOT NULL CONSTRAINT [DF_UitgeslotenEmailAdressen_Inserted] DEFAULT GETUTCDATE(),
     CONSTRAINT [PK_UitgeslotenEmailAdressen] PRIMARY KEY CLUSTERED ([Id] ASC),
     CONSTRAINT [UQ_UitgeslotenEmailAdressen_Adres] UNIQUE ([EmailAdres], [ClubCode])

--- a/Database/dbo/Tables/Velden.sql
+++ b/Database/dbo/Tables/Velden.sql
@@ -4,6 +4,6 @@ CREATE TABLE [dbo].[Velden] (
     [VeldType]        NVARCHAR(20)  NOT NULL CONSTRAINT [DF_Velden_Type] DEFAULT 'kunstgras',
     [HeeftKunstlicht] BIT           NOT NULL,
     [Actief]          BIT           NOT NULL CONSTRAINT [DF_Velden_Actief] DEFAULT 1,
-    [ClubCode]        NVARCHAR(20)  NOT NULL CONSTRAINT [DF_Velden_ClubCode] DEFAULT 'VRC', -- migratie-backwards-compat; inserts geven altijd expliciet ClubCode mee
+    [ClubCode]        NVARCHAR(20)  NOT NULL, -- geen DEFAULT: clubnaam hoort niet in het schema (#598); inserts geven ClubCode altijd expliciet mee
     CONSTRAINT [PK_Velden] PRIMARY KEY CLUSTERED ([VeldNummer] ASC)
 );

--- a/Database/planner/Tables/HerplanVerzoeken.sql
+++ b/Database/planner/Tables/HerplanVerzoeken.sql
@@ -12,5 +12,6 @@ CREATE TABLE [planner].[HerplanVerzoeken] (
     [Opmerking]             NVARCHAR(500)  NULL,
     [mta_inserted]          DATETIME       NOT NULL CONSTRAINT [DF_HerplanVerzoeken_Ins] DEFAULT GETUTCDATE(),
     [mta_modified]          DATETIME       NOT NULL CONSTRAINT [DF_HerplanVerzoeken_Mod] DEFAULT GETUTCDATE(),
+    [ClubCode]              NVARCHAR(20)   NOT NULL, -- multi-club discriminator (#595); geen DEFAULT
     CONSTRAINT [PK_HerplanVerzoeken] PRIMARY KEY CLUSTERED ([Id] ASC)
 );

--- a/FunctionApp/Email/BerichtAiService.cs
+++ b/FunctionApp/Email/BerichtAiService.cs
@@ -65,6 +65,27 @@ public class BerichtAiService
         - Onderling overleg + KNVB-goedkeuring; moet voor de bekerronde plaatsvinden
         """;
 
+    /// <summary>
+    /// Seizoenslabel waarvoor <see cref="KnvbRegelsContext"/> geldt. Bij het jaarlijkse onderhoud
+    /// (zie docs/ARCHITECTUUR-AI-SERVICES.md) samen met de regels bijwerken. (#608)
+    /// </summary>
+    internal const string KnvbRegelsSeizoen = "2026/'27";
+
+    /// <summary>
+    /// Laatste dag waarop <see cref="KnvbRegelsContext"/> geldig is: einde nacompetitie van het
+    /// seizoen waarvoor de regels zijn opgesteld (20 juni 2027). Voorbij deze datum zijn alle
+    /// deadlines in de constante verlopen. (#608)
+    /// </summary>
+    internal static readonly DateOnly KnvbRegelsGeldigTot = new(2027, 6, 20);
+
+    /// <summary>
+    /// Zijn de KNVB-regels verlopen op de gegeven datum? Gebruikt om zowel de beheerder (log) als
+    /// het model (prompt) te waarschuwen, zodat verouderde deadlines niet stilzwijgend als
+    /// geldend advies worden gepresenteerd. (#608)
+    /// </summary>
+    internal static bool KnvbRegelsZijnVerlopen(DateTime today)
+        => DateOnly.FromDateTime(today) > KnvbRegelsGeldigTot;
+
     private static string BouwClassificatieSystemPrompt(DateTime today, IReadOnlyList<ClassificatieCorrectieVoorbeeld>? voorbeelden = null)
     {
         var clubNaam = SystemUtilities.AppSettings.GetSetting("clubName");
@@ -77,6 +98,15 @@ public class BerichtAiService
         if (dagenTotMaandag == 0) dagenTotMaandag = 7;
         var volgendeMa = today.AddDays(dagenTotMaandag);
         var doordeweeksVoorbeeld = $"[\"{volgendeMa:yyyy-MM-dd}\",\"{volgendeMa.AddDays(1):yyyy-MM-dd}\",\"{volgendeMa.AddDays(2):yyyy-MM-dd}\",\"{volgendeMa.AddDays(3):yyyy-MM-dd}\"]";
+
+        // Verlopen regels niet stilzwijgend als geldend advies presenteren: het model krijgt expliciet
+        // te horen dat de deadlines verouderd zijn en geen KNVB-waarschuwing meer mag afgeven. (#608)
+        var knvbStalenessWaarschuwing = KnvbRegelsZijnVerlopen(today)
+            ? $"\nLET OP: de hierboven genoemde KNVB-regels golden voor seizoen {KnvbRegelsSeizoen} en zijn "
+              + $"verlopen sinds {KnvbRegelsGeldigTot:d MMMM yyyy}. Geef GEEN knvbWaarschuwing op basis van deze "
+              + "deadlines; zet dat veld op null en vermeld in de samenvatting dat de KNVB-regels in het systeem "
+              + "verouderd zijn.\n"
+            : "";
 
         var fewShotSectie = "";
         if (voorbeelden != null && voorbeelden.Count > 0)
@@ -141,6 +171,7 @@ public class BerichtAiService
             Laat null als datum ruim voor eventuele deadlines valt of het teamtype niet duidelijk is.
 
             {{KnvbRegelsContext}}
+            {{knvbStalenessWaarschuwing}}
             {{fewShotSectie}}
             """;
     }
@@ -164,6 +195,18 @@ public class BerichtAiService
         _logger.LogInformation("Bericht classificatie gestart (onderwerp niet gelogd — AVG #210)");
 
         var today = DateTime.Now; // Lokale tijd — NL-context voor datumberekening
+
+        // Staleness-guard: maak zichtbaar dat de KNVB-regels onderhoud nodig hebben in plaats van
+        // stilzwijgend verlopen deadlines te blijven gebruiken. (#608)
+        if (KnvbRegelsZijnVerlopen(today))
+        {
+            _logger.LogWarning(
+                "KNVB-verplaatsingsregels in KnvbRegelsContext gelden voor seizoen {Seizoen} en zijn verlopen "
+                + "sinds {GeldigTot:yyyy-MM-dd}. Werk BerichtAiService.KnvbRegelsContext bij "
+                + "(zie docs/ARCHITECTUUR-AI-SERVICES.md).",
+                KnvbRegelsSeizoen, KnvbRegelsGeldigTot);
+        }
+
         var userPrompt = $"Van: {afzender}\nOnderwerp: {subject}\n\n{body}";
 
         var messages = new List<Microsoft.Extensions.AI.ChatMessage>

--- a/FunctionApp/Feedback/FeedbackFunction.cs
+++ b/FunctionApp/Feedback/FeedbackFunction.cs
@@ -89,11 +89,13 @@ public static class FeedbackFunction
             var pat = Environment.GetEnvironmentVariable("GitHubPat");
             var owner = Environment.GetEnvironmentVariable("GitHubOwner")
                      ?? Environment.GetEnvironmentVariable("GITHUB_REPOSITORY_OWNER") ?? "";
-            var repo = Environment.GetEnvironmentVariable("GitHubRepo") ?? "Sportlink-wedstrijdzaken";
+            // GitHubRepo is net als GitHubOwner verplicht: een stille fallback op de upstream-repo-naam
+            // geeft een fork met een andere naam een verwarrende 404 i.p.v. een configuratiefout. (#607)
+            var repo = Environment.GetEnvironmentVariable("GitHubRepo");
 
-            if (string.IsNullOrWhiteSpace(pat) || string.IsNullOrWhiteSpace(owner))
+            if (string.IsNullOrWhiteSpace(pat) || string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repo))
             {
-                log.LogWarning("GitHubPat/GitHubOwner niet geconfigureerd — feedback-submit niet mogelijk");
+                log.LogWarning("GitHubPat/GitHubOwner/GitHubRepo niet volledig geconfigureerd — feedback-submit niet mogelijk");
                 return new ObjectResult(new { error = "GitHub-integratie niet geconfigureerd. Neem contact op met de beheerder." }) { StatusCode = 503 };
             }
 
@@ -399,6 +401,17 @@ public static class FeedbackFunction
         return clean.Length > maxLen ? clean[..maxLen] + "…" : clean;
     }
 
+    /// <summary>
+    /// Rate limiter voor feedback-submits.
+    ///
+    /// #610 — bewuste keuze: de teller is in-memory en geldt dus per Consumption-plan-instance, niet
+    /// globaal. Bij opschaling kan de effectieve limiet een veelvoud van
+    /// <see cref="MaxSubmissiesPerVenster"/> zijn. Acceptabel omdat dit endpoint admin-only is
+    /// (<c>RequireAdmin</c>) en de limiet bedoeld is als rem tegen per ongeluk doorklikken, niet als
+    /// beveiligingsgrens tegen een aanvaller. Een gedeelde store (SQL/Table Storage) zou een extra
+    /// round-trip en onderhoud kosten zonder dat het risico dat rechtvaardigt. Wordt dit ooit een
+    /// publiek endpoint, dan is een gedeelde teller wél nodig.
+    /// </summary>
     private static bool TryAcquireSubmitSlot()
     {
         lock (_rateLock)

--- a/FunctionApp/Infrastructure/GitHubIssueReporter.cs
+++ b/FunctionApp/Infrastructure/GitHubIssueReporter.cs
@@ -15,7 +15,7 @@ namespace SportlinkFunction.Infrastructure;
 /// Vereiste environment variables:
 ///   GitHubPat   — fine-grained PAT met issues:write scope (zie #103)
 ///   GitHubOwner — GitHub organisatie of gebruikersnaam (default: env GITHUB_REPOSITORY_OWNER)
-///   GitHubRepo  — repository naam (default: "Sportlink-wedstrijdzaken")
+///   GitHubRepo  — repository naam (verplicht — geen fallback, zie #607)
 ///
 /// Wanneer GitHubPat niet geconfigureerd is, wordt alles stil overgeslagen.
 /// </summary>
@@ -39,11 +39,13 @@ public static class GitHubIssueReporter
         var owner = Environment.GetEnvironmentVariable("GitHubOwner")
                  ?? Environment.GetEnvironmentVariable("GITHUB_REPOSITORY_OWNER")
                  ?? "";
-        var repo = Environment.GetEnvironmentVariable("GitHubRepo") ?? "Sportlink-wedstrijdzaken";
+        // Geen stille fallback op de upstream-repo-naam: een fork met een andere naam zou dan
+        // issues naar de verkeerde repo proberen te sturen (404). (#607)
+        var repo = Environment.GetEnvironmentVariable("GitHubRepo");
 
-        if (string.IsNullOrWhiteSpace(owner))
+        if (string.IsNullOrWhiteSpace(owner) || string.IsNullOrWhiteSpace(repo))
         {
-            log.LogWarning("GitHubOwner niet geconfigureerd — issue-reporting overgeslagen");
+            log.LogWarning("GitHubOwner/GitHubRepo niet volledig geconfigureerd — issue-reporting overgeslagen");
             return;
         }
 

--- a/FunctionApp/Planner/PlannerHtmlGenerator.cs
+++ b/FunctionApp/Planner/PlannerHtmlGenerator.cs
@@ -469,7 +469,7 @@ document.addEventListener('click', () => {
                 if (naam.Contains("O23")) return 230;
                 if (naam.Contains("VR")) return 300;
                 // Senioren (eerste team en reserves): helemaal onderaan
-                var _cc = SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
+                var _cc = SystemUtilities.AppSettings.GetOptionalClubCode();
                 if (!string.IsNullOrWhiteSpace(_cc)
                     && System.Text.RegularExpressions.Regex.IsMatch(naam,
                         $@"{System.Text.RegularExpressions.Regex.Escape(_cc)} \d"))

--- a/FunctionApp/Planner/Repositories/PlannerMatchRepository.cs
+++ b/FunctionApp/Planner/Repositories/PlannerMatchRepository.cs
@@ -320,7 +320,7 @@ internal static class PlannerMatchRepository
         string? tegenstander, int wedstrijdDuurMinuten, string? aangevraagdDoor,
         string? clubCode = null)
     {
-        var cc = clubCode ?? SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
+        var cc = SystemUtilities.AppSettings.RequireClubCode(clubCode);
         using var conn = new SqlConnection(Cs);
         await conn.OpenAsync();
         using var cmd = new SqlCommand(@"

--- a/FunctionApp/Planner/Repositories/PlannerSettingsRepository.cs
+++ b/FunctionApp/Planner/Repositories/PlannerSettingsRepository.cs
@@ -14,7 +14,7 @@ internal static class PlannerSettingsRepository
     {
         // Normaliseer eerst zodat "JO15 Meiden" → "MO15" (#486)
         leeftijdsCategorie = LeeftijdNormalisatie.Normaliseer(leeftijdsCategorie);
-        var cc = clubCode ?? SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
+        var cc = SystemUtilities.AppSettings.RequireClubCode(clubCode);
         using var conn = new SqlConnection(Cs);
         await conn.OpenAsync();
         using var cmd = new SqlCommand(
@@ -29,8 +29,7 @@ internal static class PlannerSettingsRepository
 
     internal static async Task<List<VeldInfo>> GetVeldenAsync(string? clubCode = null)
     {
-        clubCode ??= SystemUtilities.AppSettings.GetSetting("clubCode")
-            ?? throw new InvalidOperationException("Vereiste instelling 'clubCode' ontbreekt in dbo.AppSettings");
+        clubCode = SystemUtilities.AppSettings.RequireClubCode(clubCode);
         var results = new List<VeldInfo>();
         using var conn = new SqlConnection(Cs);
         await conn.OpenAsync();
@@ -57,7 +56,7 @@ internal static class PlannerSettingsRepository
 
     internal static async Task<Dictionary<string, Speeltijd>> GetSpeeltijdenLookupAsync(string? clubCode = null)
     {
-        var cc = clubCode ?? SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
+        var cc = SystemUtilities.AppSettings.RequireClubCode(clubCode);
         var result = new Dictionary<string, Speeltijd>(StringComparer.OrdinalIgnoreCase);
         using var conn = new SqlConnection(Cs);
         await conn.OpenAsync();

--- a/FunctionApp/Planner/Repositories/TeamRulesRepository.cs
+++ b/FunctionApp/Planner/Repositories/TeamRulesRepository.cs
@@ -12,7 +12,7 @@ internal static class TeamRulesRepository
 
     internal static async Task<List<TeamRegel>> GetTeamRulesAsync(string teamNaam, string? clubCode = null)
     {
-        var cc = clubCode ?? SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
+        var cc = SystemUtilities.AppSettings.RequireClubCode(clubCode);
         var results = new List<TeamRegel>();
         using var conn = new SqlConnection(Cs);
         await conn.OpenAsync();
@@ -58,7 +58,7 @@ internal static class TeamRulesRepository
         foreach (var team in teams) results[team] = new List<TeamRegel>();
         if (teams.Count == 0) return results;
 
-        var cc = clubCode ?? SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
+        var cc = SystemUtilities.AppSettings.RequireClubCode(clubCode);
         var paramNames = teams.Select((_, i) => $"@team{i}").ToList();
 
         using var conn = new SqlConnection(Cs);
@@ -100,7 +100,7 @@ internal static class TeamRulesRepository
 
     internal static async Task<Dictionary<string, (int bufferVoor, int bufferNa)>> GetAllTeamBuffersAsync(string? clubCode = null)
     {
-        var cc = clubCode ?? SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
+        var cc = SystemUtilities.AppSettings.RequireClubCode(clubCode);
         var result = new Dictionary<string, (int bufferVoor, int bufferNa)>(StringComparer.OrdinalIgnoreCase);
         using var conn = new SqlConnection(Cs);
         await conn.OpenAsync();

--- a/FunctionApp/Processing/BerichtPipeline.cs
+++ b/FunctionApp/Processing/BerichtPipeline.cs
@@ -73,7 +73,7 @@ public static class BerichtPipeline
 
         if (!string.IsNullOrWhiteSpace(team) && !string.IsNullOrWhiteSpace(tegenstander))
         {
-            var cc = SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
+            var cc = SystemUtilities.AppSettings.GetOptionalClubCode();
             bool teamIsEigenClub = !team.Contains(' ')
                 || (!string.IsNullOrWhiteSpace(cc) && team.StartsWith(cc, StringComparison.OrdinalIgnoreCase));
             bool tegenstanderIsEigenClub = !tegenstander.Contains(' ')
@@ -94,7 +94,7 @@ public static class BerichtPipeline
                 var alleDatums = ExpandDoordeweeksDatums(
                     classificatie.GetAlleDatums(), bericht.Onderwerp, bericht.Body);
 
-                var cc2 = SystemUtilities.AppSettings.GetSetting("clubCode") ?? "";
+                var cc2 = SystemUtilities.AppSettings.GetOptionalClubCode();
                 bool heeftExterneTegenstander = !string.IsNullOrWhiteSpace(classificatie.Tegenstander)
                     && (string.IsNullOrWhiteSpace(cc2)
                         || !classificatie.Tegenstander.StartsWith(cc2, StringComparison.OrdinalIgnoreCase));
@@ -397,7 +397,7 @@ public static class BerichtPipeline
 
     private static string? ExtractEigenTeamUitWedstrijd(string wedstrijd, string tegenstander)
     {
-        var clubPrefix = (SystemUtilities.AppSettings.GetSetting("clubCode") ?? "") + " ";
+        var clubPrefix = (SystemUtilities.AppSettings.GetOptionalClubCode()) + " ";
         var parts = wedstrijd.Split(" - ", 2, StringSplitOptions.TrimEntries);
         foreach (var part in parts)
             if (!string.IsNullOrWhiteSpace(clubPrefix.Trim())

--- a/FunctionApp/Program.cs
+++ b/FunctionApp/Program.cs
@@ -21,12 +21,20 @@ if (!string.IsNullOrEmpty(tenantId) && !string.IsNullOrEmpty(clientId) && !strin
 }
 
 // IChatClient: provider-agnostische AI-abstractie (CLAUDE.md architectuurregel).
-// Provider: OpenAI gpt-4o-mini direct — geen Azure OpenAI.
+// Provider: OpenAI direct — geen Azure OpenAI.
+// Modelnaam komt uit de app setting `AiModelName` zodat een model-upgrade geen code-wijziging
+// vereist (zie docs/ARCHITECTUUR-AI-SERVICES.md). Niet uit dbo.AppSettings: de DI-registratie
+// loopt bij host-start, vóór de eerste databaseverbinding. (#604)
 var openAiApiKey = Environment.GetEnvironmentVariable("OpenAiApiKey");
 if (!string.IsNullOrWhiteSpace(openAiApiKey))
 {
+    // Fallback is puur een provider-model-identifier — geen club-specifieke waarde, dus toegestaan.
+    const string defaultAiModelName = "gpt-4o-mini";
+    var aiModelName = Environment.GetEnvironmentVariable("AiModelName");
+    if (string.IsNullOrWhiteSpace(aiModelName)) aiModelName = defaultAiModelName;
+
     builder.Services.AddSingleton<IChatClient>(
-        new ChatClient("gpt-4o-mini", new System.ClientModel.ApiKeyCredential(openAiApiKey))
+        new ChatClient(aiModelName, new System.ClientModel.ApiKeyCredential(openAiApiKey))
             .AsIChatClient());
 }
 

--- a/FunctionApp/Utilities.cs
+++ b/FunctionApp/Utilities.cs
@@ -96,6 +96,40 @@ namespace SportlinkFunction
                 return settings.TryGetValue(key, out var value) ? value : null;
             }
 
+            /// <summary>
+            /// Leest een verplichte instelling en gooit als deze ontbreekt of leeg is. Gebruik dit
+            /// op elk pad dat de waarde als SQL-filter of kolomwaarde wegschrijft — een stille
+            /// fallback maskeert misconfiguratie en breekt de multi-club invariant. (#601)
+            /// </summary>
+            public static string RequireSetting(string key)
+            {
+                var value = GetSetting(key);
+                if (string.IsNullOrWhiteSpace(value))
+                    throw new InvalidOperationException($"Vereiste instelling '{key}' ontbreekt in dbo.AppSettings");
+                return value;
+            }
+
+            /// <summary>
+            /// Resolveert de ClubCode-discriminator: een expliciet meegegeven waarde heeft voorrang,
+            /// anders de instelling uit <c>dbo.AppSettings</c>. Ontbreken beide → harde fout. (#600, #601)
+            /// </summary>
+            public static string RequireClubCode(string? clubCode = null)
+            {
+                return !string.IsNullOrWhiteSpace(clubCode) ? clubCode : RequireSetting("clubCode");
+            }
+
+            /// <summary>
+            /// ClubCode voor paden waar de waarde alléén een heuristiek verrijkt (eigen-team-naam
+            /// herkennen, sorteervolgorde) en géén SQL-filter of kolomwaarde is. Ontbreekt de
+            /// instelling, dan degradeert de heuristiek bewust naar een lege string in plaats van
+            /// de verwerking te laten falen. Gebruik dit nooit op een lees- of schrijfpad — daar
+            /// hoort <see cref="RequireClubCode"/>. (#601)
+            /// </summary>
+            public static string GetOptionalClubCode()
+            {
+                return GetSetting("clubCode") ?? "";
+            }
+
             public static async Task SaveLastSyncTimestampAsync(ILogger log)
             {
                 try

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.16.4.0</Version>
-    <AssemblyVersion>2.16.4.0</AssemblyVersion>
-    <FileVersion>2.16.4.0</FileVersion>
+    <Version>2.16.5.0</Version>
+    <AssemblyVersion>2.16.5.0</AssemblyVersion>
+    <FileVersion>2.16.5.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/FunctionApp/local.settings.template.json
+++ b/FunctionApp/local.settings.template.json
@@ -14,6 +14,7 @@
     "GraphClientSecret": "",
     "GraphMailbox": "",
     "OpenAiApiKey": "",
+    "AiModelName": "gpt-4o-mini",
     "EmailProcessorEnabled": "false",
     "EmailReviewMode": "true",
     "EmailReviewRecipient": "",

--- a/SETUP-NIEUWE-CLUB.md
+++ b/SETUP-NIEUWE-CLUB.md
@@ -58,14 +58,22 @@ az functionapp config appsettings set \
     "GraphClientSecret=<entra-app-secret>" \
     "GraphMailbox=<coordinator@voorbeeld.nl>" \
     "OpenAiApiKey=<openai-api-key>" \
+    "AiModelName=gpt-4o-mini" \
     "GitHubPat=<github-pat>" \
     "GitHubOwner=<github-username>" \
-    "GitHubRepo=Sportlink-wedstrijdzaken" \
+    "GitHubRepo=<naam-van-jouw-fork>" \
     "EmailProcessorEnabled=false" \
     "EmailReviewMode=true"
 ```
 
 > Stel `EmailProcessorEnabled=true` pas in als je de e-mailverwerking wilt activeren. Begin met `false` tijdens de initiële setup.
+
+> **`GitHubRepo` is verplicht (#607).** Heb je de repo onder een andere naam geforkt, vul dan die naam
+> in. Ontbreekt de instelling, dan geeft de feedback-widget een duidelijke configuratiefout (503) —
+> voorheen probeerde hij stilzwijgend de upstream-repo en kreeg je een verwarrende 404.
+
+> **`AiModelName` is optioneel (#604).** Zonder deze instelling gebruikt het systeem `gpt-4o-mini`.
+> Zet hier een andere modelnaam om te upgraden zonder de software opnieuw te deployen.
 
 ### 2b. Azure SQL Database (Free tier)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -32,6 +32,7 @@ Zonder geldige sleutel → 401 Unauthorized (kost niets, geen verwerking).
 | `GET` | `/beheer/teambegeleiding` | **Admin+User** | Alle teams met begeleiding in database |
 | `GET` | `/beheer/teambegeleiding/{team}` | **Admin+User** | Begeleiders van team (naam + rol, nooit e-mail) |
 | `POST` | `/beheer/teambegeleiding/doorsturen` | **Admin+User** | Vraag doorsturen naar coach (BCC coördinator) |
+| `POST` | `/beheer/teambegeleiding/import` | **Admin** | CSV-import van begeleiders (vervangt de rijen van de club). CSV wordt in-memory verwerkt en nooit opgeslagen; `avg.ImportLog` bevat alleen metadata — geen PII |
 | `GET/POST/PUT/DELETE` | `/beheer/speeltijden` en `/{leeftijd}` | **Admin** | Speeltijden per leeftijdscategorie beheren |
 | `GET` | `/beheer/leermomenten` | **Admin** | Classificatie-leermomenten ophalen (`?status=pending\|validated\|rejected`) |
 | `GET` | `/beheer/leermomenten/stats` | **Admin** | Aantallen leermomenten per status |
@@ -46,6 +47,7 @@ Zonder geldige sleutel → 401 Unauthorized (kost niets, geen verwerking).
 | `POST` | `/beheer/testdata/wedstrijden` | **Admin** | Test-wedstrijd aanmaken of bijwerken (upsert op `bk_matches`) — forceert `ClubCode='ALLSTARS'` |
 | `DELETE` | `/beheer/testdata/wedstrijden/{bk}` | **Admin** | Één test-wedstrijd verwijderen op `bk_matches` |
 | `DELETE` | `/beheer/testdata/wedstrijden?van=YYYY-MM-DD&tot=YYYY-MM-DD` | **Admin** | Test-wedstrijden verwijderen voor datumbereik (beide params optioneel; zonder params: alles verwijderen) |
+| `POST` | `/beheer/testdata/wedstrijden/verplaats-datum` | **Admin** | Alle ALLSTARS-wedstrijden van `oudeDatum` naar `nieuweDatum` verplaatsen — raakt uitsluitend `ClubCode='ALLSTARS'` |
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,7 +50,7 @@ Browser (beheerder)
         his.* / stg.* / pub.*               (ETL-pipeline)
 ```
 
-**Technologiestack:** FunctionApp `net9.0` · BlazorAdmin `net10.0` · Azure Functions v4 · Blazor WebAssembly · Azure SQL · Microsoft Graph API · Azure OpenAI · Azure Static Web Apps · Entra ID (single-tenant)
+**Technologiestack:** FunctionApp `net9.0` · BlazorAdmin `net10.0` · Azure Functions v4 · Blazor WebAssembly · Azure SQL · Microsoft Graph API · OpenAI (direct, model via `AiModelName`) · Azure Static Web Apps · Entra ID (single-tenant)
 
 > **Runtimeversies zijn niet uitwisselbaar — niet upgraden zonder infrastructuurwijziging (#579).**
 >

--- a/docs/ARCHITECTUUR-AI-SERVICES.md
+++ b/docs/ARCHITECTUUR-AI-SERVICES.md
@@ -165,6 +165,15 @@ var modelName = Environment.GetEnvironmentVariable("AiModelName") ?? "gpt-4o-min
 Configureer via GitHub Variable `AI_MODEL_NAME` en Azure Function Application Settings.
 Dit maakt model-upgrades (gpt-4o-mini → gpt-4.1-mini, etc.) zonder deployment mogelijk.
 
+> **Status: geïmplementeerd (#604).** `FunctionApp/Program.cs` leest de modelnaam uit de app setting
+> `AiModelName` bij de `IChatClient`-registratie; ontbreekt die, dan valt hij terug op `gpt-4o-mini`.
+> De fallback is toegestaan omdat het puur een provider-model-identifier is — geen club-specifieke
+> waarde. De naam komt bewust **niet** uit `dbo.AppSettings`: de DI-registratie loopt bij host-start,
+> vóór de eerste databaseverbinding.
+>
+> Zet de waarde lokaal in `FunctionApp/local.settings.json` (zie de template) en in productie als
+> Azure Function Application Setting.
+
 ---
 
 ## Jaarlijkse onderhoudsplicht: KNVB-regels

--- a/docs/VERIFICATIE-SCRIPTS.md
+++ b/docs/VERIFICATIE-SCRIPTS.md
@@ -83,3 +83,52 @@ Lokaal wordt de live database **niet automatisch geüpdatet** bij een git pull.
 - Ontbrekende kolommen toevoegen via `ALTER TABLE`
 
 Voor productie-deploys: gebruik de SSDT publish-diff workflow of een migratiescript.
+
+---
+
+## CI: schema-drift guard (`.github/workflows/build.yml`)
+
+> Toegevoegd bij #595/#599.
+
+De deploy-pipeline publiceert **geen dacpac** — de `db-migrate`-job runt uitsluitend
+`Database/Script.PostDeployment1.sql`. Elk object uit het DB-project moet daarom óók idempotent in
+dat script staan, anders ontbreekt het op een verse deploy en falen functies met
+`Invalid object name`.
+
+Dat ging structureel mis: **12 objecten** stonden alleen in het DB-project — waaronder alle vier de
+ETL-procedures (`sp_CreateTargetTableFromSource`, `sp_MergeStgToHis`, `sp_UpdateSeasonTable`,
+`sp_CreateDateTable`), de stuurtabel `mta.source_target_mapping` (inclusief de seed-rijen, die alleen
+als SQL-comment bestonden), `dbo.Season`, de drie `pub`-views, `avg.ImportLog`,
+`planner.HerplanVerzoeken` en `dbo.Zonsondergang`.
+
+De job `build` controleert nu op elke PR dat elke `CREATE TABLE` / `CREATE PROCEDURE` / `CREATE VIEW`
+uit `Database/**` voorkomt in het PostDeployment-script. Voegt iemand een object toe zonder guard,
+dan faalt de PR.
+
+**Bewuste uitzonderingen** (allowlist in de workflow, met reden):
+
+| Object | Waarom uitgezonderd |
+|---|---|
+| `stg.teams`, `stg.matches`, `stg.matchdetails` | Dynamisch aangemaakt door `FunctionApp/CreateTable.cs` op basis van het actuele Sportlink API-schema |
+| `dbo.DateTable` | Aangemaakt (DROP + CREATE) door `dbo.sp_CreateDateTable`, die zelf wél in PostDeployment staat |
+
+**Bij een nieuw database-object:** voeg een `IF NOT EXISTS ... CREATE TABLE`-guard toe voor tabellen,
+of `CREATE OR ALTER` voor procedures en views. Houd de definitie gelijk aan het bronbestand onder
+`Database/`.
+
+> **Nog open:** een echte `SqlPackage /Action:Publish` in de pipeline zou dit dubbel onderhoud
+> overbodig maken. Dat is bewust niet in deze wijziging meegenomen — een schema-publish tegen de
+> live Free-tier database kan destructieve ALTER/DROP-operaties uitvoeren en vraagt een expliciete
+> afweging van de eigenaar. Zie #595.
+
+### Lokaal narekenen
+
+```powershell
+# Voer het PostDeployment-script twee keer uit tegen een database met >1 club.
+# Twee keer, omdat idempotentie-fouten pas bij de tweede run zichtbaar worden (#564).
+sqlcmd -S <server> -d SportlinkSqlDb -E -C -i Database\Script.PostDeployment1.sql -b
+sqlcmd -S <server> -d SportlinkSqlDb -E -C -i Database\Script.PostDeployment1.sql -b
+```
+
+Alleen parsen is niet genoeg: batch-binding-fouten (Msg 207/1911) en `Msg 512` verschijnen pas bij
+echte uitvoering.

--- a/docs/api-standaarden/openapi.json
+++ b/docs/api-standaarden/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Sportlink Wedstrijdzaken API",
     "description": "API voor het beheer van wedstrijden, veldplanning en club-instellingen.\n\n## Beveiliging\n\nTwee beveiligingsschema's:\n\n- **functionKey** — `?code=` queryparameter, vereist voor planner- en sync-endpoints.\n  Gebruik de Azure Function key (voor planner-endpoints) of de Master key (voor admin sync-matches en\n  populate-sunset).\n- **easyAuth** — Azure Easy Auth Bearer token (Entra ID) in de `Authorization`-header, vereist voor\n  alle `/beheer/`- en `/feedback/`-endpoints. Lokaal omzeild wanneer de omgevingsvariabele\n  `WEBSITE_SITE_NAME` afwezig is.\n\nAlle `/beheer/`- en `/feedback/`-endpoints retourneren de header `x-correlation-id` in het antwoord.\n",
-    "version": "2.8.0",
+    "version": "2.16.5",
     "contact": {
       "name": "Sportlink Wedstrijdzaken",
       "url": "https://github.com/jaapbeus/Sportlink-wedstrijdzaken"
@@ -164,7 +164,7 @@
             "type": "number",
             "format": "float",
             "description": "Fractie van het veld (0.25, 0.50 of 1.00)",
-            "example": 1
+            "example": 1.0
           },
           "wedstrijdDuurMinuten": {
             "type": "integer",
@@ -1664,7 +1664,7 @@
             "type": "number",
             "format": "decimal",
             "description": "Fractie van het veld (bijv. 0.5 = half veld)",
-            "example": 1
+            "example": 1.0
           },
           "WedstrijdTotaal": {
             "type": "integer",
@@ -1697,7 +1697,7 @@
           "veldafmeting": {
             "type": "number",
             "format": "decimal",
-            "default": 1
+            "default": 1.0
           },
           "wedstrijdTotaal": {
             "type": "integer",
@@ -1956,6 +1956,74 @@
           "bericht": {
             "type": "string",
             "description": "Berichttekst (max 2000 tekens)"
+          }
+        }
+      },
+      "TeambegeleidingImportRequest": {
+        "type": "object",
+        "required": [
+          "csvContent"
+        ],
+        "properties": {
+          "csvContent": {
+            "type": "string",
+            "description": "Volledige inhoud van de CSV-export uit club.sportlink.com. Wordt in-memory verwerkt\nen nooit opgeslagen (AVG).\n"
+          },
+          "bestandsnaam": {
+            "type": "string",
+            "nullable": true,
+            "description": "Alleen voor de audit-regel in `avg.ImportLog` — puur metadata."
+          }
+        }
+      },
+      "TeambegeleidingImportResultaat": {
+        "type": "object",
+        "properties": {
+          "rijen": {
+            "type": "integer",
+            "description": "Aantal geïmporteerde gegevensrijen"
+          },
+          "herkend": {
+            "type": "array",
+            "description": "Herkende CSV-kolomnamen",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ontbreekt": {
+            "type": "array",
+            "description": "Ontbrekende verplichte kolommen (leeg bij een geslaagde import)",
+            "items": {
+              "type": "string"
+            }
+          },
+          "waarschuwingen": {
+            "type": "array",
+            "description": "Niet-blokkerende opmerkingen over de verwerkte CSV",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "VerplaatsDatumRequest": {
+        "type": "object",
+        "required": [
+          "oudeDatum",
+          "nieuweDatum"
+        ],
+        "properties": {
+          "oudeDatum": {
+            "type": "string",
+            "format": "date",
+            "description": "Huidige wedstrijddatum (yyyy-MM-dd)",
+            "example": "2026-05-30"
+          },
+          "nieuweDatum": {
+            "type": "string",
+            "format": "date",
+            "description": "Nieuwe wedstrijddatum (yyyy-MM-dd)",
+            "example": "2026-06-06"
           }
         }
       },
@@ -4950,9 +5018,6 @@
           "403": {
             "$ref": "#/components/responses/Forbidden"
           },
-          "500": {
-            "$ref": "#/components/responses/InternalServerError"
-          },
           "502": {
             "description": "Club-website kon niet worden opgehaald",
             "content": {
@@ -4962,6 +5027,9 @@
                 }
               }
             }
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
           }
         }
       }
@@ -5324,6 +5392,137 @@
         }
       }
     },
+    "/beheer/teambegeleiding/import": {
+      "post": {
+        "tags": [
+          "beheer"
+        ],
+        "operationId": "importTeambegeleiding",
+        "summary": "Teambegeleiding importeren uit CSV",
+        "description": "Importeert begeleidersgegevens uit een CSV-export van club.sportlink.com naar\n`avg.Teambegeleiding`. De bestaande rijen van de betrokken club worden eerst verwijderd\n(TRUNCATE-en-vervang per `ClubCode`).\n\n**AVG:** de CSV-inhoud wordt in-memory verwerkt en nooit op schijf opgeslagen. De audit-regel\nin `avg.ImportLog` bevat alleen metadata (aantal rijen, bestandsnaam, duur) — geen\npersoonsgegevens.\n",
+        "security": [
+          {
+            "easyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TeambegeleidingImportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Import geslaagd",
+            "headers": {
+              "x-correlation-id": {
+                "$ref": "#/components/headers/CorrelationId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TeambegeleidingImportResultaat"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "CSV ontbreekt of mist verplichte kolommen",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "ontbreekt": {
+                      "type": "array",
+                      "description": "Namen van de ontbrekende verplichte kolommen",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/beheer/testdata/wedstrijden/verplaats-datum": {
+      "post": {
+        "tags": [
+          "testdata"
+        ],
+        "operationId": "verplaatsTestDataDatum",
+        "summary": "ALLSTARS-testwedstrijden naar een andere datum verplaatsen",
+        "description": "Verplaatst alle wedstrijden van de ALLSTARS demo-club van `oudeDatum` naar `nieuweDatum`.\nRaakt uitsluitend rijen met `ClubCode = 'ALLSTARS'` — productiedata blijft ongemoeid.\nBedoeld om demodata mee te laten schuiven met het actuele seizoen.\n",
+        "security": [
+          {
+            "easyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VerplaatsDatumRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Wedstrijden verplaatst",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "aantalVerplaatst": {
+                      "type": "integer",
+                      "description": "Aantal bijgewerkte wedstrijden"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
     "/beheer/testdata/wedstrijden": {
       "get": {
         "tags": [
@@ -5601,60 +5800,6 @@
         }
       }
     },
-    "/planner/auto-plan/toepassen": {
-      "post": {
-        "tags": [
-          "planner"
-        ],
-        "operationId": "autoPlanToepassen",
-        "summary": "Automatisch plan toepassen",
-        "description": "Past het gegenereerde auto-plan toe door wedstrijdsloten te boeken in\n`planner.GeplandeWedstrijden`. Schrijft alleen voor wedstrijden die nog\ngeen slot hebben.\n\n**Let op:** alleen beschikbaar als de club-code `ALLSTARS` is (testmodus).\nProductie-clubs ontvangen HTTP 403.\n",
-        "security": [
-          {
-            "easyAuth": []
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AutoPlanToepassenRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Plan toegepast",
-            "headers": {
-              "x-correlation-id": {
-                "$ref": "#/components/headers/CorrelationId"
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AutoPlanToepassenResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden"
-          },
-          "500": {
-            "$ref": "#/components/responses/InternalServerError"
-          }
-        }
-      }
-    },
     "/planner/veldbezetting": {
       "get": {
         "tags": [
@@ -5691,6 +5836,60 @@
                   "items": {
                     "$ref": "#/components/schemas/VeldbezettingItem"
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/planner/auto-plan/toepassen": {
+      "post": {
+        "tags": [
+          "planner"
+        ],
+        "operationId": "autoPlanToepassen",
+        "summary": "Automatisch plan toepassen",
+        "description": "Past het gegenereerde auto-plan toe door wedstrijdsloten te boeken in\n`planner.GeplandeWedstrijden`. Schrijft alleen voor wedstrijden die nog\ngeen slot hebben.\n\n**Let op:** alleen beschikbaar als de club-code `ALLSTARS` is (testmodus).\nProductie-clubs ontvangen HTTP 403.\n",
+        "security": [
+          {
+            "easyAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutoPlanToepassenRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Plan toegepast",
+            "headers": {
+              "x-correlation-id": {
+                "$ref": "#/components/headers/CorrelationId"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoPlanToepassenResponse"
                 }
               }
             }

--- a/docs/api-standaarden/openapi.yaml
+++ b/docs/api-standaarden/openapi.yaml
@@ -16,7 +16,7 @@ info:
       `WEBSITE_SITE_NAME` afwezig is.
 
     Alle `/beheer/`- en `/feedback/`-endpoints retourneren de header `x-correlation-id` in het antwoord.
-  version: 2.8.0
+  version: 2.16.5
   contact:
     name: Sportlink Wedstrijdzaken
     url: https://github.com/jaapbeus/Sportlink-wedstrijdzaken
@@ -1509,7 +1509,61 @@ components:
           type: string
           description: Berichttekst (max 2000 tekens)
 
+    TeambegeleidingImportRequest:
+      type: object
+      required:
+        - csvContent
+      properties:
+        csvContent:
+          type: string
+          description: |
+            Volledige inhoud van de CSV-export uit club.sportlink.com. Wordt in-memory verwerkt
+            en nooit opgeslagen (AVG).
+        bestandsnaam:
+          type: string
+          nullable: true
+          description: Alleen voor de audit-regel in `avg.ImportLog` — puur metadata.
+
+    TeambegeleidingImportResultaat:
+      type: object
+      properties:
+        rijen:
+          type: integer
+          description: Aantal geïmporteerde gegevensrijen
+        herkend:
+          type: array
+          description: Herkende CSV-kolomnamen
+          items:
+            type: string
+        ontbreekt:
+          type: array
+          description: Ontbrekende verplichte kolommen (leeg bij een geslaagde import)
+          items:
+            type: string
+        waarschuwingen:
+          type: array
+          description: Niet-blokkerende opmerkingen over de verwerkte CSV
+          items:
+            type: string
+
     # ── Testdata ──────────────────────────────────────────────────────────────
+
+    VerplaatsDatumRequest:
+      type: object
+      required:
+        - oudeDatum
+        - nieuweDatum
+      properties:
+        oudeDatum:
+          type: string
+          format: date
+          description: Huidige wedstrijddatum (yyyy-MM-dd)
+          example: '2026-05-30'
+        nieuweDatum:
+          type: string
+          format: date
+          description: Nieuwe wedstrijddatum (yyyy-MM-dd)
+          example: '2026-06-06'
 
     TestDataWedstrijd:
       type: object
@@ -3752,7 +3806,98 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /beheer/teambegeleiding/import:
+    post:
+      tags: [beheer]
+      operationId: importTeambegeleiding
+      summary: Teambegeleiding importeren uit CSV
+      description: |
+        Importeert begeleidersgegevens uit een CSV-export van club.sportlink.com naar
+        `avg.Teambegeleiding`. De bestaande rijen van de betrokken club worden eerst verwijderd
+        (TRUNCATE-en-vervang per `ClubCode`).
+
+        **AVG:** de CSV-inhoud wordt in-memory verwerkt en nooit op schijf opgeslagen. De audit-regel
+        in `avg.ImportLog` bevat alleen metadata (aantal rijen, bestandsnaam, duur) — geen
+        persoonsgegevens.
+      security:
+        - easyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TeambegeleidingImportRequest'
+      responses:
+        '200':
+          description: Import geslaagd
+          headers:
+            x-correlation-id:
+              $ref: '#/components/headers/CorrelationId'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TeambegeleidingImportResultaat'
+        '400':
+          description: CSV ontbreekt of mist verplichte kolommen
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  ontbreekt:
+                    type: array
+                    description: Namen van de ontbrekende verplichte kolommen
+                    items:
+                      type: string
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   # ── Testdata ──────────────────────────────────────────────────────────────────
+
+  /beheer/testdata/wedstrijden/verplaats-datum:
+    post:
+      tags: [testdata]
+      operationId: verplaatsTestDataDatum
+      summary: ALLSTARS-testwedstrijden naar een andere datum verplaatsen
+      description: |
+        Verplaatst alle wedstrijden van de ALLSTARS demo-club van `oudeDatum` naar `nieuweDatum`.
+        Raakt uitsluitend rijen met `ClubCode = 'ALLSTARS'` — productiedata blijft ongemoeid.
+        Bedoeld om demodata mee te laten schuiven met het actuele seizoen.
+      security:
+        - easyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VerplaatsDatumRequest'
+      responses:
+        '200':
+          description: Wedstrijden verplaatst
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+                  aantalVerplaatst:
+                    type: integer
+                    description: Aantal bijgewerkte wedstrijden
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /beheer/testdata/wedstrijden:
     get:


### PR DESCRIPTION
## Samenvatting

Verwerkt de Fable 5-review (#595-#610): **15 van 16 issues afgehandeld**, versie `2.16.4.0` → `2.16.5.0`.

Eén issue (#596, branch protection op `develop`) is repo-configuratie en kan niet via code — zie onderaan.

## Kritiek: een verse deploy was onbruikbaar (#595)

Fable 5 noemde 3 ontbrekende tabellen. De CI-guard die ik daarvoor bouwde vond er **9 meer** — in totaal 12 database-objecten die alleen in het DB-project stonden en dus nooit werden aangemaakt (de pipeline publiceert geen dacpac):

| Object | Impact bij ontbreken |
|---|---|
| `sp_CreateTargetTableFromSource`, `sp_MergeStgToHis`, `sp_UpdateSeasonTable`, `sp_CreateDateTable` | **De volledige Sportlink-ETL draait niet.** PostDeployment riep `sp_UpdateSeasonTable` zelfs al aan zonder die ooit aan te maken |
| `mta.source_target_mapping` | Stuurt de ETL. De seed-rijen bestonden **alleen als SQL-comment** — zelfs een dacpac liet de tabel leeg |
| `dbo.Season` | `sp_UpdateSeasonTable` doet alleen `INSERT`, maakt de tabel niet aan |
| `pub.DateTable`, `pub.Teams`, `pub.Matches` | Publieke views voor consumers |
| `avg.ImportLog`, `planner.HerplanVerzoeken`, `dbo.Zonsondergang` | De 3 door Fable 5 gevonden tabellen |

`planner.HerplanVerzoeken` kreeg ook de ontbrekende `ClubCode` (nullable → backfill → NOT NULL, zoals #428).

**Structurele fix:** nieuwe job in `.github/workflows/build.yml` faalt zodra een `CREATE TABLE`/`PROCEDURE`/`VIEW` uit `Database/**` niet in het PostDeployment-script voorkomt. Met gedocumenteerde allowlist voor de `stg.*`-tabellen (runtime aangemaakt door `CreateTable.cs`) en `dbo.DateTable` (door `sp_CreateDateTable`).

> **Bewust géén `SqlPackage /Action:Publish` toegevoegd.** Het issue bood dat als optie (a). Een schema-publish tegen de live Free-tier database kan destructieve `ALTER`/`DROP` uitvoeren op onbekende drift. Dat is een afweging voor de eigenaar, niet iets om ongevraagd in een deploy-pipeline te zetten. Optie (b) — de drift-check — voorkomt de bugklasse zonder dat risico.

## Multi-club invariant (#598, #600, #601)

- Club-`DEFAULT` verwijderd op alle 5 objecten, vervangen door `CHECK (LEN([ClubCode]) > 0)` (patroon van #242).
- **Bijkomend probleem opgelost:** de seeds voor `Velden`/`VeldBeschikbaarheid`/`TeamRegels`/`Speeltijden`/`AppSettings` gaven `ClubCode` helemaal niet mee — ze leunden op die default. Zonder aanpassing zou het weghalen van de default de verse deploy juist bréken. Ze geven `ClubCode` nu expliciet mee, gelezen uit `dbo.AppSettings`.
- De `TeamRegels`-seed bevatte een hardcoded clubnaam als teamnaam; die wordt nu club-neutraal opgebouwd als `<ClubCode> + ' 1'`.
- `AppSettings.RequireClubCode()` op lees-/schrijfpaden (gooit bij ontbrekende instelling), `GetOptionalClubCode()` op de drie heuristische paden waar graceful degradation bewust is — zodat het verschil leesbaar is bij de call site in plaats van eruit te zien als drift.

## Overige

| Issue | Fix |
|---|---|
| #597 | FeedbackWidget riep JS `eval()` aan → geblokkeerd door de productie-CSP, widget crashte **live** maar niet lokaal. Nu `NavigationManager` + een dedicated interop-helper |
| #610 | **`sp_CreateDateTable` markeerde vrijdag als weekend en zondag niet** (`DATEPART(WEEKDAY)` hangt van `DATEFIRST` af). Nu DATEFIRST-onafhankelijk |
| #602 | `TimeInput` splat `AdditionalAttributes` |
| #603 | `sandbox="allow-same-origin"` op de srcdoc-iframe, bewust zonder `allow-scripts` |
| #604 | Modelnaam via app setting `AiModelName` (naam die `docs/ARCHITECTUUR-AI-SERVICES.md` al voorschreef) |
| #606 | Index op business key + `ClubCode` van `his.*` |
| #607 | `GitHubRepo` verplicht — ook in `GitHubIssueReporter`, die dezelfde stille fallback had |
| #608 | Staleness-guard op de KNVB-regels: log-warning én instructie in de system prompt om geen verlopen deadlines meer als advies te geven |
| #599 | `build` losgekoppeld van `db-check`; de DB-gate zit nu op `db-migrate`/`deploy`. Een gepauzeerde database maskeert geen compileerfouten meer |
| #605 | openapi naar `2.16.5`, 2 ontbrekende routes + 3 schema's, `openapi.json` gegenereerd **uit** de yaml zodat ze niet meer kunnen driften |

### #606 — afgeweken van het voorstel, met opzet

Fable 5 vroeg een `UNIQUE` index op de business key. `his.teams` blijkt **10 dubbele business keys** te bevatten — precies wat #569 (nog open) beschrijft. Een onvoorwaardelijke `CREATE UNIQUE INDEX` zou de deploy laten falen. De migratie maakt de index daarom uniek waar de data dat toestaat en anders niet-uniek, met een `PRINT` die de duplicaten meldt. Bij uitvoering: `matches` en `matchdetails` uniek, `teams` niet-uniek + melding. De uniciteit volgt zodra #569 is opgelost.

### #609 — false positive, weerlegd

De aanname was dat `git ls-files 'docs/*.md'` geneste submappen mist. Git's standaard pathspec-matching laat `*` óók `/` matchen (geen `WM_PATHNAME`), dus die 4 bestanden werden al gescand — **23 bestanden via beide methoden**, geverifieerd. Wel omgezet naar `find` omdat dat expliciet is en niet van die subtiliteit afhangt. Geen dekkingsgat geweest.

## Verificatie

- `dotnet build` FunctionApp (net9.0) + BlazorAdmin (net10.0): beide 0 warnings, 0 errors
- **PostDeployment 2× uitgevoerd tegen een database met 2 clubs** (exit 0 beide keren) — echt uitgevoerd, niet alleen geparsed, want batch-binding-fouten en `Msg 512` verschijnen pas bij uitvoering (#564)
- Constraints/objecten/indexen ná uitvoering geverifieerd via `sys.*`
- `Test-App.ps1`: **31/31**, exit 0
- Blazor importmap-fingerprint consistent (200 op `dotnet.<hash>.js`)
- Browsercheck via Playwright op `/`, `/instellingen`, `/dagplanning`, `/testdata/wedstrijden`: geen foutbanner, **0 console-errors**, `v2.16.5.0` zichtbaar
- **#597 bewezen:** `window.eval` geblokkeerd → FEEDBACK-venster opent alsnog volledig. De oude code zou hier een `EvalError` gooien
- **#602 bewezen:** gesplatte input rendert op 120px, de andere 21 op 53px
- **#610 bewezen:** `DateTable` toont nu Monday=1 en zaterdag+zondag als weekend

## Nog voor de eigenaar

- **#596** — branch protection op `develop` vereist repo-admin en verandert de merge-flow voor iedereen. Bewust niet ongevraagd ingesteld; commando staat in het issue.
- **#595** — de `SqlPackage`-publish (optie a) blijft een open afweging, zie hierboven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
