### PR TITLE
chore: release v2.17.2.0 voorbereiden

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.17.1.0</Version>
-    <AssemblyVersion>2.17.1.0</AssemblyVersion>
-    <FileVersion>2.17.1.0</FileVersion>
+    <Version>2.17.2.0</Version>
+    <AssemblyVersion>2.17.2.0</AssemblyVersion>
+    <FileVersion>2.17.2.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+## [2.17.2.0] — 2026-07-26
+
 ### Fixed
 - De melding na een release die aangeeft welke issues nog openstaan, noemde ook issues die in diezelfde release net waren afgerond. Dat kwam doordat het overzicht van GitHub even achterloopt. Er wordt nu gefilterd op wat de release zelf heeft afgehandeld, zodat de melding alleen nog echt achtergebleven issues toont. (#630)
 

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.17.1.0</Version>
-    <AssemblyVersion>2.17.1.0</AssemblyVersion>
-    <FileVersion>2.17.1.0</FileVersion>
+    <Version>2.17.2.0</Version>
+    <AssemblyVersion>2.17.2.0</AssemblyVersion>
+    <FileVersion>2.17.2.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/docs/api-standaarden/openapi.json
+++ b/docs/api-standaarden/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Sportlink Wedstrijdzaken API",
     "description": "API voor het beheer van wedstrijden, veldplanning en club-instellingen.\n\n## Beveiliging\n\nTwee beveiligingsschema's:\n\n- **functionKey** — `?code=` queryparameter, vereist voor planner- en sync-endpoints.\n  Gebruik de Azure Function key (voor planner-endpoints) of de Master key (voor admin sync-matches en\n  populate-sunset).\n- **easyAuth** — Azure Easy Auth Bearer token (Entra ID) in de `Authorization`-header, vereist voor\n  alle `/beheer/`- en `/feedback/`-endpoints. Lokaal omzeild wanneer de omgevingsvariabele\n  `WEBSITE_SITE_NAME` afwezig is.\n\nAlle `/beheer/`- en `/feedback/`-endpoints retourneren de header `x-correlation-id` in het antwoord.\n",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "contact": {
       "name": "Sportlink Wedstrijdzaken",
       "url": "https://github.com/jaapbeus/Sportlink-wedstrijdzaken"

--- a/docs/api-standaarden/openapi.yaml
+++ b/docs/api-standaarden/openapi.yaml
@@ -16,7 +16,7 @@ info:
       `WEBSITE_SITE_NAME` afwezig is.
 
     Alle `/beheer/`- en `/feedback/`-endpoints retourneren de header `x-correlation-id` in het antwoord.
-  version: 2.17.1
+  version: 2.17.2
   contact:
     name: Sportlink Wedstrijdzaken
     url: https://github.com/jaapbeus/Sportlink-wedstrijdzaken


### PR DESCRIPTION
Sluit `[Unreleased]` af en zet de versie op **2.17.2.0**.

## Waarom een bump voor een CI-only wijziging
`[Unreleased]` bevat alleen `fix:`-werk en geen `feat:` → **PATCH**-bump conform docs/VERSIONING.md fase 2.

Inhoud is bewust klein: uitsluitend de vervolgfix op #630. Geen applicatiecode — alleen `close-released-issues.yml` en de CHANGELOG.

**Overwogen alternatief:** mergen zonder bump en zonder tag, want de gedeployde applicatie blijft byte-identiek. Niet gedaan, om twee redenen:
1. `main` is productie. Zonder tag zou de inhoud van `main` niet meer overeenkomen met een release-tag — dat is precies de traceerbaarheid die je bij een deploybranch wil houden.
2. Zonder tag draait `close-released-issues.yml` niet, waardoor #630 onterecht als openstaand blijft hangen.

## Wijzigingen
- `CHANGELOG.md` — `[Unreleased]` afgesloten als `[2.17.2.0] — 2026-07-26`
- Beide csproj''s — `2.17.2.0`
- `openapi.yaml` → `2.17.2`, `openapi.json` geregenereerd uit de YAML

## Verificatie
| Stap | Resultaat |
|---|---|
| `dotnet build` FunctionApp (net9.0) | 0 errors, 0 warnings |
| `dotnet build` BlazorAdmin (net10.0) | 0 errors, 0 warnings |
| `dotnet test` | 126 passed, 3 skipped, 0 failed |
| Versies gesynchroniseerd | beide csproj''s + openapi.yaml/.json |
| #630 in de `[2.17.2.0]`-sectie | ja |

## Terzijde
Deze release is tegelijk de eerste uitvoering van de gefixte vangnet-logica die erin zit. Als het rapport na de tag géén vals alarm meer geeft over een net gesloten issue, is de fix in productie bewezen.