### PR TITLE
fix(#631): seizoen wordt niet meer bij elke deploy gedupliceerd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 ## [Unreleased]
 
 ### Fixed
+- **Het huidige seizoen werd bij elke uitrol opnieuw aan de seizoenslijst toegevoegd.** In productie stond het seizoen 2026/'27 daardoor drie keer in de lijst, en groeide dat met elke uitrol verder. De gegevenslijst die datums aan seizoenen koppelt gaf daardoor elke datum van dit seizoen drievoudig terug. De planning en de synchronisatie waren hierdoor niet geraakt — die kijken alleen naar de eerste en laatste datum. De dubbele regels zijn opgeruimd en de lijst laat een seizoen nu maar één keer toe. (#631)
 - **Issues bleven na een release onterecht als 'wacht op release' openstaan, of kwamen juist weer open te staan nadat ze al waren afgerond.** Bij de vorige release gold dat voor vijf issues: hun nummer stond niet in de commit-tekst, alleen in het wijzigingsoverzicht. Daarnaast werd een al afgerond issue opnieuw geopend zodra een latere wijziging het nummer terzijde vermeldde. Beide zijn verholpen: het wijzigingsoverzicht wordt nu meegelezen bij het afsluiten, een terzijde-vermelding heropent niets meer, en na elke release wordt gemeld welke issues nog openstaan zodat er niets stil blijft hangen. (#630)
 
 ### Changed

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -800,6 +800,53 @@ END;
 END
 GO
 
+-- ============================================================
+-- #631: duplicaten in dbo.Season opruimen en een unique constraint aanbrengen.
+--
+-- De oude guard in sp_UpdateSeasonTable vergeleek YEAR(MAX(DateUntil)) met YEAR(GETDATE())+1.
+-- Zodra er een toekomstig seizoen in de tabel stond kon die conditie nooit meer onwaar worden,
+-- waardoor bij ELKE deploy hetzelfde seizoen opnieuw werd ingevoegd. In productie stonden zo
+-- 3 identieke rijen voor 2026-2027. Omdat pub.DateTable een INNER JOIN op dbo.Season doet,
+-- leverde die view 3 rijen per datum voor het huidige seizoen (2557 i.p.v. 2192 rijen).
+--
+-- De applicatie zelf was niet geraakt: alle C#-consumers gebruiken MAX()/MIN()-aggregaten.
+--
+-- Deze block draait VOOR de EXEC hieronder, zodat de deduplicatie klaar is voordat de procedure
+-- iets kan invoegen. Volgorde is essentieel: de constraint kan pas na het opruimen, anders faalt
+-- de deploy op de bestaande duplicaten.
+-- ============================================================
+IF EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.Season'))
+BEGIN
+    -- Rijen zonder naam zijn onbruikbaar (de naam is de business key) en blokkeren NOT NULL.
+    DELETE FROM [dbo].[Season] WHERE [Name] IS NULL;
+
+    -- Houd per seizoensnaam één rij over. ORDER BY op de datums zodat de bewaarde rij
+    -- deterministisch is en niet afhangt van de fysieke rijvolgorde.
+    ;WITH Duplicaten AS (
+        SELECT ROW_NUMBER() OVER (
+                   PARTITION BY [Name]
+                   ORDER BY [DateFrom], [DateUntil]
+               ) AS rn
+        FROM [dbo].[Season]
+    )
+    DELETE FROM Duplicaten WHERE rn > 1;
+
+    IF EXISTS (
+        SELECT 1 FROM sys.columns
+        WHERE object_id = OBJECT_ID('dbo.Season')
+          AND name = 'Name'
+          AND is_nullable = 1
+    )
+        ALTER TABLE [dbo].[Season] ALTER COLUMN [Name] NCHAR(9) NOT NULL;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM sys.indexes
+        WHERE object_id = OBJECT_ID('dbo.Season') AND name = 'UQ_Season_Name'
+    )
+        ALTER TABLE [dbo].[Season] ADD CONSTRAINT [UQ_Season_Name] UNIQUE ([Name]);
+END
+GO
+
 -- Update the Season and datetable
 -- Een scalar subquery zonder aggregatie faalt met Msg 512 zodra dbo.AppSettings meer dan één rij
 -- heeft — en dat is altijd het geval nadat de AllStars FC demo-club verderop in dit script is
@@ -1578,10 +1625,13 @@ GO
 -- ============================================================
 IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.Season'))
 BEGIN
+    -- #631: Name is NOT NULL met unique constraint, zodat een verse installatie meteen beschermd
+    -- is tegen duplicaatseizoenen. Bestaande installaties worden hierboven opgeruimd en gemigreerd.
     CREATE TABLE [dbo].[Season] (
-        [Name]      NCHAR(9) NULL,
+        [Name]      NCHAR(9) NOT NULL,
         [DateFrom]  DATE     NULL,
-        [DateUntil] DATE     NULL
+        [DateUntil] DATE     NULL,
+        CONSTRAINT [UQ_Season_Name] UNIQUE ([Name])
     );
 END
 GO
@@ -1718,8 +1768,17 @@ BEGIN
 	END
 
 	-- Create 2 months before start of a new season a new record in season table
-	IF (SELECT YEAR(MAX(DateUntil)) FROM [dbo].[Season]) <> YEAR(GETDATE()) +1
-		AND GETDATE() >= DATEFROMPARTS(YEAR(GETDATE()),@SeasonStartMonth-2,1)  
+	--
+	-- #631: de guard controleerde YEAR(MAX(DateUntil)) <> YEAR(GETDATE())+1. Zodra er een
+	-- TOEKOMSTIG seizoen in de tabel staat is MAX(DateUntil) niet meer het huidige seizoen en kan
+	-- die vergelijking nooit meer onwaar worden. In productie stond 2027-2028, dus de conditie was
+	-- permanent waar en werd 2026-2027 bij ELKE deploy opnieuw ingevoegd (3 identieke rijen).
+	-- Nu wordt gecontroleerd of het seizoen dat we gaan maken al bestaat. Dat is idempotent en
+	-- werkt ook met toekomstige seizoenen in de tabel.
+	DECLARE @NewSeasonName NCHAR(9) = CONCAT(YEAR(GETDATE()),'-',YEAR(GETDATE())+1);
+
+	IF NOT EXISTS (SELECT 1 FROM [dbo].[Season] WHERE [Name] = @NewSeasonName)
+		AND GETDATE() >= DATEFROMPARTS(YEAR(GETDATE()),@SeasonStartMonth-2,1)
 	BEGIN
 		INSERT INTO [dbo].[Season]
 			(
@@ -1727,9 +1786,9 @@ BEGIN
 			[DateFrom],
 			[DateUntil]
 			)
-		 VALUES 
+		 VALUES
 			(
-			CONCAT(YEAR(GETDATE()),'-',YEAR(GETDATE())+1),
+			@NewSeasonName,
 			DATEFROMPARTS(YEAR(GETDATE()),@SeasonStartMonth,1),
 			EOMONTH(DATEFROMPARTS(YEAR(GETDATE())+1,@SeasonStartMonth-1,1))
 			)

--- a/Database/dbo/System Stored Procedures/sp_UpdateSeasonTable.sql
+++ b/Database/dbo/System Stored Procedures/sp_UpdateSeasonTable.sql
@@ -28,8 +28,17 @@ BEGIN
 	END
 
 	-- Create 2 months before start of a new season a new record in season table
-	IF (SELECT YEAR(MAX(DateUntil)) FROM [dbo].[Season]) <> YEAR(GETDATE()) +1
-		AND GETDATE() >= DATEFROMPARTS(YEAR(GETDATE()),@SeasonStartMonth-2,1)  
+	--
+	-- #631: de guard controleerde YEAR(MAX(DateUntil)) <> YEAR(GETDATE())+1. Zodra er een
+	-- TOEKOMSTIG seizoen in de tabel staat is MAX(DateUntil) niet meer het huidige seizoen en kan
+	-- die vergelijking nooit meer onwaar worden. In productie stond 2027-2028, dus de conditie was
+	-- permanent waar en werd 2026-2027 bij ELKE deploy opnieuw ingevoegd (3 identieke rijen).
+	-- Nu wordt gecontroleerd of het seizoen dat we gaan maken al bestaat. Dat is idempotent en
+	-- werkt ook met toekomstige seizoenen in de tabel.
+	DECLARE @NewSeasonName NCHAR(9) = CONCAT(YEAR(GETDATE()),'-',YEAR(GETDATE())+1);
+
+	IF NOT EXISTS (SELECT 1 FROM [dbo].[Season] WHERE [Name] = @NewSeasonName)
+		AND GETDATE() >= DATEFROMPARTS(YEAR(GETDATE()),@SeasonStartMonth-2,1)
 	BEGIN
 		INSERT INTO [dbo].[Season]
 			(
@@ -37,9 +46,9 @@ BEGIN
 			[DateFrom],
 			[DateUntil]
 			)
-		 VALUES 
+		 VALUES
 			(
-			CONCAT(YEAR(GETDATE()),'-',YEAR(GETDATE())+1),
+			@NewSeasonName,
 			DATEFROMPARTS(YEAR(GETDATE()),@SeasonStartMonth,1),
 			EOMONTH(DATEFROMPARTS(YEAR(GETDATE())+1,@SeasonStartMonth-1,1))
 			)

--- a/Database/dbo/Tables/Season.sql
+++ b/Database/dbo/Tables/Season.sql
@@ -1,5 +1,10 @@
-﻿CREATE TABLE [dbo].[Season](
-	[Name] [nchar](9) NULL,
+CREATE TABLE [dbo].[Season](
+	[Name] [nchar](9) NOT NULL,
 	[DateFrom] [date] NULL,
-	[DateUntil] [date] NULL
+	[DateUntil] [date] NULL,
+	-- #631: zonder deze constraint kon sp_UpdateSeasonTable hetzelfde seizoen bij elke deploy
+	-- opnieuw invoegen. In productie stonden 3 identieke rijen voor 2026-2027, waardoor
+	-- pub.DateTable (INNER JOIN op Season) 3 rijen per datum opleverde. Een regressie faalt nu
+	-- hard bij de INSERT in plaats van stil data te vervuilen.
+	CONSTRAINT [UQ_Season_Name] UNIQUE ([Name])
 ) ON [PRIMARY]


### PR DESCRIPTION
`dbo.Season` kreeg bij elke deploy een extra rij voor het huidige seizoen. In productie stonden 3 identieke rijen voor `2026-2027`.

Closes #631

## Oorzaak
De guard in `sp_UpdateSeasonTable` vergeleek `YEAR(MAX(DateUntil))` met `YEAR(GETDATE())+1`. Zodra er een **toekomstig** seizoen in de tabel staat is `MAX(DateUntil)` niet meer het huidige seizoen, en kan die vergelijking nooit meer onwaar worden.

Live geëvalueerd tegen productie (`SeasonStartMonth` = 7):

| expressie | waarde |
|---|---|
| `YEAR(MAX(DateUntil))` | 2028 (want `2027-2028` staat in de tabel) |
| `YEAR(GETDATE()) + 1` | 2027 |
| conditie 1 | **permanent waar** |
| conditie 2 | waar |

Daarbovenop had `dbo.Season` geen primary key en geen unique constraint — niets hield duplicaten tegen.

## Impact
- **Applicatie: niet geraakt.** Alle C#-consumers gebruiken aggregaten (`MAX(DateUntil)` in `Utilities.cs:240` en `PlannerSettingsRepository.cs:125`, `MIN(DateFrom)` in `Utilities.cs:266`). Sync en planner werkten correct.
- **`pub.DateTable`: wel geraakt.** Die view doet `INNER JOIN dbo.Season ON dt.Date BETWEEN s.DateFrom AND s.DateUntil` en leverde 3 rijen per datum voor het huidige seizoen — 2557 i.p.v. 2192 rijen. Het `pub`-schema is de read-only interface voor externe consumers.
- Onbegrensde groei: één rij per deploy, met een oplopende vermenigvuldigingsfactor in de view.

## Wijziging

| Onderdeel | Wijziging |
|---|---|
| `sp_UpdateSeasonTable` (beide definities) | Guard controleert nu `NOT EXISTS (... WHERE [Name] = @NewSeasonName)` in plaats van `MAX(DateUntil)`. Idempotent, en werkt mét toekomstige seizoenen in de tabel |
| `Script.PostDeployment1.sql` | Nieuwe block dat duplicaten opruimt (`ROW_NUMBER()` per `Name`), naamloze rijen verwijdert, `Name` NOT NULL maakt en `UQ_Season_Name` aanbrengt |
| `Season.sql` + `CREATE TABLE` in PostDeployment | `Name NOT NULL` met unique constraint, zodat een verse installatie meteen beschermd is |

De guard staat in twee bestanden (DB-project én de `CREATE OR ALTER` in PostDeployment); beide zijn bijgewerkt zodat ze niet gaan driften.

**Volgorde is essentieel:** het opruim-block staat vóór de `EXEC`. De constraint kan pas ná deduplicatie worden aangebracht, anders faalt de deploy op de bestaande rijen.

## Verificatie — script daadwerkelijk uitgevoerd
Conform de projectregel is dit niet alleen geparsed maar echt tegen een database gedraaid. De productiesituatie is lokaal nagebootst: 7 rijen, 4 unieke namen, `2026-2027` 3×, plus een naamloze rij en het toekomstige seizoen `2027-2028` dat de bug veroorzaakt.

| Stap | Resultaat |
|---|---|
| Opruim-block pass 1 | 1 naamloze + 2 duplicaatrijen verwijderd → 4 rijen / 4 unieke namen; constraint aangebracht; `Name NOT NULL` |
| Opruim-block pass 2 | 0 rijen geraakt, geen constraint-fout — **idempotent** |
| Gecorrigeerde proc 3× achtereen | 4 rijen vóór en ná; **nul duplicaten**, terwijl de oude guard aantoonbaar zou vuren |
| `pub.DateTable` | weer **1 rij per datum** (was 3) |

De testopstelling bevestigde expliciet de precondities: toekomstig seizoen aanwezig, en `oude guard zou vuren: WAAR (dus insert bij elke run)`.

## Opgemerkt maar niet meegenomen
`Script.PostDeployment1.sql` roept `sp_UpdateSeasonTable` aan op regel ~860, terwijl de procedure pas rond regel 1740 met `CREATE OR ALTER` wordt aangemaakt. Op een volledig verse database bestaat de procedure daar dus nog niet. Dat is dezelfde klasse ordeningsprobleem als #595 en verdient een eigen issue met eigen verificatie — buiten scope van deze fix. Het nieuwe opruim-block is hier ongevoelig voor: het is gegate op `IF EXISTS (... OBJECT_ID('dbo.Season'))`.