### PR TITLE
fix(#630): issue-lifecycle sluit gereleasede issues en heropent ze niet meer onterecht

### DIFF
--- a/.github/workflows/close-released-issues.yml
+++ b/.github/workflows/close-released-issues.yml
@@ -39,10 +39,33 @@ jobs:
             RANGE="${CURRENT_TAG}"
           fi
 
-          NUMBERS=$(git log $RANGE --oneline | grep -oE '#[0-9]+' | tr -d '#' | sort -un | tr '\n' ',' | sed 's/,$//')
+          # Bron 1 — commit-subjects in de range. Dekt de conventie 'fix(#NNN): ...'.
+          COMMIT_NUMBERS=$(git log $RANGE --oneline | grep -oE '#[0-9]+' | tr -d '#' | sort -un)
+          echo "Uit commit-subjects: $(echo $COMMIT_NUMBERS | tr '\n' ' ')"
+
+          # Bron 2 — de CHANGELOG-sectie van deze versie (#630).
+          # Commit-subjects alleen zijn niet genoeg: batch-PR's sommen niet alle nummers op in het
+          # subject. Bij v2.17.0.0 miste dat #574, #575, #576, #579 en #599 terwijl die wel in de
+          # release zaten. De CHANGELOG is de gecureerde lijst van wat er daadwerkelijk in zit.
+          #
+          # Alleen haakjesgroepen die UITSLUITEND issuenummers bevatten — '(#574)' of '(#599, #595)' —
+          # conform de attributie-conventie uit CLAUDE.md. Zo blijven kruisverwijzingen in prozavorm
+          # buiten beeld: '(zie #569)' en 'conform het patroon van issue #242' mogen niets sluiten.
+          VERSION="${CURRENT_TAG#v}"
+          CHANGELOG_NUMBERS=$(awk -v marker="## [${VERSION}]" '
+              index($0, marker) == 1 { inside = 1; next }
+              inside && /^## \[/ { exit }
+              inside
+            ' CHANGELOG.md \
+            | grep -oE '\(#[0-9]+(, *#[0-9]+)*\)' \
+            | grep -oE '[0-9]+' | sort -un || true)
+          echo "Uit CHANGELOG-sectie [${VERSION}]: $(echo $CHANGELOG_NUMBERS | tr '\n' ' ')"
+
+          NUMBERS=$(printf '%s\n%s\n' "$COMMIT_NUMBERS" "$CHANGELOG_NUMBERS" \
+            | grep -E '^[0-9]+$' | sort -un | tr '\n' ',' | sed 's/,$//')
           echo "numbers=${NUMBERS}" >> "$GITHUB_OUTPUT"
           echo "tag=${CURRENT_TAG}" >> "$GITHUB_OUTPUT"
-          echo "Gevonden issue-nummers: ${NUMBERS:-geen}"
+          echo "Samengevoegd: ${NUMBERS:-geen}"
 
       - name: Issues sluiten en label verwijderen
         if: steps.issues.outputs.numbers != ''
@@ -101,3 +124,39 @@ jobs:
                 core.notice(`#${number}: gesloten (${tag})`);
               }
             }
+
+      # Vangnet (#630): meld wat na deze run nog op 'awaiting-release' staat. Zonder dit rapport
+      # blijft een gemist issue stil openstaan met een label dat suggereert dat het nog wacht —
+      # precies de verwarring die #615 wilde wegnemen.
+      - name: Rapporteer issues die nog op awaiting-release staan
+        if: always()
+        uses: actions/github-script@v9
+        env:
+          RELEASE_TAG: ${{ steps.issues.outputs.tag }}
+        with:
+          script: |
+            const label = 'status: awaiting-release';
+            const { data: remaining } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: label,
+              state: 'open',
+              per_page: 100,
+            });
+
+            const issues = remaining.filter(i => !i.pull_request);
+            if (issues.length === 0) {
+              core.notice(`Geen issues meer op '${label}' — lifecycle sluitend na ${process.env.RELEASE_TAG}.`);
+              return;
+            }
+
+            const lijst = issues.map(i => `#${i.number} — ${i.title}`).join('\n');
+            core.warning(
+              `${issues.length} issue(s) staan na release ${process.env.RELEASE_TAG} nog op '${label}'.\n` +
+              `Als de fix wél in deze release zat, ontbreekt het nummer in zowel de commit-subjects ` +
+              `als de CHANGELOG-attributie — controleer handmatig:\n${lijst}`
+            );
+            await core.summary
+              .addHeading(`Nog op '${label}' na ${process.env.RELEASE_TAG}`, 3)
+              .addList(issues.map(i => `#${i.number} — ${i.title}`))
+              .write();

