### PR TITLE
chore(#615): automatiseer issue-lifecycle voor develop→main release-gat

### DIFF
--- a/.github/workflows/close-released-issues.yml
+++ b/.github/workflows/close-released-issues.yml
@@ -1,0 +1,103 @@
+name: Sluit gereleasede issues
+
+# Zodra een release-tag naar main wordt gepusht (zelfde trigger als release.yml),
+# doorzoekt deze workflow de commits sinds de vorige release-tag op #NNN-referenties,
+# verwijdert het label 'status: awaiting-release' en sluit die issues definitief.
+# Zie CLAUDE.md, sectie "Issue-lifecycle: awaiting-release".
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-*'
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  close-released-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (volledige geschiedenis + tags)
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Issue-nummers verzamelen sinds vorige release-tag
+        id: issues
+        run: |
+          CURRENT_TAG="${GITHUB_REF#refs/tags/}"
+          PREVIOUS_TAG=$(git tag --sort=-creatordate | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+' | grep -v "^${CURRENT_TAG}$" | head -n1 || true)
+
+          if [ -n "$PREVIOUS_TAG" ]; then
+            echo "Vorige release-tag: $PREVIOUS_TAG"
+            RANGE="${PREVIOUS_TAG}..${CURRENT_TAG}"
+          else
+            echo "Geen vorige release-tag gevonden — volledige geschiedenis tot ${CURRENT_TAG}"
+            RANGE="${CURRENT_TAG}"
+          fi
+
+          NUMBERS=$(git log $RANGE --oneline | grep -oE '#[0-9]+' | tr -d '#' | sort -un | tr '\n' ',' | sed 's/,$//')
+          echo "numbers=${NUMBERS}" >> "$GITHUB_OUTPUT"
+          echo "tag=${CURRENT_TAG}" >> "$GITHUB_OUTPUT"
+          echo "Gevonden issue-nummers: ${NUMBERS:-geen}"
+
+      - name: Issues sluiten en label verwijderen
+        if: steps.issues.outputs.numbers != ''
+        uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBERS: ${{ steps.issues.outputs.numbers }}
+          RELEASE_TAG: ${{ steps.issues.outputs.tag }}
+        with:
+          script: |
+            const label = 'status: awaiting-release';
+            const tag = process.env.RELEASE_TAG;
+            const numbers = process.env.ISSUE_NUMBERS.split(',').map(n => parseInt(n, 10)).filter(Boolean);
+
+            for (const number of numbers) {
+              let issue;
+              try {
+                issue = (await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                })).data;
+              } catch (e) {
+                core.warning(`#${number}: kon issue niet ophalen (${e.message}) — overgeslagen`);
+                continue;
+              }
+
+              // issues.get retourneert ook PR's — die slaan we over.
+              if (issue.pull_request) {
+                continue;
+              }
+
+              const hasLabel = issue.labels.some(l => (typeof l === 'string' ? l : l.name) === label);
+              if (hasLabel) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  name: label,
+                }).catch(() => {});
+              }
+
+              if (issue.state === 'open') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  body: `✅ Uitgerold naar productie in release \`${tag}\`.`,
+                });
+                core.notice(`#${number}: gesloten (${tag})`);
+              }
+            }

