### PR TITLE
chore(#618): release v2.17.1.0 voorbereiden

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.17.0.0</Version>
-    <AssemblyVersion>2.17.0.0</AssemblyVersion>
-    <FileVersion>2.17.0.0</FileVersion>
+    <Version>2.17.1.0</Version>
+    <AssemblyVersion>2.17.1.0</AssemblyVersion>
+    <FileVersion>2.17.1.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+## [2.17.1.0] — 2026-07-26
+
 ### Fixed
 - **De demo-omgeving (AllStars FC) was leeg.** De democlub bestond wel, maar had geen velden, geen speeltijden, geen teams en geen wedstrijden — de testmodus in de beheeromgeving toonde daardoor een leeg scherm. De demogegevens worden nu bij elke uitrol automatisch aangemaakt: 3 velden met beschikbaarheid, 28 teams met een begeleider, en 224 wedstrijden verdeeld over de acht komende zaterdagen, ongeveer de helft thuis en de helft uit. De speeldata schuiven mee met de uitroldatum, zodat de demo niet na een paar maanden alleen nog verleden wedstrijden toont. Optimaliseren in de Dagplanning verdeelt de wedstrijden nu daadwerkelijk over de drie demovelden. (#635)
 - In de testmodus werd bij een uitwedstrijd het eigen team ook als tegenstander getoond ("AllStars JO10 1 – AllStars JO10 1"). Bij een uitwedstrijd staat de tegenstander in het thuisteam-veld; daar wordt nu op gecontroleerd. (#635)

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.17.0.0</Version>
-    <AssemblyVersion>2.17.0.0</AssemblyVersion>
-    <FileVersion>2.17.0.0</FileVersion>
+    <Version>2.17.1.0</Version>
+    <AssemblyVersion>2.17.1.0</AssemblyVersion>
+    <FileVersion>2.17.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/docs/api-standaarden/openapi.json
+++ b/docs/api-standaarden/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Sportlink Wedstrijdzaken API",
     "description": "API voor het beheer van wedstrijden, veldplanning en club-instellingen.\n\n## Beveiliging\n\nTwee beveiligingsschema's:\n\n- **functionKey** — `?code=` queryparameter, vereist voor planner- en sync-endpoints.\n  Gebruik de Azure Function key (voor planner-endpoints) of de Master key (voor admin sync-matches en\n  populate-sunset).\n- **easyAuth** — Azure Easy Auth Bearer token (Entra ID) in de `Authorization`-header, vereist voor\n  alle `/beheer/`- en `/feedback/`-endpoints. Lokaal omzeild wanneer de omgevingsvariabele\n  `WEBSITE_SITE_NAME` afwezig is.\n\nAlle `/beheer/`- en `/feedback/`-endpoints retourneren de header `x-correlation-id` in het antwoord.\n",
-    "version": "2.17.0",
+    "version": "2.17.1",
     "contact": {
       "name": "Sportlink Wedstrijdzaken",
       "url": "https://github.com/jaapbeus/Sportlink-wedstrijdzaken"

--- a/docs/api-standaarden/openapi.yaml
+++ b/docs/api-standaarden/openapi.yaml
@@ -16,7 +16,7 @@ info:
       `WEBSITE_SITE_NAME` afwezig is.
 
     Alle `/beheer/`- en `/feedback/`-endpoints retourneren de header `x-correlation-id` in het antwoord.
-  version: 2.17.0
+  version: 2.17.1
   contact:
     name: Sportlink Wedstrijdzaken
     url: https://github.com/jaapbeus/Sportlink-wedstrijdzaken


### PR DESCRIPTION
Sluit `[Unreleased]` af en zet de versie op **2.17.1.0**.

Refs #618

## Waarom 2.17.1.0 en niet 2.18.0.0
`[Unreleased]` bevat uitsluitend `fix:`, `security:` en `chore:`-werk — **geen enkele `feat:`**. Conform docs/VERSIONING.md fase 2 is dat een **PATCH**-bump (`2.17.0.0 → 2.17.1.0`, REVISION terug naar 0), niet MINOR. In het overleg vooraf noemde ik v2.18.0.0 als werktitel; de regel in het project zegt PATCH, dus die volg ik.

## Wijzigingen
- `CHANGELOG.md` — `[Unreleased]` afgesloten als `[2.17.1.0] — 2026-07-26`, lege `[Unreleased]` teruggezet
- Beide csproj''s — `Version`/`AssemblyVersion`/`FileVersion` → `2.17.1.0`
- `openapi.yaml` — `info.version` → `2.17.1`
- `openapi.json` — geregenereerd uit de YAML (niet handmatig bijgewerkt)

Geen code- of schemawijzigingen in deze PR.

## Inhoud van de release

| Issue | Onderwerp |
|---|---|
| #630 | Issue-lifecycle: gereleasede issues werden gemist én al-gesloten issues onterecht heropend |
| #631 | Seizoen werd bij elke deploy gedupliceerd; `pub.DateTable` gaf 3 rijen per datum |
| #632 | Tijdelijke SQL-firewallregels werden nooit opgeruimd (16 achtergebleven) |
| #634 | Dependency-updates: Worker-SDK, HTTP-extensie, AI-bibliotheek, `azure/sql-action` |
| #635 | AllStars-demodata was leeg in productie; nu automatisch én daadwerkelijk planbaar |

## Verificatie
| Stap | Resultaat |
|---|---|
| `dotnet build` FunctionApp (net9.0) | 0 errors, 0 warnings |
| `dotnet build` BlazorAdmin (net10.0) | 0 errors, 0 warnings |
| `dotnet test` | 126 passed, 3 skipped, 0 failed |
| `Test-App.ps1` met live services | exit 0 — 31 checks |
| Health endpoint | 200, `version: 2.17.1.0`, `database: online` |
| Blazor fingerprint-consistentie | consistent |
| Browser render check | Instellingen + Dashboard, **geen foutbanner**, 0 console-errors, `v2.17.1.0` in header |
| Dagplanning (democlub) | 28 wedstrijden, 0 zonder tijd, verdeeld over 3 velden binnen 08:30–22:00 |
| PostDeployment-script | 2× end-to-end tegen een echte database, exit 0, geen Msg/Error |

## Kostenbeleid
Geen nieuwe Azure-resources en geen tier-wijzigingen. FunctionApp blijft `net9.0` — expliciet gecontroleerd bij de Worker-SDK minor-bump in #634, omdat Linux Consumption `net10.0` niet ondersteunt.

## Na deze PR
De release-PR `develop → main` zet ik klaar maar **merge ik niet** — conform je keuze om vóór de productie-merge te stoppen.