### PR TITLE
fix(#630): vangnet-rapport meldt geen issues meer die deze run zelf sloot

### DIFF
--- a/.github/workflows/close-released-issues.yml
+++ b/.github/workflows/close-released-issues.yml
@@ -133,6 +133,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           RELEASE_TAG: ${{ steps.issues.outputs.tag }}
+          AFGEHANDELD: ${{ steps.issues.outputs.numbers }}
         with:
           script: |
             const label = 'status: awaiting-release';
@@ -144,7 +145,23 @@ jobs:
               per_page: 100,
             });
 
-            const issues = remaining.filter(i => !i.pull_request);
+            // De label-index van GitHub loopt achter op de sluitingen uit de vorige stap: bij de
+            // release van v2.17.1.0 meldde dit rapport #649 als 'blijft open' terwijl datzelfde
+            // issue een seconde eerder in deze run was gesloten. Een vangnet dat bij elke release
+            // valse alarmen geeft, wordt genegeerd — en dan doet het zijn werk niet meer.
+            //
+            // Daarom deterministisch filteren op wat deze run zelf heeft afgehandeld, in plaats van
+            // te vertrouwen op de versheid van de index.
+            const afgehandeld = new Set(
+              (process.env.AFGEHANDELD || '')
+                .split(',')
+                .map(n => parseInt(n, 10))
+                .filter(Number.isInteger)
+            );
+
+            const issues = remaining
+              .filter(i => !i.pull_request)
+              .filter(i => !afgehandeld.has(i.number));
             if (issues.length === 0) {
               core.notice(`Geen issues meer op '${label}' — lifecycle sluitend na ${process.env.RELEASE_TAG}.`);
               return;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- De melding na een release die aangeeft welke issues nog openstaan, noemde ook issues die in diezelfde release net waren afgerond. Dat kwam doordat het overzicht van GitHub even achterloopt. Er wordt nu gefilterd op wat de release zelf heeft afgehandeld, zodat de melding alleen nog echt achtergebleven issues toont. (#630)
+
 ## [2.17.1.0] — 2026-07-26
 
 ### Fixed


### PR DESCRIPTION
Correctie op het vangnet dat in #630 is toegevoegd. Direct waargenomen bij de release van v2.17.1.0.

Refs #630

## Wat er gebeurde
Het vangnet meldde na de release:

```
1 issue(s) staan na release v2.17.1.0 nog op 'status: awaiting-release'.
#649 — security: gitleaks/PII-scanconfiguratie mist het goedgekeurde .test-demodomein
```

Terwijl #649 een seconde eerder **in diezelfde run** was gesloten:

```
- #649: gesloten (v2.17.1.0)
```

## Oorzaak
De label-index van GitHub loopt achter op de sluitingen uit de voorgaande stap. Het rapport vroeg die index opnieuw op en zag het label daar nog staan.

## Waarom dit ertoe doet
Een vangnet dat bij **elke** release een vals alarm geeft, wordt genegeerd. Dan doet het zijn werk niet meer — precies het tegenovergestelde van waarvoor het in #630 is toegevoegd. Het gaat er juist om dat een écht gemist issue opvalt.

## Oplossing
Deterministisch filteren op de nummers die deze run zelf heeft afgehandeld (`steps.issues.outputs.numbers`), in plaats van te vertrouwen op de versheid van de index.

## Verificatie
Logica los getest op drie gevallen:

| Geval | Verwacht | Resultaat |
|---|---|---|
| Index-lag (de echte v2.17.1.0-situatie: #649 in de index, ook in de afgehandelde lijst) | geen melding | `[]` |
| Daadwerkelijk gemist issue (#777 in de index, niet afgehandeld) | wél melden | `[777]` |
| PR in de lijst | negeren | alleen het issue |

YAML-syntaxis gevalideerd.

Geen versiebump: CI-only wijziging zonder effect op de applicatie.

---

**Terzijde:** dit is de eerste PR sinds `enforce_admins` op beide branches aan staat (#596). Als deze normaal doorloopt, is daarmee bevestigd dat de strengere gate de reguliere flow niet blokkeert.