--- a/.github/workflows/label-awaiting-release.yml
+++ b/.github/workflows/label-awaiting-release.yml
@@ -27,12 +27,32 @@ jobs:
           script: |
             const label = 'status: awaiting-release';
             const pr = context.payload.pull_request;
-            const text = `${pr.title}\n${pr.body || ''}`;
+            const title = pr.title || '';
+            const body = pr.body || '';
+            const text = `${title}\n${body}`;
 
-            // Verzamel alle #NNN-referenties uit titel + body van de PR.
+            // Alle #NNN-referenties uit titel + body. Basis voor het LABELEN van open issues:
+            // ruim scannen is daar onschadelijk en levert de meeste zichtbaarheid op.
             const numbers = [...new Set(
               [...text.matchAll(/#(\d+)/g)].map(m => parseInt(m[1], 10))
             )];
+
+            // Voor het HEROPENEN van een al gesloten issue geldt een strengere eis (#630).
+            // Een kale kruisverwijzing mag een gereleasede fix niet uit de dood halen: PR #633
+            // noemde '#624' alleen in proza ("nieuw in #624") en heropende daarmee een issue dat
+            // 20 minuten eerder correct door de release was gesloten.
+            //
+            // Alleen deze twee vormen gelden als "deze PR pakt dat issue aan":
+            //   1. het nummer staat in de PR-TITEL — dekt de conventie 'fix(#NNN): ...'
+            //   2. het nummer staat achter een sluitend keyword in de body ('Closes #N', 'Fixes #N')
+            const titleNumbers = new Set(
+              [...title.matchAll(/#(\d+)/g)].map(m => parseInt(m[1], 10))
+            );
+            const closingNumbers = new Set(
+              [...body.matchAll(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s+#(\d+)/gi)]
+                .map(m => parseInt(m[1], 10))
+            );
+            const mayReopen = n => titleNumbers.has(n) || closingNumbers.has(n);
 
             if (numbers.length === 0) {
               core.notice('Geen #issuenummer gevonden in PR-titel of -body — niets te labelen.');
@@ -54,6 +74,13 @@ jobs:
 
               // issues.get retourneert ook PR's — die slaan we over.
               if (issue.pull_request) {
+                continue;
+              }
+
+              // Gesloten issue zonder titel- of sluitend-keyword-referentie: volledig overslaan.
+              // Niet labelen en niet heropenen — het is hier alleen als kruisverwijzing genoemd (#630).
+              if (issue.state === 'closed' && !mayReopen(number)) {
+                core.notice(`#${number}: gesloten en alleen als kruisverwijzing genoemd — overgeslagen`);
                 continue;
               }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- **Issues bleven na een release onterecht als 'wacht op release' openstaan, of kwamen juist weer open te staan nadat ze al waren afgerond.** Bij de vorige release gold dat voor vijf issues: hun nummer stond niet in de commit-tekst, alleen in het wijzigingsoverzicht. Daarnaast werd een al afgerond issue opnieuw geopend zodra een latere wijziging het nummer terzijde vermeldde. Beide zijn verholpen: het wijzigingsoverzicht wordt nu meegelezen bij het afsluiten, een terzijde-vermelding heropent niets meer, en na elke release wordt gemeld welke issues nog openstaan zodat er niets stil blijft hangen. (#630)
+
 ### Changed
 - Onderhoudsupdates van externe softwarebibliotheken doorgevoerd (Azure Functions worker-SDK en HTTP-uitbreiding, de AI-bibliotheek, en de database-actie in de bouwstraat). Geen functionele wijzigingen; dit houdt het systeem bij op beveiligings- en foutherstel van de leveranciers. (#634)
 


### PR DESCRIPTION
Twee tegengestelde defecten in de issue-lifecycle-automatisering uit #615, beide waargenomen bij release v2.17.0.0.

Closes #630

## Defect 1 — `close-released-issues` miste issues
De workflow las uitsluitend commit-subjects. Batch-PR''s sommen niet alle nummers in het subject op, waardoor **#574, #575, #576, #579 en #599** open bleven met `status: awaiting-release` terwijl hun fix live stond. Ik heb die vijf handmatig moeten verifiëren en sluiten.

**Nu:** de CHANGELOG-sectie van de gereleasede versie is een tweede bron.

Alleen haakjesgroepen die **uitsluitend** issuenummers bevatten — `(#574)` of `(#599, #595)` — conform de attributie-conventie uit CLAUDE.md. Prozaverwijzingen blijven daardoor buiten beeld, wat essentieel is: `(zie #569)` en "conform het patroon van issue #242" mogen niets sluiten.

Empirisch getoetst tegen de echte `v2.16.0.0..v2.17.0.0`-data:

| Controle | Resultaat |
|---|---|
| #574, #575, #576, #579, #599 gevonden | alle vijf |
| #569 (staat als `(zie #569)`) | correct uitgesloten |
| #242 ("van issue #242") | correct uitgesloten |

## Defect 2 — `label-awaiting-release` heropende gereleasede issues
Elke `#NNN` in titel of body leidde tot heropening van een gesloten issue. PR #633 noemde `#624` **alleen in proza** ("nieuw in #624") en haalde daarmee een issue terug dat 20 minuten eerder correct door de release was gesloten.

Tijdlijn van #624 vandaag:

| Tijd | Gebeurtenis |
|---|---|
| 10:06:32 | gesloten door `close-released-issues.yml` — correct |
| 10:29:31 | **heropend** door `label-awaiting-release.yml` — onterecht |

**Nu:** heropenen vereist dat het nummer in de PR-**titel** staat (dekt de conventie `fix(#NNN): ...`) of achter een **sluitend keyword** in de body (`Closes`/`Fixes`/`Resolves #N`). Een gesloten issue dat alleen als kruisverwijzing voorkomt wordt volledig overgeslagen — niet gelabeld, niet heropend.

Labelen van **open** issues blijft ruim scannen; daar is een extra label onschadelijk en levert het de meeste zichtbaarheid.

Getoetst tegen de echte PR-teksten:

| Scenario | Verwacht | Resultaat |
|---|---|---|
| PR #633 heropent #624 (prozavermelding) | nee | nee |
| PR #625 labelt #624 (`fix(#624):` + `Closes #624`) | ja | ja |
| PR #584 raakt #577 (daar bewust buiten scope) | nee | nee |

## Waarom niet gekozen voor "PR-bodies scannen"
Dat was mijn eerste gedachte in #630, maar het werkt niet. PR #584 somt de opgeloste issues in **Nederlandse proza** op ("Lost de review-issues #573, #580, #572, #575, #574 … op") zonder Engels keyword, én zegt expliciet dat #577 **niet** is meegenomen. Bodies scannen levert dus óf niets (bij eisen van keywords) óf sluit #577 onterecht (bij alle refs). De CHANGELOG is wél gecureerd en betrouwbaar.

## Vangnet
Na elke release wordt gerapporteerd welke issues nog op `status: awaiting-release` staan — als `::warning::` en in de job-summary. Een gemist issue blijft daardoor niet stil hangen achter een misleidend label.

## Verificatie
- Extractielogica gesimuleerd tegen de echte release-range en CHANGELOG (zie tabellen hierboven)
- Reopen-guard getest tegen de echte PR-titels en -bodies
- YAML-syntaxis van beide workflows gevalideerd
- Geen versiebump: CI-only wijziging zonder effect op de applicatie

Volledig sluitend bewijs volgt pas bij de volgende release-tag — dan draait deze code voor het eerst echt.