--- a/.github/workflows/label-awaiting-release.yml
+++ b/.github/workflows/label-awaiting-release.yml
@@ -1,0 +1,85 @@
+name: Label issues awaiting release
+
+# Voegt 'status: awaiting-release' toe aan issues waarvan de fix net naar develop
+# is gemerged. Develop wordt niet automatisch naar productie (main) uitgerold —
+# dit label (en desnoods heropening) voorkomt dat een issue als 'klaar' oogt
+# terwijl de fix nog niet live staat. Het label wordt weer verwijderd door
+# close-released-issues.yml zodra de fix daadwerkelijk naar main gaat.
+# Zie CLAUDE.md, sectie "Issue-lifecycle: awaiting-release".
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [develop]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  label-awaiting-release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Issues labelen als 'awaiting-release'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const label = 'status: awaiting-release';
+            const pr = context.payload.pull_request;
+            const text = `${pr.title}\n${pr.body || ''}`;
+
+            // Verzamel alle #NNN-referenties uit titel + body van de PR.
+            const numbers = [...new Set(
+              [...text.matchAll(/#(\d+)/g)].map(m => parseInt(m[1], 10))
+            )];
+
+            if (numbers.length === 0) {
+              core.notice('Geen #issuenummer gevonden in PR-titel of -body — niets te labelen.');
+              return;
+            }
+
+            for (const number of numbers) {
+              let issue;
+              try {
+                issue = (await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                })).data;
+              } catch (e) {
+                core.warning(`#${number}: kon issue niet ophalen (${e.message}) — overgeslagen`);
+                continue;
+              }
+
+              // issues.get retourneert ook PR's — die slaan we over.
+              if (issue.pull_request) {
+                continue;
+              }
+
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                labels: [label],
+              });
+
+              if (issue.state === 'closed') {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  state: 'open',
+                  state_reason: 'reopened',
+                });
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: number,
+                  body: `🔄 Heropend: de fix zit sinds PR #${pr.number} in \`develop\`, maar \`develop\` is nog niet uitgerold naar productie (\`main\`). Dit issue sluit automatisch zodra de eerstvolgende release naar \`main\` gaat.`,
+                });
+                core.notice(`#${number}: heropend + gelabeld`);
+              } else {
+                core.notice(`#${number}: gelabeld`);
+              }
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Het AI-model is nu instelbaar via de app-instelling `AiModelName`. Een model-upgrade vereist daarmee geen nieuwe versie van de software meer. (#604)
 - Elke pull request bouwt nu automatisch beide projecten en controleert of het databaseontwerp en het migratiescript nog gelijk lopen. Fouten worden zo bij het voorstellen van een wijziging gemeld in plaats van pas bij een deploy. (#599, #595)
 - Verlopen KNVB-verplaatsingsregels worden nu actief gemeld in de logging, en het AI-model geeft in dat geval geen KNVB-waarschuwing meer af op basis van verouderde deadlines. Voorheen verouderden die regels stilzwijgend. (#608)
+- GitHub-issues sluiten niet langer voortijdig: zodra een fix naar `develop` merget krijgt het gekoppelde issue automatisch het label `status: awaiting-release` (en wordt heropend als het al gesloten was). Pas bij de daadwerkelijke release naar productie (`main`) sluit het issue automatisch. (#615)
 
 ### Fixed
 - **De FEEDBACK-knop werkte niet in de live omgeving.** Het venster liep vast met "An unhandled error has occurred" doordat de beveiligingsinstellingen van de website een techniek blokkeerden die het venster gebruikte om de paginanaam en browserversie op te halen. Lokaal was dit niet te zien omdat die beveiliging daar niet geldt. (#597)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,25 @@ gh pr create --base develop --title "feat(#<nr>): ..." --body "..."
 # gh pr create --base main --head develop --title "release: vX.Y.Z" --body "..."
 ```
 
+### Issue-lifecycle: awaiting-release (verplicht — nooit handmatig sluiten bij een develop-merge)
+
+> **Harde regel, vastgelegd na incident 2026-07-26:** issues werden gesloten zodra hun fix-PR
+> naar `develop` merget, terwijl `develop` soms weken/tientallen commits achterloopt op `main`.
+> Daardoor oogden issues als "opgelost" terwijl de fix niet live stond in productie.
+
+- **Een feature- of hotfix-PR mergen naar `develop` sluit het gekoppelde issue NOOIT.** Dat gebeurt
+  automatisch door de workflow `.github/workflows/label-awaiting-release.yml`, die bij elke
+  PR-merge naar `develop` het label `status: awaiting-release` toevoegt aan alle `#<nr>`-issues
+  die in de PR-titel/body staan (en het issue heropent als het per ongeluk al gesloten was).
+- **Het issue sluit pas** wanneer `.github/workflows/close-released-issues.yml` draait — dat
+  gebeurt bij een version-tag push naar `main` (dezelfde trigger als `release.yml`). Die workflow
+  verwijdert het label en sluit alle issues die sinds de vorige release-tag zijn gemerged.
+- Claude zelf roept dus **nooit** `gh issue close <nr>` aan direct na een develop-merge. Stap 5
+  hieronder rapporteert alleen de PR-status — het issue blijft open met `status: awaiting-release`
+  totdat de workflow het automatisch sluit bij de volgende productie-release.
+- Uitzondering: een **hotfix-PR naar `main`** mag na een succesvolle merge + groene
+  `close-released-issues.yml`-run als gesloten worden gerapporteerd, want die code staat dan al live.
+
 ### Stap 4 — CI bewaken
 ```powershell
 gh pr checks <pr-nr> --watch           # wacht op groen


### PR DESCRIPTION
## Samenvatting

Lost #615 op: issues sloten voortijdig zodra hun fix-PR naar `develop` merget, terwijl `develop` soms tientallen commits achterloopt op `main` (productie). Daardoor oogden issues als opgelost terwijl de fix nog niet live stond.

## Wijzigingen

- **Nieuw label** `status: awaiting-release`
- **`.github/workflows/label-awaiting-release.yml`** — bij elke PR-merge naar `develop`: labelt gekoppelde `#nr`-issues met `status: awaiting-release`, heropent ze als ze al gesloten waren
- **`.github/workflows/close-released-issues.yml`** — bij een version-tag push naar `main` (zelfde trigger als `release.yml`): verwijdert het label en sluit de issues definitief, met een comment naar de release-tag
- **CLAUDE.md** — nieuwe sectie "Issue-lifecycle: awaiting-release": nooit meer handmatig een issue sluiten bij een develop-merge

## Test plan

- [ ] Deze PR mergen naar `develop` en controleren dat #615 het label `status: awaiting-release` krijgt
- [ ] Bij de eerstvolgende release-tag naar `main` controleren dat het label verdwijnt en het issue sluit