### PR TITLE
release: v2.17.2.0

### DIFF
--- a/.github/workflows/close-released-issues.yml
+++ b/.github/workflows/close-released-issues.yml
@@ -133,6 +133,7 @@ jobs:
         uses: actions/github-script@v9
         env:
           RELEASE_TAG: ${{ steps.issues.outputs.tag }}
+          AFGEHANDELD: ${{ steps.issues.outputs.numbers }}
         with:
           script: |
             const label = 'status: awaiting-release';
@@ -144,7 +145,23 @@ jobs:
               per_page: 100,
             });
 
-            const issues = remaining.filter(i => !i.pull_request);
+            // De label-index van GitHub loopt achter op de sluitingen uit de vorige stap: bij de
+            // release van v2.17.1.0 meldde dit rapport #649 als 'blijft open' terwijl datzelfde
+            // issue een seconde eerder in deze run was gesloten. Een vangnet dat bij elke release
+            // valse alarmen geeft, wordt genegeerd — en dan doet het zijn werk niet meer.
+            //
+            // Daarom deterministisch filteren op wat deze run zelf heeft afgehandeld, in plaats van
+            // te vertrouwen op de versheid van de index.
+            const afgehandeld = new Set(
+              (process.env.AFGEHANDELD || '')
+                .split(',')
+                .map(n => parseInt(n, 10))
+                .filter(Number.isInteger)
+            );
+
+            const issues = remaining
+              .filter(i => !i.pull_request)
+              .filter(i => !afgehandeld.has(i.number));
             if (issues.length === 0) {
               core.notice(`Geen issues meer op '${label}' — lifecycle sluitend na ${process.env.RELEASE_TAG}.`);
               return;

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.17.1.0</Version>
-    <AssemblyVersion>2.17.1.0</AssemblyVersion>
-    <FileVersion>2.17.1.0</FileVersion>
+    <Version>2.17.2.0</Version>
+    <AssemblyVersion>2.17.2.0</AssemblyVersion>
+    <FileVersion>2.17.2.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- De melding na een release die aangeeft welke issues nog openstaan, noemde ook issues die in diezelfde release net waren afgerond. Dat kwam doordat het overzicht van GitHub even achterloopt. Er wordt nu gefilterd op wat de release zelf heeft afgehandeld, zodat de melding alleen nog echt achtergebleven issues toont. (#630)
+
 ## [2.17.1.0] — 2026-07-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+## [2.17.2.0] — 2026-07-26
+
 ### Fixed
 - De melding na een release die aangeeft welke issues nog openstaan, noemde ook issues die in diezelfde release net waren afgerond. Dat kwam doordat het overzicht van GitHub even achterloopt. Er wordt nu gefilterd op wat de release zelf heeft afgehandeld, zodat de melding alleen nog echt achtergebleven issues toont. (#630)
 

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.17.1.0</Version>
-    <AssemblyVersion>2.17.1.0</AssemblyVersion>
-    <FileVersion>2.17.1.0</FileVersion>
+    <Version>2.17.2.0</Version>
+    <AssemblyVersion>2.17.2.0</AssemblyVersion>
+    <FileVersion>2.17.2.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/docs/api-standaarden/openapi.json
+++ b/docs/api-standaarden/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Sportlink Wedstrijdzaken API",
     "description": "API voor het beheer van wedstrijden, veldplanning en club-instellingen.\n\n## Beveiliging\n\nTwee beveiligingsschema's:\n\n- **functionKey** — `?code=` queryparameter, vereist voor planner- en sync-endpoints.\n  Gebruik de Azure Function key (voor planner-endpoints) of de Master key (voor admin sync-matches en\n  populate-sunset).\n- **easyAuth** — Azure Easy Auth Bearer token (Entra ID) in de `Authorization`-header, vereist voor\n  alle `/beheer/`- en `/feedback/`-endpoints. Lokaal omzeild wanneer de omgevingsvariabele\n  `WEBSITE_SITE_NAME` afwezig is.\n\nAlle `/beheer/`- en `/feedback/`-endpoints retourneren de header `x-correlation-id` in het antwoord.\n",
-    "version": "2.17.1",
+    "version": "2.17.2",
     "contact": {
       "name": "Sportlink Wedstrijdzaken",
       "url": "https://github.com/jaapbeus/Sportlink-wedstrijdzaken"

--- a/docs/api-standaarden/openapi.yaml
+++ b/docs/api-standaarden/openapi.yaml
@@ -16,7 +16,7 @@ info:
       `WEBSITE_SITE_NAME` afwezig is.
 
     Alle `/beheer/`- en `/feedback/`-endpoints retourneren de header `x-correlation-id` in het antwoord.
-  version: 2.17.1
+  version: 2.17.2
   contact:
     name: Sportlink Wedstrijdzaken
     url: https://github.com/jaapbeus/Sportlink-wedstrijdzaken


### PR DESCRIPTION
Kleine patch-release. Uitsluitend de vervolgfix op #630 — **geen applicatiecode**.

## Inhoud
| Issue | Onderwerp |
|---|---|
| #630 | Het vangnet-rapport na een release meldde ook issues die diezelfde run zelf had gesloten (label-index van GitHub liep achter) |

Gewijzigd: `.github/workflows/close-released-issues.yml`, `CHANGELOG.md`, versienummers. De gedeployde applicatie is functioneel identiek aan v2.17.1.0.

## Versie
`2.17.1.0` → **`2.17.2.0`** — PATCH conform docs/VERSIONING.md fase 2 (alleen `fix:`, geen `feat:`).

Bewust wél een bump en een tag, ondanks dat het een CI-only wijziging is: `main` is productie, en zonder tag zou de inhoud van `main` niet meer overeenkomen met een release-tag. Bovendien draait `close-released-issues.yml` alleen op een tag-push, dus zonder tag blijft #630 onterecht openstaan.

## Databasewijzigingen
**Geen.** Het PostDeployment-script is ongewijzigd sinds v2.17.1.0. Het draait bij deze deploy opnieuw, maar is idempotent en eerder 2× end-to-end tegen een echte database geverifieerd.

## Verificatie
| Stap | Resultaat |
|---|---|
| `dotnet build` FunctionApp (net9.0) | 0 errors, 0 warnings |
| `dotnet build` BlazorAdmin (net10.0) | 0 errors, 0 warnings |
| `dotnet test` | 126 passed, 3 skipped, 0 failed |
| Versies gesynchroniseerd | beide csproj''s + openapi.yaml/.json |

## Voorafgaand afgerond
- **#653** — verweesde branch protection-regel `Main` verwijderd door de eigenaar. Geverifieerd: er resteren precies twee regels (`main`, `develop`), elk met één matchende branch, beide met `enforce_admins` aan en de approval-eis weg die in de dode regel zat.
- **#596** — gesloten. Beide branches: PR verplicht, Security Gate verplicht, up-to-date verplicht, `enforce_admins` aan, deletions geblokkeerd.
- **#654** — nieuw, openstaand: REST en GraphQL rapporteren tegenstrijdig over `allow_force_pushes` op `main`. Blokkeert deze release niet; alle overige beschermingen zijn geverifieerd actief.

## Na de merge
Deploy per job verifiëren → tag `v2.17.2.0` pushen. Die tag-push is tegelijk de eerste echte uitvoering van de gefixte vangnet-logica: als het rapport géén vals alarm meer geeft over #630, is de fix in productie bewezen.