### PR TITLE
chore(#634): dependabot-updates juli 2026 ronde 2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
       - name: "▶ Login-poging om auto-resume te triggeren"
         if: steps.status.outputs.paused == 'true'
         continue-on-error: true
-        uses: azure/sql-action@v2.3
+        uses: azure/sql-action@v2.4
         with:
           connection-string: ${{ secrets.SQL_CONNECTION_STRING }}
           path: scripts/ci/wake-database.sql
@@ -213,7 +213,7 @@ jobs:
           echo "rule_name=$RULE_NAME" >> $GITHUB_OUTPUT
 
       - name: Database-migratie uitvoeren (PostDeployment script — idempotent)
-        uses: azure/sql-action@v2.3
+        uses: azure/sql-action@v2.4
         with:
           connection-string: ${{ secrets.SQL_CONNECTION_STRING }}
           path: Database/Script.PostDeployment1.sql

--- a/.github/workflows/pre-release-check.yml
+++ b/.github/workflows/pre-release-check.yml
@@ -73,7 +73,7 @@ jobs:
       - name: "▶ Login-poging om auto-resume te triggeren"
         if: steps.status.outputs.paused == 'true'
         continue-on-error: true
-        uses: azure/sql-action@v2.3
+        uses: azure/sql-action@v2.4
         with:
           connection-string: ${{ secrets.SQL_CONNECTION_STRING }}
           path: scripts/ci/wake-database.sql

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Changed
+- Onderhoudsupdates van externe softwarebibliotheken doorgevoerd (Azure Functions worker-SDK en HTTP-uitbreiding, de AI-bibliotheek, en de database-actie in de bouwstraat). Geen functionele wijzigingen; dit houdt het systeem bij op beveiligings- en foutherstel van de leveranciers. (#634)
+
 ### Security
 - **Tijdelijke toegangsregels van de bouwstraat werden nooit opgeruimd.** Bij elke deploy krijgt de bouwserver kortdurend toegang tot de database; die toegang moest daarna weer worden ingetrokken. Door een fout in het opruimcommando gebeurde dat nooit, terwijl de stap wél een vinkje gaf — er stonden 15 verouderde toegangsregels open. Het commando is gecorrigeerd en fouten worden nu zichtbaar gemeld in plaats van weggeslikt. (#632)
 

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -26,11 +26,11 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Cronos" Version="0.13.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="2.52.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Timer" Version="4.3.1" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.1.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.2" />
-    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.1" />
     <PackageReference Include="Microsoft.Graph" Version="6.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />


### PR DESCRIPTION
Voegt de vier openstaande dependabot-updates samen op één branch.

Closes #634
Supersedes #626, #627, #628, #629

## Waarom samengevoegd
#627, #628 en #629 wijzigen alle drie hetzelfde `PackageReference`-blok in `FunctionApp/fa-dev-sportlink-01.csproj`. Los mergen laat de tweede en derde PR conflicteren. Conform de werkwijze uit #586 zijn de doelversies daarom op één branch toegepast en in één keer geverifieerd.

| Update | Van | Naar | PR |
|---|---|---|---|
| `Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore` | 2.1.0 | 2.1.1 | #627 |
| `Microsoft.Azure.Functions.Worker.Sdk` | 2.0.7 | 2.1.0 | #628 |
| `Microsoft.Extensions.AI.OpenAI` | 10.8.0 | 10.8.1 | #629 |
| `azure/sql-action` | v2.3 | v2.4 | #626 |

`azure/sql-action` is op alle drie de gebruikslocaties bijgewerkt: `db-check` en `db-migrate` in `deploy.yml`, en `db-check` in `pre-release-check.yml`.

## Expliciet gecontroleerd: net9.0-constraint
`Microsoft.Azure.Functions.Worker.Sdk` is een **minor** bump op de isolated-worker SDK — precies het type update dat een TFM-verhoging kan meebrengen. Nagegaan: `<TargetFramework>` staat nog op `net9.0`. Verhogen naar `net10.0` breekt het Linux Consumption Plan met 503 "Function host is not running".

## Verificatie
| Stap | Resultaat |
|---|---|
| `dotnet build` FunctionApp (net9.0) | 0 errors, 0 warnings |
| `dotnet build` BlazorAdmin (net10.0) | 0 errors, 0 warnings |
| `dotnet test` | 126 passed, 3 skipped, 0 failed |
| YAML-syntaxis beide workflows | geldig |
| FunctionApp TFM | `net9.0` — ongewijzigd |

## Nog te verifiëren ná merge
De Node.js 20-deprecatiewaarschuwing op `azure/sql-action@v2.3` verscheen tweemaal in de deploy van v2.17.0.0. Of v2.4 op Node 24 target en die waarschuwing daarmee verdwijnt is **niet vastgesteld** — dat blijkt pas uit de eerstvolgende workflow-run die de actie gebruikt.

Belangrijker: `db-check` gebruikt `azure/sql-action` sinds #624 voor de resume-login. Die logica is alleen echt te testen tegen een **gepauzeerde** database. De database staat nu Online (autoPauseDelay 60 min), dus dat volgt automatisch bij een volgende run buiten actief gebruik.

## Geen versiebump
Patch-level dependency-updates zonder functioneel effect op de applicatie.