### PR TITLE
feat(#657): script en handleiding voor een eigen domein op de Admin GUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Added
+- **Een club kan de beheeromgeving nu onder een eigen webadres bereikbaar maken**, bijvoorbeeld `wz.[clubdomein]` in plaats van het automatisch gegenereerde Azure-adres. Er is een handleiding en een script dat de drie benodigde wijzigingen in één keer doorvoert. Dat is meer werk dan alleen een DNS-record: zonder de bijbehorende instellingen laadt de omgeving wel, maar blijven alle schermen leeg of mislukt het inloggen. Het script controleert dat vooraf en laat zich veilig herhalen. Kost niets — het gratis Azure-pakket staat twee eigen webadressen toe, inclusief automatisch vernieuwende beveiligingscertificaten. (#657)
+
 ## [2.17.2.0] — 2026-07-26
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,7 @@ bewust worden bekeken.
 | `FunctionApp/CLAUDE.md` | Endpoint, datamodel, API-veld of FunctionApp-configuratie gewijzigd |
 | `docs/ARCHITECTURE-PLANNER.md` | Planner-logica, pipeline of kanaalstrategie gewijzigd |
 | `docs/ENTRA-AUTH-BEHEER.md` | Auth-configuratie, Easy Auth, Entra App Registration of rollen gewijzigd |
+| `docs/CUSTOM-DOMAIN.md` | Eigen domein, SWA-hostnames, CORS-origins of redirect-URI's gewijzigd |
 | `docs/BEHEERDER-HANDLEIDING.md` | Admin GUI: scherm, instelling, knop of workflow gewijzigd |
 | `docs/VERSIONING.md` | Release-proces of semver-afspraken gewijzigd |
 | `docs/API.md` | Endpoint toegevoegd, gewijzigd of verwijderd |

--- a/docs/CUSTOM-DOMAIN.md
+++ b/docs/CUSTOM-DOMAIN.md
@@ -1,0 +1,151 @@
+# Eigen domein voor de Admin GUI
+
+De Admin GUI is na een verse installatie bereikbaar op een automatisch gegenereerde URL van de vorm
+`[swa-url].azurestaticapps.net`. Wil je een eigen subdomein gebruiken — bijvoorbeeld
+`wz.[club-domein]` — dan kan dat, en het kost niets.
+
+## Kosten: geen
+
+De Static Web Apps **Free tier** ondersteunt **2 custom domains per app**, inclusief **gratis,
+automatisch vernieuwende SSL/TLS-certificaten**. Geen tier-upgrade nodig.
+
+Bron: [Azure Static Web Apps hosting plans](https://learn.microsoft.com/azure/static-web-apps/plans)
+
+> Loop je tegen de limiet van 2 aan, dan is de Standard tier **niet** gratis. Dat valt buiten het
+> kostenbeleid van dit project — zie het kostenbeleid in de root-`CLAUDE.md`.
+
+## Alleen een DNS-record is niet genoeg
+
+Dit is de belangrijkste les van deze handleiding. Er zijn **drie** wijzigingen nodig, en twee ervan
+geven een verwarrend foutbeeld als je ze overslaat:
+
+| # | Wijziging | Waar | Symptoom als je het vergeet |
+|---|---|---|---|
+| 1 | Domein registreren | Static Web App | Certificaatfout; Azure serveert het domein niet |
+| 2 | CORS-origin toevoegen | Function App | UI laadt wél, maar de browser blokkeert **elke** API-call → overal lege schermen |
+| 3 | SPA redirect-URI toevoegen | Entra App Registration | Login mislukt met `AADSTS50011` (redirect URI mismatch) |
+
+Symptoom 2 is het meest misleidend: de site lijkt te werken, maar toont nergens gegevens. In de
+browserconsole staat dan een CORS-fout.
+
+> **Waarschuwing bij stap 3.** De lijst met redirect-URI's moet worden **uitgebreid**, niet
+> overschreven. Een `az ad app update --set spa.redirectUris=...` met alleen de nieuwe URI wist de
+> bestaande — en dan kan niemand meer inloggen, ook niet op de oude URL. Gebruik daarom het script
+> hieronder; dat leest de bestaande lijst, voegt toe en controleert daarna of er niets verdwenen is.
+
+## Stap 1 — DNS-record aanmaken
+
+Maak bij je DNS-provider een **CNAME**-record aan:
+
+| Instelling | Waarde |
+|---|---|
+| Type | `CNAME` |
+| Host / naam | het subdomein, bijvoorbeeld `wz` |
+| Waarde / target | de gegenereerde hostnaam van je Static Web App (`[swa-url].azurestaticapps.net`) |
+| TTL | standaardwaarde laten staan |
+
+Je vindt de hostnaam met:
+
+```powershell
+az staticwebapp show --name <swa-naam> --resource-group <swa-rg> --query defaultHostname -o tsv
+```
+
+DNS-propagatie duurt afhankelijk van de TTL enkele minuten tot enkele uren. Azure kan het domein
+pas valideren als het record wereldwijd resolvet.
+
+### Apex-domein (zonder subdomein)
+
+Wil je het domein zonder subdomein gebruiken (`[club-domein]` in plaats van `wz.[club-domein]`),
+dan werkt een CNAME niet — DNS staat geen CNAME toe op de apex. Je hebt dan ALIAS/ANAME-records
+nodig, of Azure DNS. Zie
+[een apex-domein instellen](https://learn.microsoft.com/azure/static-web-apps/apex-domain-external).
+Het script hieronder waarschuwt als je een apex-domein meegeeft.
+
+## Stap 2 — De drie Azure-wijzigingen doorvoeren
+
+Gebruik het script. Het is idempotent: een tweede run doet niets en meldt per stap `(al correct)`.
+
+Doe **eerst** een dry-run:
+
+```powershell
+az login   # eenmalig, op het juiste account
+
+.\scripts\azure\Add-CustomDomain.ps1 `
+    -Domain 'wz.[club-domein]' `
+    -StaticWebAppName '<swa-naam>' -StaticWebAppResourceGroup '<swa-rg>' `
+    -FunctionAppName '<func-naam>' -FunctionAppResourceGroup '<func-rg>' `
+    -ClientId '<app-id>' -ExpectedTenantId '<tenant-id>' `
+    -WhatIf
+```
+
+Ziet het resultaat goed uit? Draai dan dezelfde regel **zonder** `-WhatIf`.
+
+Het script stopt direct als je op de verkeerde tenant bent ingelogd, als een resource niet bestaat,
+of als het domeinformaat ongeldig is. Resolveert het CNAME-record nog niet, dan waarschuwt het en
+gaat het door — de SWA-validatie kan dan later alsnog slagen.
+
+### Waar vind ik de waarden?
+
+| Parameter | Vindplaats |
+|---|---|
+| `StaticWebAppName` / `StaticWebAppResourceGroup` | `az staticwebapp list -o table` |
+| `FunctionAppName` / `FunctionAppResourceGroup` | `az functionapp list -o table` |
+| `ClientId` | Azure Portal › App registrations › jouw app › Overview |
+| `ExpectedTenantId` | Azure Portal › Microsoft Entra ID › Overview › Tenant ID |
+
+## Stap 3 — Verifiëren
+
+Validatie en certificaatuitgifte duren enkele minuten tot enkele uren. Controleer de status met:
+
+```powershell
+az staticwebapp hostname list --name <swa-naam> --resource-group <swa-rg> -o table
+```
+
+Loop daarna deze vier punten na — punt 3 is de enige die bewijst dat CORS klopt:
+
+1. `https://wz.[club-domein]` opent **met een geldig certificaat**, zonder browserwaarschuwing.
+2. Inloggen via Microsoft werkt, zonder `AADSTS50011`.
+3. Een pagina die gegevens toont, laadt die gegevens ook echt. Lege schermen betekenen een
+   CORS-probleem — controleer de browserconsole (F12).
+4. De oude `[swa-url].azurestaticapps.net` werkt nog steeds. Beide URL's blijven geldig.
+
+> Doe punt 2 in een **verse incognito-sessie**. MSAL bewaart het ID-token in `localStorage`; zonder
+> verse sessie test je de oude token en niet de nieuwe redirect-URI.
+
+## Wat níet hoeft te wijzigen
+
+- **De Content-Security-Policy** in `staticwebapp.config.json`. Die staat op
+  `connect-src 'self' https://login.microsoftonline.com {{AZURE_FUNCTIONAPP_URL}}` — `'self'` wordt
+  automatisch je nieuwe domein, en de Function App staat er expliciet in.
+- **`appsettings.Production.template.json`.** Daar staat geen frontend-URL in; MSAL leidt de
+  redirect-URI af van de origin waarop de app draait.
+- **De CI/CD-pipeline.** Het domein is runtime-configuratie in Azure; de build hoeft het niet te
+  kennen.
+
+## Club-specifieke waarden horen niet in git
+
+Het domein, de SWA-hostnaam en de resourcenamen zijn club-identificerend en horen **nergens** in
+de repository, ook niet in issues, PR-teksten of commit-messages. Ze gaan uitsluitend als parameter
+mee bij het uitvoeren van het script.
+
+Twee praktische punten:
+
+- Gebruik **geen GitHub *Variable*** voor zo'n waarde als een workflow hem zou kunnen echoën:
+  variables worden **niet gemaskeerd** in Actions-logs, en die logs zijn openbaar bij een publieke
+  repository. Secrets worden wél gemaskeerd. In de opzet hierboven hoeft CI het domein niet te
+  kennen, wat de veiligste variant is.
+- Zet je club-specifieke waarden in `.githooks/sensitive-patterns.txt` (lokaal, staat in
+  `.gitignore`). De git-hooks blokkeren dan een commit of push die zo'n waarde bevat. Zie de
+  security-setup in de root-`CLAUDE.md`.
+
+> Let op: een hostnaam blijft niet geheim. Zodra er een publiek vertrouwd certificaat voor wordt
+> uitgegeven, verschijnt hij in de openbare
+> [Certificate Transparency](https://certificate.transparency.dev/)-logs. Het doel van bovenstaande
+> regels is dus niet geheimhouding, maar dat de repository club-neutraal blijft en een fork geen
+> verwijzingen naar een andere club bevat.
+
+## Verwante documentatie
+
+- `SETUP-NIEUWE-CLUB.md` — volledige installatie voor een nieuwe club
+- `docs/ENTRA-AUTH-BEHEER.md` — Entra-configuratie en de verplichte 3-user-test
+- `docs/ARCHITECTURE.md` — architectuuroverzicht, inclusief de auth-lagen

--- a/scripts/azure/Add-CustomDomain.ps1
+++ b/scripts/azure/Add-CustomDomain.ps1
@@ -1,0 +1,318 @@
+#requires -Version 7.0
+<#
+.SYNOPSIS
+    Voegt een eigen (sub)domein toe aan de Admin GUI: Static Web App, Function App CORS
+    en de Entra SPA redirect-URI in één idempotente run.
+
+.DESCRIPTION
+    Een CNAME-record aanmaken is NIET genoeg. Er zijn drie wijzigingen nodig, en twee
+    daarvan geven een verwarrend foutbeeld als je ze vergeet:
+
+      1. Domein registreren in de Static Web App
+         Zonder dit: certificaatfout, Azure serveert het domein niet.
+
+      2. CORS-origin toevoegen op de Function App
+         Zonder dit: de UI laadt wél, maar de browser blokkeert élke API-call.
+         Je krijgt een schijnbaar werkende site met overal lege schermen.
+
+      3. SPA redirect-URI toevoegen in de Entra App Registration
+         Zonder dit: login mislukt met AADSTS50011 (redirect URI mismatch).
+
+    Stap 3 is met de hand riskant: de lijst met redirect-URI's moet worden UITGEBREID,
+    niet overschreven. Eén verkeerde 'az ad app update --set' wist de bestaande URI en
+    dan kan niemand meer inloggen — ook niet op de oude URL. Dit script leest de
+    bestaande lijst, voegt toe en schrijft terug.
+
+    Idempotent: op een al-correcte configuratie doet het niets en print het per stap
+    '(al correct)'. Veilig om herhaald te runnen.
+
+    Kosten: geen. De Static Web Apps Free tier ondersteunt 2 custom domains per app,
+    inclusief gratis automatisch vernieuwende SSL-certificaten. Geen tier-upgrade nodig.
+    Zie https://learn.microsoft.com/azure/static-web-apps/plans
+
+    Volledige handleiding, inclusief het DNS-record en de verificatie na afloop:
+    docs/CUSTOM-DOMAIN.md
+
+.PARAMETER Domain
+    Het volledige domein dat je wilt toevoegen, bijvoorbeeld 'wz.jouwclub.nl'.
+    Apex-domeinen (zonder subdomein) vragen een andere DNS-opzet — zie de handleiding.
+
+.PARAMETER StaticWebAppName
+    Naam van de Static Web App-resource.
+
+.PARAMETER StaticWebAppResourceGroup
+    Resourcegroup van de Static Web App.
+
+.PARAMETER FunctionAppName
+    Naam van de Function App die de API host.
+
+.PARAMETER FunctionAppResourceGroup
+    Resourcegroup van de Function App. Kan afwijken van die van de Static Web App.
+
+.PARAMETER ClientId
+    Application (client) ID van de Entra App Registration van de Admin GUI.
+
+.PARAMETER ExpectedTenantId
+    Tenant ID van de Entra tenant. Het script stopt als 'az login' op een andere
+    tenant staat (faalt-snel-principe).
+
+.PARAMETER WhatIf
+    Print alleen welke wijzigingen zouden gebeuren, doet niets.
+
+.EXAMPLE
+    .\scripts\azure\Add-CustomDomain.ps1 `
+        -Domain 'wz.jouwclub.nl' `
+        -StaticWebAppName '<swa-naam>' -StaticWebAppResourceGroup '<swa-rg>' `
+        -FunctionAppName '<func-naam>' -FunctionAppResourceGroup '<func-rg>' `
+        -ClientId '<app-id>' -ExpectedTenantId '<tenant-id>' -WhatIf
+
+.NOTES
+    Vereist 'az login' op het juiste account. Voer eerst een dry-run met -WhatIf uit.
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [Parameter(Mandatory = $true, HelpMessage = 'Volledig domein, bijv. wz.jouwclub.nl')]
+    [string] $Domain,
+
+    [Parameter(Mandatory = $true, HelpMessage = 'Naam van de Static Web App-resource')]
+    [string] $StaticWebAppName,
+
+    [Parameter(Mandatory = $true, HelpMessage = 'Resourcegroup van de Static Web App')]
+    [string] $StaticWebAppResourceGroup,
+
+    [Parameter(Mandatory = $true, HelpMessage = 'Naam van de Function App die de API host')]
+    [string] $FunctionAppName,
+
+    [Parameter(Mandatory = $true, HelpMessage = 'Resourcegroup van de Function App')]
+    [string] $FunctionAppResourceGroup,
+
+    [Parameter(Mandatory = $true, HelpMessage = 'Application (client) ID van de Entra App Registration')]
+    [string] $ClientId,
+
+    [Parameter(Mandatory = $true, HelpMessage = 'Tenant ID uit Microsoft Entra ID › Overview')]
+    [string] $ExpectedTenantId
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Section($t) { Write-Host ''; Write-Host "═══ $t ═══" -ForegroundColor Cyan }
+function Write-Step($t)    { Write-Host "  • $t" -ForegroundColor Yellow }
+function Write-Done($t)    { Write-Host "  ✓ $t" -ForegroundColor Green }
+function Write-Skip($t)    { Write-Host "  → $t (al correct)" -ForegroundColor DarkGreen }
+function Write-WouldDo($t) { Write-Host "  ⊘ $t (WhatIf — niet uitgevoerd)" -ForegroundColor Magenta }
+function Write-Warn($t)    { Write-Host "  ⚠ $t" -ForegroundColor Yellow }
+function Write-Fail($t)    { Write-Host "  ✗ $t" -ForegroundColor Red }
+
+# ── Banner: dit script WIJZIGT Azure ──────────────────────────────────────────
+Write-Host ''
+if ($WhatIfPreference) {
+    Write-Host '┌─────────────────────────────────────────────────────────────────┐' -ForegroundColor Magenta
+    Write-Host '│  Add-CustomDomain.ps1 — DRY-RUN (-WhatIf)                       │' -ForegroundColor Magenta
+    Write-Host '│  Toont wat zou gebeuren — er worden GEEN wijzigingen toegepast. │' -ForegroundColor Magenta
+    Write-Host '└─────────────────────────────────────────────────────────────────┘' -ForegroundColor Magenta
+} else {
+    Write-Host '┌─────────────────────────────────────────────────────────────────┐' -ForegroundColor Yellow
+    Write-Host '│  Add-CustomDomain.ps1 — APPLY MODE                              │' -ForegroundColor Yellow
+    Write-Host '│  Past SWA-domein, Function App CORS en Entra-redirect aan.      │' -ForegroundColor Yellow
+    Write-Host '│  Idempotent. Voor een dry-run: gebruik -WhatIf.                 │' -ForegroundColor Yellow
+    Write-Host '└─────────────────────────────────────────────────────────────────┘' -ForegroundColor Yellow
+}
+
+# ── Pre-flight ────────────────────────────────────────────────────────────────
+Write-Section 'Pre-flight'
+
+if ($Domain -notmatch '^[a-z0-9]([a-z0-9\-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9\-]*[a-z0-9])?)+$') {
+    Write-Fail "Domein '$Domain' lijkt geen geldige hostnaam. Gebruik kleine letters, bijv. wz.jouwclub.nl"
+    exit 1
+}
+# Punycode/unicode-domeinen worden door Static Web Apps niet ondersteund.
+if ($Domain -like 'xn--*' -or $Domain -like '*.xn--*') {
+    Write-Fail 'Unicode/punycode-domeinen worden niet ondersteund door Static Web Apps.'
+    exit 1
+}
+$labelCount = ($Domain -split '\.').Count
+if ($labelCount -lt 3) {
+    Write-Warn "'$Domain' lijkt een apex-domein (geen subdomein)."
+    Write-Warn 'Een apex-domein vraagt een andere DNS-opzet (ALIAS/A + TXT) — zie docs/CUSTOM-DOMAIN.md.'
+}
+
+$account = az account show 2>$null | ConvertFrom-Json
+if (-not $account) {
+    Write-Fail 'Niet ingelogd bij Azure CLI. Voer eerst `az login` uit.'
+    exit 1
+}
+if ($account.tenantId -ne $ExpectedTenantId) {
+    Write-Fail "Verkeerde tenant: $($account.tenantId) (verwacht $ExpectedTenantId)"
+    exit 1
+}
+Write-Done "Ingelogd als: $($account.user.name)"
+
+$swa = az staticwebapp show --name $StaticWebAppName --resource-group $StaticWebAppResourceGroup 2>$null | ConvertFrom-Json
+if (-not $swa) {
+    Write-Fail "Static Web App '$StaticWebAppName' niet gevonden in resourcegroup '$StaticWebAppResourceGroup'."
+    exit 2
+}
+$swaHost = $swa.defaultHostname
+Write-Done "Static Web App gevonden (SKU: $($swa.sku.name))"
+
+$func = az functionapp show --name $FunctionAppName --resource-group $FunctionAppResourceGroup 2>$null | ConvertFrom-Json
+if (-not $func) {
+    Write-Fail "Function App '$FunctionAppName' niet gevonden in resourcegroup '$FunctionAppResourceGroup'."
+    exit 2
+}
+Write-Done 'Function App gevonden'
+
+$app = az ad app show --id $ClientId 2>$null | ConvertFrom-Json
+if (-not $app) {
+    Write-Fail "Entra App Registration met ClientId '$ClientId' niet gevonden."
+    exit 2
+}
+Write-Done 'Entra App Registration gevonden'
+
+# Free tier staat 2 custom domains per app toe. Waarschuw vóór we tegen de limiet lopen.
+$existingHosts = az staticwebapp hostname list --name $StaticWebAppName --resource-group $StaticWebAppResourceGroup 2>$null | ConvertFrom-Json
+$customHostCount = @($existingHosts | Where-Object { $_.name -ne $swaHost }).Count
+if ($swa.sku.name -eq 'Free' -and $customHostCount -ge 2 -and -not ($existingHosts.name -contains $Domain)) {
+    Write-Fail "Free tier staat 2 custom domains per app toe; er zijn er al $customHostCount geconfigureerd."
+    Write-Fail 'Verwijder eerst een bestaand domein, of stap over op de Standard tier (niet gratis).'
+    exit 3
+}
+
+# ── DNS-controle ─────────────────────────────────────────────────────────────
+# Static Web Apps valideert het domein pas als het CNAME-record wereldwijd resolvet.
+# Dit is een waarschuwing, geen blokkade: propagatie kan tot enkele uren duren.
+Write-Section 'DNS-controle'
+Write-Step "Verwacht CNAME: $Domain → $swaHost"
+
+$dnsOk = $false
+try {
+    $resolved = Resolve-DnsName -Name $Domain -Type CNAME -ErrorAction Stop 2>$null
+    $target = ($resolved | Where-Object { $_.NameHost } | Select-Object -First 1).NameHost
+    if ($target -and $target.TrimEnd('.') -ieq $swaHost.TrimEnd('.')) {
+        Write-Done "CNAME resolvet correct naar $target"
+        $dnsOk = $true
+    } elseif ($target) {
+        Write-Warn "CNAME wijst naar '$target' in plaats van '$swaHost'."
+        Write-Warn 'Static Web Apps kan het domein dan niet valideren. Corrigeer het record.'
+    } else {
+        Write-Warn 'Geen CNAME-record gevonden.'
+    }
+} catch {
+    Write-Warn "CNAME nog niet vindbaar voor '$Domain'."
+}
+if (-not $dnsOk) {
+    Write-Warn 'Maak eerst het CNAME-record aan; DNS-propagatie kan tot enkele uren duren.'
+    Write-Warn 'Het script gaat door — de SWA-validatie hieronder faalt dan mogelijk nog.'
+}
+
+# ── Stap 1: domein registreren in de Static Web App ──────────────────────────
+Write-Section 'Stap 1 — Static Web App: custom domain'
+
+if ($existingHosts.name -contains $Domain) {
+    $state = ($existingHosts | Where-Object { $_.name -eq $Domain }).status
+    Write-Skip "Domein al geregistreerd (status: $state)"
+} else {
+    if ($PSCmdlet.ShouldProcess($Domain, 'Custom domain toevoegen aan Static Web App')) {
+        Write-Step "Registreren van $Domain ..."
+        az staticwebapp hostname set `
+            --name $StaticWebAppName `
+            --resource-group $StaticWebAppResourceGroup `
+            --hostname $Domain `
+            --output none
+        Write-Done 'Domein geregistreerd — Azure valideert nu het DNS-record'
+        Write-Warn 'Validatie en certificaatuitgifte kunnen enkele minuten tot uren duren.'
+    } else {
+        Write-WouldDo "Custom domain $Domain toevoegen aan de Static Web App"
+    }
+}
+
+# ── Stap 2: CORS-origin op de Function App ───────────────────────────────────
+Write-Section 'Stap 2 — Function App: CORS-origin'
+
+$newOrigin = "https://$Domain"
+$cors = az functionapp cors show --name $FunctionAppName --resource-group $FunctionAppResourceGroup 2>$null | ConvertFrom-Json
+$currentOrigins = @($cors.allowedOrigins)
+
+if ($currentOrigins -contains $newOrigin) {
+    Write-Skip "CORS-origin $newOrigin staat er al"
+} else {
+    if ($PSCmdlet.ShouldProcess($newOrigin, 'CORS-origin toevoegen aan Function App')) {
+        Write-Step "Toevoegen van $newOrigin ..."
+        # 'cors add' voegt toe aan de bestaande lijst; bestaande origins blijven staan.
+        az functionapp cors add `
+            --name $FunctionAppName `
+            --resource-group $FunctionAppResourceGroup `
+            --allowed-origins $newOrigin `
+            --output none
+        Write-Done 'CORS-origin toegevoegd'
+    } else {
+        Write-WouldDo "CORS-origin $newOrigin toevoegen (bestaande origins blijven staan)"
+    }
+}
+
+# ── Stap 3: Entra SPA redirect-URI ───────────────────────────────────────────
+Write-Section 'Stap 3 — Entra App Registration: SPA redirect-URI'
+
+$newRedirect = "https://$Domain/authentication/login-callback"
+$currentRedirects = @($app.spa.redirectUris)
+
+if ($currentRedirects -contains $newRedirect) {
+    Write-Skip "Redirect-URI staat er al"
+} else {
+    if ($PSCmdlet.ShouldProcess($newRedirect, 'SPA redirect-URI toevoegen aan Entra App Registration')) {
+        Write-Step "Toevoegen van $newRedirect ..."
+        # KRITIEK: uitbreiden, niet overschrijven. Zou de bestaande URI verdwijnen, dan
+        # kan niemand meer inloggen — ook niet op de oude URL.
+        $merged = @($currentRedirects) + $newRedirect | Select-Object -Unique
+        $payload = @{ spa = @{ redirectUris = @($merged) } } | ConvertTo-Json -Depth 6 -Compress
+        $tmp = [System.IO.Path]::GetTempFileName()
+        try {
+            [System.IO.File]::WriteAllText($tmp, $payload, (New-Object System.Text.UTF8Encoding($false)))
+            az rest --method PATCH `
+                --uri "https://graph.microsoft.com/v1.0/applications/$($app.id)" `
+                --headers 'Content-Type=application/json' `
+                --body "@$tmp" `
+                --output none
+        } finally {
+            Remove-Item $tmp -ErrorAction SilentlyContinue
+        }
+
+        # Terugcontrole: de bestaande URI's moeten er nog staan.
+        $after = @((az ad app show --id $ClientId | ConvertFrom-Json).spa.redirectUris)
+        $lost = @($currentRedirects | Where-Object { $after -notcontains $_ })
+        if ($lost.Count -gt 0) {
+            Write-Fail "Bestaande redirect-URI(s) verdwenen: $($lost -join ', ')"
+            Write-Fail 'Herstel dit direct in de Portal, anders kan niemand meer inloggen.'
+            exit 4
+        }
+        Write-Done "Redirect-URI toegevoegd ($($after.Count) in totaal, bestaande behouden)"
+    } else {
+        Write-WouldDo "Redirect-URI $newRedirect toevoegen (bestaande $($currentRedirects.Count) blijven staan)"
+    }
+}
+
+# ── Samenvatting ─────────────────────────────────────────────────────────────
+Write-Section 'Samenvatting'
+if ($WhatIfPreference) {
+    Write-Host ''
+    Write-Host '  DRY-RUN — er is niets gewijzigd. Run zonder -WhatIf om toe te passen.' -ForegroundColor Magenta
+    Write-Host ''
+    exit 0
+}
+
+Write-Host ''
+Write-Host '  Verifieer daarna handmatig:' -ForegroundColor Cyan
+Write-Host "    1. https://$Domain opent met een geldig certificaat (geen waarschuwing)" -ForegroundColor Gray
+Write-Host '    2. Login via Microsoft werkt — geen AADSTS50011' -ForegroundColor Gray
+Write-Host '    3. Een pagina met data laadt daadwerkelijk gegevens (bewijst dat CORS klopt)' -ForegroundColor Gray
+Write-Host '    4. De oude .azurestaticapps.net-URL werkt nog steeds' -ForegroundColor Gray
+Write-Host ''
+Write-Host '  Doe stap 2 in een verse incognito-sessie: MSAL bewaart het ID-token in' -ForegroundColor Gray
+Write-Host '  localStorage, dus zonder verse sessie test je de oude token.' -ForegroundColor Gray
+Write-Host ''
+if (-not $dnsOk) {
+    Write-Warn 'Het CNAME-record resolveerde nog niet. Controleer de domeinstatus later met:'
+    Write-Host "    az staticwebapp hostname list --name $StaticWebAppName --resource-group $StaticWebAppResourceGroup -o table" -ForegroundColor Gray
+    Write-Host ''
+}
+exit 0


### PR DESCRIPTION
Maakt het mogelijk de Admin GUI onder een eigen (sub)domein te bereiken, met een club-neutraal script en handleiding.

Closes #657

## Waarom een script en niet een instructie met drie `az`-commando''s

Alleen een CNAME aanmaken is niet genoeg, en twee van de drie benodigde wijzigingen geven een **misleidend** foutbeeld:

| # | Wijziging | Symptoom als je het vergeet |
|---|---|---|
| 1 | Domein registreren in de Static Web App | Certificaatfout |
| 2 | CORS-origin op de Function App | UI laadt wél, maar de browser blokkeert **elke** API-call → schijnbaar werkende site met overal lege schermen |
| 3 | SPA redirect-URI in de Entra App Registration | Login mislukt met `AADSTS50011` |

**Stap 3 is met de hand echt riskant.** De redirect-URI-lijst moet worden *uitgebreid*, niet overschreven. Eén `az ad app update --set spa.redirectUris=` met alleen de nieuwe URI wist de bestaande — en dan kan niemand meer inloggen, **ook niet op de oude URL**.

Het script leest daarom de bestaande lijst, voegt toe, en **controleert daarna expliciet of er niets verdwenen is**. Zo niet: `exit 4` met een herstelinstructie. Dat sluit ook aan op de regel in CLAUDE.md dat Entra-configuratie via een script gaat en niet via Portal-klikken.

## `scripts/azure/Add-CustomDomain.ps1`
- Alle waarden verplichte parameters — **geen club-specifieke defaults**
- Idempotent; tweede run meldt per stap `(al correct)`
- `-WhatIf` met dezelfde dry-run/apply-banner als `Configure-EntraApp.ps1`
- Faalt snel op verkeerde tenant, ontbrekende resource of ongeldig domeinformaat
- Waarschuwt bij een **apex-domein** (daar kan geen CNAME) en bij de **Free-tier limiet van 2** custom domains
- Controleert of het CNAME al resolvet naar de SWA-hostnaam; zo niet een waarschuwing en toch doorgaan, want DNS-propagatie duurt

## `docs/CUSTOM-DOMAIN.md`
Generieke handleiding met placeholders, bruikbaar door elke fork. Bevat de drie valkuilen met hun symptomen, de verificatiestappen na afloop, en expliciet wat **niet** hoeft te wijzigen (CSP, `appsettings.Production.template.json`, CI).

Eén verificatiestap is de enige die CORS echt bewijst: een pagina die daadwerkelijk gegevens laadt. Alleen "de site opent" zegt niets.

## Kosten: geen
Free tier staat **2 custom domains per app** toe met gratis, automatisch vernieuwende SSL-certificaten — geverifieerd via [MS Docs](https://learn.microsoft.com/azure/static-web-apps/plans). Geen tier-upgrade, geen nieuwe resources.

## Club-neutraliteit
Gecontroleerd dat geen enkel bestand een clubdomein, SWA-hostnaam, resourcegroep, resourcenaam, client-id, tenant-id of subscription-id bevat. Alles gaat via parameters.

De doc waarschuwt bovendien om **geen GitHub *Variable*** te gebruiken voor zulke waarden: variables worden **niet gemaskeerd** in Actions-logs, en die logs zijn openbaar bij een publieke repository. Secrets wél. In deze opzet hoeft CI het domein helemaal niet te kennen.

Er staat ook een eerlijke nuance in: een hostnaam blijft niet geheim zodra er een publiek certificaat voor is uitgegeven (Certificate Transparency). Het doel is club-neutraliteit van de repo, niet geheimhouding.

## Verificatie
| Stap | Resultaat |
|---|---|
| PowerShell-parser | geen fouten |
| `Get-Help` | help-blok en parameters correct |
| Guard: ongeldig domeinformaat | exit 1 met duidelijke melding |
| Guard: verkeerde tenant | exit 1 met duidelijke melding |
| CI-docs-scan (e-mailadressen) lokaal gesimuleerd | passeert |
| Club-infrastructuurcheck lokaal gesimuleerd | alleen generiek suffix-gebruik |
| Club-specifieke waarden in de diff | geen |

Azure is **niet** aangeraakt: de eigenaar voert het script zelf uit met de eigen waarden, zodat die nergens in een sessielog of in git terechtkomen.

`CLAUDE.md` is bijgewerkt met de nieuwe doc in de Stap 2b-tabel.

Geen versiebump: tooling en documentatie, geen effect op de applicatie.