### PR TITLE
fix(#624): db-check hervat gepauzeerde database via echte login i.p.v. TCP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,12 +29,17 @@ jobs:
     runs-on: ubuntu-latest
     if: vars.AZURE_SQL_SERVER_NAME != '' && vars.AZURE_SQL_DATABASE_NAME != ''
     steps:
+      # Nodig voor scripts/ci/wake-database.sql in de login-poging hieronder (#624).
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
       - name: Azure inloggen
         uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: "▶ Database hervatten indien gepauzeerd (Free-tier auto-pause)"
+      - name: "▶ Databasestatus bepalen (Free-tier auto-pause)"
+        id: status
         run: |
           STATUS=$(az sql db show \
             --name "$SQL_DATABASE" \
@@ -42,6 +47,7 @@ jobs:
             --server "$SQL_SERVER" \
             --query 'status' --output tsv 2>/dev/null || echo "unknown")
           echo "Database status: $STATUS"
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
 
           if [ "$STATUS" = "Disabled" ]; then
             echo "::error::⛔ Database is uitgeschakeld (Disabled) — maandlimiet bereikt of handmatig uitgeschakeld."
@@ -50,59 +56,70 @@ jobs:
           fi
 
           if [ "$STATUS" = "Paused" ] || [ "$STATUS" = "AutoPaused" ]; then
-            echo "Database is gepauzeerd — verbindingspoging om auto-resume te triggeren..."
-
-            # Voeg runner-IP toe aan firewall zodat de TCP-verbinding de database bereikt
-            RUNNER_IP=$(curl -s https://api.ipify.org)
-            RULE_NAME="db-check-resume-${{ github.run_id }}"
-            az sql server firewall-rule create \
-              --resource-group "$SQL_RESOURCE_GROUP" \
-              --server "$SQL_SERVER" \
-              --name "$RULE_NAME" \
-              --start-ip-address "$RUNNER_IP" \
-              --end-ip-address "$RUNNER_IP" 2>/dev/null || echo "Firewall rule aanmaken mislukt — doorgaan"
-
-            # TCP-verbindingspoging triggert Azure SQL Serverless auto-resume (SYN naar poort 1433)
-            timeout 5 bash -c "echo > /dev/tcp/$SQL_SERVER.database.windows.net/1433" 2>/dev/null \
-              && echo "TCP-verbinding gelukt" \
-              || echo "TCP-verbindingspoging verstuurd (auto-resume gestart)"
-
-            echo "Wachten op Online status (max 10 minuten)..."
-            for i in $(seq 1 40); do
-              sleep 15
-              STATUS=$(az sql db show \
-                --name "$SQL_DATABASE" \
-                --resource-group "$SQL_RESOURCE_GROUP" \
-                --server "$SQL_SERVER" \
-                --query 'status' --output tsv 2>/dev/null || echo "unknown")
-              echo "  Check $i/40: $STATUS"
-              if [ "$STATUS" = "Online" ]; then
-                echo "✓ Database Online"
-                break
-              fi
-              if [ "$STATUS" = "Resuming" ]; then
-                echo "  Database aan het hervatten — wachten..."
-              fi
-            done
-
-            # Firewall-regel opruimen (ook bij fout)
-            az sql server firewall-rule delete \
-              --resource-group "$SQL_RESOURCE_GROUP" \
-              --server "$SQL_SERVER" \
-              --name "$RULE_NAME" \
-              --yes 2>/dev/null || true
-
-            if [ "$STATUS" != "Online" ]; then
-              echo "::error::⛔ Database niet Online na 10 minuten wachten (status: $STATUS)."
-              echo "::error::Herstel: Azure Portal → SQL Database → Overzicht → Resume, dan deploy opnieuw starten."
-              exit 1
-            fi
+            echo "paused=true" >> $GITHUB_OUTPUT
+          else
+            echo "paused=false" >> $GITHUB_OUTPUT
           fi
 
-          if [ "$STATUS" = "unknown" ]; then
+      - name: "▶ Runner-IP toevoegen aan SQL-firewall (alleen bij gepauzeerde database)"
+        if: steps.status.outputs.paused == 'true'
+        run: |
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          az sql server firewall-rule create \
+            --resource-group "$SQL_RESOURCE_GROUP" \
+            --server "$SQL_SERVER" \
+            --name "db-check-resume-${{ github.run_id }}" \
+            --start-ip-address "$RUNNER_IP" \
+            --end-ip-address "$RUNNER_IP" 2>/dev/null || echo "Firewall rule aanmaken mislukt — doorgaan"
+
+      # Een echte login triggert Azure SQL Serverless auto-resume. Een kale TCP-verbinding
+      # doet dat NIET: die wordt door de SQL-gateway afgehandeld en bereikt de database nooit,
+      # waardoor de gate 'Paused' bleef zien tot de timeout. Zie #624.
+      # De eerste login faalt verwacht (database wakker aan het worden) — daarom continue-on-error.
+      - name: "▶ Login-poging om auto-resume te triggeren"
+        if: steps.status.outputs.paused == 'true'
+        continue-on-error: true
+        uses: azure/sql-action@v2.3
+        with:
+          connection-string: ${{ secrets.SQL_CONNECTION_STRING }}
+          path: scripts/ci/wake-database.sql
+
+      - name: "▶ Wachten tot database Online is (max 10 minuten)"
+        if: steps.status.outputs.paused == 'true'
+        run: |
+          for i in $(seq 1 40); do
+            STATUS=$(az sql db show \
+              --name "$SQL_DATABASE" \
+              --resource-group "$SQL_RESOURCE_GROUP" \
+              --server "$SQL_SERVER" \
+              --query 'status' --output tsv 2>/dev/null || echo "unknown")
+            echo "  Check $i/40: $STATUS"
+            [ "$STATUS" = "Online" ] && break
+            sleep 15
+          done
+
+          if [ "$STATUS" != "Online" ]; then
+            echo "::error::⛔ Database niet Online na 10 minuten wachten (status: $STATUS)."
+            echo "::error::Herstel: Azure Portal → SQL Database → Overzicht → Resume, dan deploy opnieuw starten."
+            exit 1
+          fi
+          echo "✓ Database Online"
+
+      - name: "▶ Firewall-regel opruimen"
+        if: always() && steps.status.outputs.paused == 'true'
+        run: |
+          az sql server firewall-rule delete \
+            --resource-group "$SQL_RESOURCE_GROUP" \
+            --server "$SQL_SERVER" \
+            --name "db-check-resume-${{ github.run_id }}" \
+            --yes 2>/dev/null || true
+
+      - name: "▶ Eindstatus"
+        run: |
+          if [ "${{ steps.status.outputs.status }}" = "unknown" ]; then
             echo "::warning::⚠️ Database-status onbekend via ARM API — deployment gaat door."
           else
-            echo "✓ Database $STATUS — deployment mag doorgaan"
+            echo "✓ Database beschikbaar — deployment mag doorgaan"
           fi
 
   build:

--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -24,12 +24,17 @@ jobs:
     runs-on: ubuntu-latest
     if: vars.AZURE_SQL_SERVER_NAME != '' && vars.AZURE_SQL_DATABASE_NAME != ''
     steps:
+      # Nodig voor scripts/ci/wake-database.sql in de login-poging hieronder (#624).
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
       - name: Azure inloggen
         uses: azure/login@v3
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-      - name: "▶ Database hervatten indien gepauzeerd en status verifiëren"
+      - name: "▶ Databasestatus bepalen"
+        id: status
         run: |
           STATUS=$(az sql db show \
             --name "$SQL_DATABASE" \
@@ -37,6 +42,7 @@ jobs:
             --server "$SQL_SERVER" \
             --query 'status' --output tsv 2>/dev/null || echo "unknown")
           echo "Database status: $STATUS"
+          echo "status=$STATUS" >> $GITHUB_OUTPUT
 
           if [ "$STATUS" = "Disabled" ]; then
             echo "::error::⛔ Database uitgeschakeld — maandlimiet bereikt. Wacht tot begin volgende maand."
@@ -44,51 +50,69 @@ jobs:
           fi
 
           if [ "$STATUS" = "Paused" ] || [ "$STATUS" = "AutoPaused" ]; then
-            echo "Database is gepauzeerd — verbindingspoging om auto-resume te triggeren..."
-
-            # Voeg runner-IP toe aan firewall zodat de TCP-verbinding de database bereikt
-            RUNNER_IP=$(curl -s https://api.ipify.org)
-            RULE_NAME="db-check-pr-${{ github.run_id }}"
-            az sql server firewall-rule create \
-              --resource-group "$SQL_RESOURCE_GROUP" \
-              --server "$SQL_SERVER" \
-              --name "$RULE_NAME" \
-              --start-ip-address "$RUNNER_IP" \
-              --end-ip-address "$RUNNER_IP" 2>/dev/null || echo "Firewall rule aanmaken mislukt — doorgaan"
-
-            # TCP-verbindingspoging triggert Azure SQL Serverless auto-resume (SYN naar poort 1433)
-            timeout 5 bash -c "echo > /dev/tcp/$SQL_SERVER.database.windows.net/1433" 2>/dev/null \
-              && echo "TCP-verbinding gelukt" \
-              || echo "TCP-verbindingspoging verstuurd (auto-resume gestart)"
-
-            for i in $(seq 1 20); do
-              sleep 15
-              STATUS=$(az sql db show \
-                --name "$SQL_DATABASE" \
-                --resource-group "$SQL_RESOURCE_GROUP" \
-                --server "$SQL_SERVER" \
-                --query 'status' --output tsv 2>/dev/null || echo "unknown")
-              echo "  Check $i/20: $STATUS"
-              [ "$STATUS" = "Online" ] && break
-            done
-
-            # Firewall-regel opruimen (ook bij fout)
-            az sql server firewall-rule delete \
-              --resource-group "$SQL_RESOURCE_GROUP" \
-              --server "$SQL_SERVER" \
-              --name "$RULE_NAME" \
-              --yes 2>/dev/null || true
-
-            if [ "$STATUS" != "Online" ]; then
-              echo "::error::⛔ Database nog niet Online na wachten (status: $STATUS)."
-              exit 1
-            fi
+            echo "paused=true" >> $GITHUB_OUTPUT
+          else
+            echo "paused=false" >> $GITHUB_OUTPUT
           fi
 
-          if [ "$STATUS" = "unknown" ]; then
+      - name: "▶ Runner-IP toevoegen aan SQL-firewall (alleen bij gepauzeerde database)"
+        if: steps.status.outputs.paused == 'true'
+        run: |
+          RUNNER_IP=$(curl -s https://api.ipify.org)
+          az sql server firewall-rule create \
+            --resource-group "$SQL_RESOURCE_GROUP" \
+            --server "$SQL_SERVER" \
+            --name "db-check-pr-${{ github.run_id }}" \
+            --start-ip-address "$RUNNER_IP" \
+            --end-ip-address "$RUNNER_IP" 2>/dev/null || echo "Firewall rule aanmaken mislukt — doorgaan"
+
+      # Een echte login triggert Azure SQL Serverless auto-resume. Een kale TCP-verbinding
+      # doet dat NIET: die wordt door de SQL-gateway afgehandeld en bereikt de database nooit,
+      # waardoor de gate 20 checks lang 'Paused' bleef zien. Zie #624.
+      # De eerste login faalt verwacht (database wakker aan het worden) — daarom continue-on-error.
+      - name: "▶ Login-poging om auto-resume te triggeren"
+        if: steps.status.outputs.paused == 'true'
+        continue-on-error: true
+        uses: azure/sql-action@v2.3
+        with:
+          connection-string: ${{ secrets.SQL_CONNECTION_STRING }}
+          path: scripts/ci/wake-database.sql
+
+      - name: "▶ Wachten tot database Online is"
+        if: steps.status.outputs.paused == 'true'
+        run: |
+          for i in $(seq 1 20); do
+            STATUS=$(az sql db show \
+              --name "$SQL_DATABASE" \
+              --resource-group "$SQL_RESOURCE_GROUP" \
+              --server "$SQL_SERVER" \
+              --query 'status' --output tsv 2>/dev/null || echo "unknown")
+            echo "  Check $i/20: $STATUS"
+            [ "$STATUS" = "Online" ] && break
+            sleep 15
+          done
+
+          if [ "$STATUS" != "Online" ]; then
+            echo "::error::⛔ Database nog niet Online na wachten (status: $STATUS)."
+            exit 1
+          fi
+          echo "✓ Database Online — release mag doorgaan"
+
+      - name: "▶ Firewall-regel opruimen"
+        if: always() && steps.status.outputs.paused == 'true'
+        run: |
+          az sql server firewall-rule delete \
+            --resource-group "$SQL_RESOURCE_GROUP" \
+            --server "$SQL_SERVER" \
+            --name "db-check-pr-${{ github.run_id }}" \
+            --yes 2>/dev/null || true
+
+      - name: "▶ Eindstatus"
+        run: |
+          if [ "${{ steps.status.outputs.status }}" = "unknown" ]; then
             echo "::warning::⚠️ Database-status onbekend — merge toegestaan, controleer handmatig."
           else
-            echo "✓ Database $STATUS — release mag doorgaan"
+            echo "✓ Database beschikbaar — release mag doorgaan"
           fi
 
   # ── 2. Build-verificatie ──────────────────────────────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - Ontbreekt de instelling voor de GitHub-repository, dan meldt het systeem dat nu als configuratiefout in plaats van een onduidelijke "niet gevonden"-melding te geven. Dit raakt clubs die het project onder een andere naam overnemen. (#607)
 - Een gepauzeerde database blokkeert de bouwstap niet langer. Voorheen werden daardoor alle controles overgeslagen en konden programmeerfouten wekenlang onopgemerkt blijven. Deployen naar een gepauzeerde database blijft geblokkeerd. (#599)
 - Testdata: het auto-invullen van het uitteam bij selectie van een thuisteam respecteert nu de ingestelde 'Tegenstander (nieuw)' — was voorheen hardcoded op 'FC Onbekend' ook als de gebruiker iets anders had ingevuld. (#498)
+- **Een release liep vast zodra de database in slaapstand stond.** De controle die de database wakker maakt vóór een deploy legde alleen een netwerkverbinding aan; die wordt door Azure afgevangen vóórdat de database hem ziet, waardoor de database bleef slapen en de release na vijf minuten afbrak. Er wordt nu daadwerkelijk ingelogd op de database — dat is wat het wakker worden in gang zet. (#624)
 
 ### Changed
 - De API-documentatie (`openapi.yaml`/`.json`) is bijgewerkt naar de huidige versie en bevat nu ook de twee endpoints voor het importeren van teambegeleiding en het verschuiven van testwedstrijden. (#605)

--- a/scripts/ci/wake-database.sql
+++ b/scripts/ci/wake-database.sql
@@ -1,0 +1,4 @@
+-- Triviale query die uitsluitend dient om een echte SQL-login uit te voeren.
+-- Een login is wat Azure SQL Serverless auto-resume triggert; een kale TCP-verbinding
+-- wordt door de gateway afgehandeld en bereikt de database nooit. Zie #624.
+SELECT 1;


### PR DESCRIPTION
Deblokkeert release-PR #622. De database-gate faalde omdat de resume-poging de database nooit bereikt.

Closes #624

## Oorzaak
De resume-stap opende een kale TCP-socket:

```bash
timeout 5 bash -c "echo > /dev/tcp/$SQL_SERVER.database.windows.net/1433"
```

Die handshake wordt afgehandeld door de **Azure SQL-gateway**, niet door de database. Serverless auto-resume wordt pas getriggerd door een **echte login**. De stap meldde daarom `TCP-verbinding gelukt` en faalde vervolgens alsnog op 20× `Paused` — een misleidende combinatie die de indruk wekte dat de database stuk was.

## Uitgesloten oorzaken
| Hypothese | Bevinding |
|---|---|
| Maandlimiet bereikt | Nee — `free_amount_remaining` = **52.282** van 100.000 vCore-seconden (`free_amount_consumed` = 48.361) |
| Expliciete resume-API bruikbaar | Nee — `POST .../resume` geeft `FeatureDisabledOnSelectedEdition` op deze editie; `az sql db resume` bestaat niet in de gebruikte CLI-versie. Vermoedelijk de reden dat eerder op TCP is overgestapt |

## Oplossing
Firewallregel → **echte login** via `azure/sql-action` met de bestaande `SQL_CONNECTION_STRING`-secret → pollen op `Online` → firewallregel opruimen (`if: always()`).

De eerste login mag falen — de database is dan net wakker aan het worden. Daarom `continue-on-error: true`: de login *zelf* is de trigger, niet het resultaat. De daaropvolgende statuspoll bepaalt of de gate slaagt.

Doorgevoerd in **beide** workflows die deze gate draaien:
- `.github/workflows/pre-release-check.yml` (blokkeert de release-PR)
- `.github/workflows/deploy.yml` (blokkeert de deploy zelf)

Beide `db-check`-jobs hebben nu een `actions/checkout`-stap — die ontbrak, maar is nodig voor `scripts/ci/wake-database.sql`.

## Overige
- De monolithische bash-stap is opgesplitst in losse stappen met `if:`-guards, zodat de firewall-opruiming via `if: always()` gegarandeerd draait en niet meer middenin een `if`-blok hangt.
- Geen versiebump: CI-only wijziging zonder effect op de applicatie.
- YAML-syntaxis van beide workflows gevalideerd.

## Verificatie
Dit is per definitie pas volledig te verifiëren in CI met een gepauzeerde database — precies de situatie op #622. Na merge naar `develop` draait de gate opnieuw op die PR; dat is de test.