### PR TITLE
security(#649) + perf(#636): scanconfiguratie en pre-push-prestaties

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -46,35 +46,64 @@ while read local_ref local_sha remote_ref remote_sha; do
   done <<< "$CHANGED_FILES"
 
   # Pattern-based scan op commits
-  if [ -f "$PATTERN_FILE" ]; then
+  #
+  # #636: voorheen liep dit als 'git show <sha>:<bestand> | grep' voor ELKE combinatie van patroon
+  # en bestand. Bij 42 patronen en ~100 gewijzigde bestanden (een tag-push dereferencet naar de
+  # volledige merge-diff) zijn dat ~4200 losse processen. Procesopstart is op Windows duur, dus een
+  # tag-push duurde meer dan vijf minuten en leek vastgelopen — met het risico dat iemand
+  # --no-verify gaat gebruiken en daarmee de AVG-/secretsbescherming omzeilt.
+  #
+  # Nu één 'git grep' per patroon: 42 processen in plaats van 4200. Dezelfde dekking, want git grep
+  # zoekt server-side in dezelfde commit over dezelfde bestandenlijst.
+  FILES_TO_SCAN=()
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    # Sla configuratie- en template-bestanden over: die bevatten de patronen per definitie.
+    case "$file" in
+      *sensitive-patterns.template.txt|*.gitleaks.toml|*pre-commit|*pre-push|*security-scan.yml) continue ;;
+    esac
+    FILES_TO_SCAN+=("$file")
+  done <<< "$CHANGED_FILES"
+
+  if [ -f "$PATTERN_FILE" ] && [ ${#FILES_TO_SCAN[@]} -gt 0 ]; then
     while IFS= read -r pattern || [ -n "$pattern" ]; do
       [ -z "$pattern" ] && continue
       [[ "$pattern" =~ ^# ]] && continue
-      while IFS= read -r file; do
-        [ -z "$file" ] && continue
-        # Sla configuratie- en template-bestanden over
-        if echo "$file" | grep -qE "(sensitive-patterns\.template\.txt|\.gitleaks\.toml|pre-commit|pre-push|security-scan\.yml)$"; then
-          continue
-        fi
-        if git show "$local_sha:$file" 2>/dev/null | grep -qiE "$pattern"; then
-          echo ""
-          echo "BLOCKED: Sensitive pattern in commit"
-          echo "  File   : $file"
-          echo "  Pattern: $pattern"
-          FOUND_ISSUE=1
-        fi
-      done <<< "$CHANGED_FILES"
+      # -I slaat binaire bestanden over; -l geeft alleen de treffers, niet de regel zelf (die kan
+      # de gevoelige waarde bevatten en hoort niet in de hook-output).
+      HITS=$(git grep -l -I -i -E -e "$pattern" "$local_sha" -- "${FILES_TO_SCAN[@]}" 2>/dev/null || true)
+      if [ -n "$HITS" ]; then
+        echo ""
+        echo "BLOCKED: Sensitive pattern in commit"
+        echo "  Pattern: $pattern"
+        while IFS= read -r hit; do
+          [ -z "$hit" ] && continue
+          # git grep geeft '<sha>:<pad>' terug wanneer een commit is meegegeven.
+          echo "  File   : ${hit#*:}"
+        done <<< "$HITS"
+        FOUND_ISSUE=1
+      fi
     done < "$PATTERN_FILE"
   fi
 done
 
 # ── 3. Gebruik gitleaks indien beschikbaar ────────────────────────────────────
+# gitleaks is optioneel (zie CLAUDE.md), dus ontbreken mag de push niet blokkeren. Maar het stil
+# overslaan gaf een vals gevoel van dekking: de patroonscan hierboven is aanzienlijk beperkter dan
+# gitleaks. Nu wordt het expliciet gemeld, net zoals #514 dat deed voor een ontbrekende
+# sensitive-patterns.txt. (#649)
 if command -v gitleaks &>/dev/null; then
   if ! gitleaks detect --exit-code 1 --no-banner 2>/dev/null; then
     echo ""
     echo "BLOCKED: gitleaks detected secrets in repository"
     FOUND_ISSUE=1
   fi
+else
+  echo ""
+  echo "WAARSCHUWING: gitleaks is niet geinstalleerd — alleen de patroonscan is uitgevoerd."
+  echo "  Die dekt minder dan gitleaks (geen entropie-analyse, geen generieke sleutelformaten)."
+  echo "  Installeren:  winget install gitleaks   (Windows)"
+  echo "                brew install gitleaks     (macOS)"
 fi
 
 if [ "$FOUND_ISSUE" -eq 1 ]; then

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -134,9 +134,13 @@ jobs:
           for f in $DOC_FILES; do
             [ ! -f "$f" ] && continue
             # Blokkeer elk emailadres (ook club-domeinen zoals vv-club.nl)
-            # Uitzondering: noreply@github.com, noreply@anthropic.com (CI-systemen)
+            # Uitzondering: noreply@github.com, noreply@anthropic.com (CI-systemen),
+            # example.* en voorbeeld.nl (goedgekeurde placeholders), en allstars-fc.test —
+            # het demodomein van AllStars FC. .test is door RFC 2606 gereserveerd en bestaat
+            # publiek niet, dus die adressen kunnen nooit een echt persoon zijn. Zonder deze
+            # uitzondering blokkeert de scan het documenteren van goedgekeurde demodata (#649).
             matches=$(grep -oiP '[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}' "$f" \
-              | grep -viP '@(github\.com|anthropic\.com|example\.(com|nl|org)|voorbeeld\.nl)$' || true)
+              | grep -viP '@(github\.com|anthropic\.com|example\.(com|nl|org)|voorbeeld\.nl|allstars-fc\.test)$' || true)
             if [ -n "$matches" ]; then
               echo "::error::🚨 EMAILADRES in documentatiebestand: $f"
               echo "$matches" | while read addr; do echo "::error::  Gevonden: $addr — gebruik placeholder [emailadres]"; done

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -87,6 +87,12 @@ description = "Bestanden die uitgesloten worden van scanning"
 regexes = [
   # voorbeeld.nl is een goedgekeurd fictief placeholder-domein (John Doe-principe, zie CLAUDE.md).
   '''trainer@voorbeeld\.nl''',
+  # allstars-fc.test is het domein van de AllStars FC demodata. .test is een door RFC 2606
+  # gereserveerd TLD en bestaat publiek niet, dus deze adressen kunnen nooit een echt persoon zijn.
+  # Goedgekeurd als AVG-uitzondering in CLAUDE.md. Preventief opgenomen (#649): de consumer-email-
+  # regel matcht nu een vaste domeinlijst, maar zodra die verbreed wordt naar een generiek patroon
+  # zouden alle seed-adressen in Script.PostDeployment1.sql geflagd worden.
+  '''@allstars-fc\.test''',
   # Jan de Vries is een fictieve naam (NL John Doe equivalent) — geen echte persoonsgegevens.
   '''Jan de Vries''',
   # Placeholder-patronen in documentatie zijn geen echte waarden

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Security
+- Het goedgekeurde fictieve demodomein wordt niet langer door de eigen beveiligingscontroles geblokkeerd. Het domein van de demogegevens is opgenomen in de uitzonderingslijsten, zodat documentatie over de demo-omgeving niet onterecht als privacyschending wordt gemeld. De controles zelf zijn niet verzwakt. (#649)
+- De controle vóór het versturen van wijzigingen meldt nu expliciet wanneer het aanvullende scanprogramma niet op de machine staat. Voorheen werd die stap stil overgeslagen, waardoor een ontwikkelaar dacht meer bescherming te hebben dan er was. (#649)
+
+### Changed
+- De controle vóór het versturen van wijzigingen is sterk versneld: van ruim negen minuten naar negen seconden bij een release. Voorheen liep die zo lang dat hij op een vastloper leek — met het risico dat iemand hem zou omzeilen. De controle is even grondig als voorheen. (#636)
+
 ## [2.17.1.0] — 2026-07-26
 
 ### Fixed


### PR DESCRIPTION
Twee gaten in de secret-/PII-scanconfiguratie plus de prestatieklacht over de pre-push hook. Beide raken hetzelfde bestand, daarom één PR.

Closes #649
Closes #636

## #649 — het goedgekeurde demodomein was nergens uitgezonderd

`@allstars-fc.test` heeft een eigen AVG-uitzondering in CLAUDE.md (RFC 2606 gereserveerd TLD, bestaat publiek niet), maar stond in **geen enkele** allowlist. CLAUDE.md draagt expliciet op dit te controleren zodra de AllStars-seed breder gebruikt wordt — en sinds #635 staat het domein in `Script.PostDeployment1.sql`, dus in elke deploy.

**Waarom het nu tóch groen is:** de code-scan matcht alleen een vaste lijst consumentendomeinen (hotmail, gmail, …) en `.test` valt daarbuiten. De strengere docs-scan blokkeert wél élk e-mailadres, maar scant `CLAUDE.md` niet — precies daarom valt het niet op dat dat bestand het domein zelf noemt.

Empirisch getest:

```
regel in een doc:  Voorbeeld demodata: frenkie.1@allstars-fc.test
huidige uitzondering  -> FAALT
met allstars-fc.test  -> passeert
```

Toegevoegd aan `.gitleaks.toml` en aan de docs-scan in `security-scan.yml`. **De scans zijn niet verbreed of verzwakt** — alleen de al goedgekeurde uitzondering is expliciet gemaakt.

## #649 — ontbrekende gitleaks werd stil overgeslagen

`.githooks/pre-push` had geen `else`-tak. Op een machine zonder gitleaks — zoals de mijne — draait dus alleen de beperktere patroonscan, zonder melding. De ontwikkelaar denkt dekking te hebben die er niet is.

Nu een expliciete waarschuwing met installatiehint. Blijft **niet-blokkerend**, want CLAUDE.md noemt gitleaks terecht optioneel. Zelfde keuze als #514 maakte voor een ontbrekende `sensitive-patterns.txt`.

## #636 — de patroonscan was ~60× te langzaam

De scan liep als `git show <sha>:<bestand> | grep` voor **elke combinatie** van patroon en bestand. Bij 42 patronen en 100 gewijzigde bestanden zijn dat ~4200 processen; procesopstart is op Windows duur.

Gemeten op de `v2.17.0.0`-mergecommit (100 bestanden, 42 patronen):

| Aanpak | Tijd |
|---|---|
| Oud (`git show` per patroon per bestand) | 79s voor 6 patronen → **~553s** voor alle 42 |
| Nieuw (`git grep` per patroon) | **9s** |

Dat verklaart de tag-push die eerder in een timeout van 300s liep. **Deze PR pushte in 7 seconden.**

Implementatiedetails: pathspec via een bash-array omdat er bestandsnamen met spaties zijn (`Database/dbo/System Stored Procedures/…`). `-I` slaat binaire bestanden over; `-l` voorkomt dat de gevonden regel — die de gevoelige waarde zelf bevat — in de hook-output belandt.

## Verificatie

| Stap | Resultaat |
|---|---|
| `bash -n .githooks/pre-push` | syntax ok |
| `git grep` positief op bekend woord / negatief op onzin-patroon | correct in beide richtingen |
| Volledige hook op gesimuleerde tag-push | 22s, exit 0, waarschuwing zichtbaar |
| **Blokkeert nog steeds** | tijdelijk testpatroon in een commit → `BLOCKED: Sensitive pattern in commit`, **exitcode 1** |
| Echte push van deze PR | 7s |
| `security-scan.yml` / `.gitleaks.toml` | valideren als YAML resp. TOML |

Testartefacten opgeruimd; `sensitive-patterns.txt` staat terug op 42 patronen.

Geen versiebump: CI- en hookwijziging zonder effect op de applicatie.