### PR TITLE
fix(#659): CSP blokkeerde inline importmap — Admin GUI startte niet in productie

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,66 @@ jobs:
         run: dotnet build BlazorAdmin/BlazorAdmin.csproj --configuration Release
 
       # ──────────────────────────────────────────────────────────────────────
+      # #659: CSP-regressiewacht op de gepubliceerde index.html.
+      #
+      # De productie-CSP van Azure Static Web Apps staat 'script-src self wasm-unsafe-eval' toe,
+      # zonder 'unsafe-inline'. Elk inline <script> in index.html wordt daar dus geblokkeerd.
+      # Dat gebeurde met de import-map die de build injecteert bij
+      # OverrideHtmlAssetPlaceholders=true: Blazor kon de gefingerprinte dotnet.js niet resolven,
+      # kreeg een 404 en startte nooit — de Admin GUI bleef permanent op het laadscherm hangen.
+      #
+      # Lokaal is dit onzichtbaar: noch de Blazor dev-server noch de SWA CLI-emulator zet de
+      # CSP-header. Deze check is daarom de enige plek waar het automatisch opvalt.
+      #
+      # Er wordt op de PUBLISH-output gecontroleerd en niet op de bron, omdat de build de
+      # import-map injecteert — een schone bron zegt dus niets.
+      # ──────────────────────────────────────────────────────────────────────
+      - name: CSP-guard — geen inline scripts in gepubliceerde index.html
+        run: |
+          dotnet publish BlazorAdmin/BlazorAdmin.csproj --configuration Release -o ./blazor-publish
+          INDEX="./blazor-publish/wwwroot/index.html"
+          if [ ! -f "$INDEX" ]; then
+            echo "::error::$INDEX niet gevonden na publish."
+            exit 1
+          fi
+
+          # HTML-commentaar eerst strippen: uitleg over deze regel mag geen valse treffer geven.
+          CLEAN=$(python3 -c "
+          import re, io, sys
+          html = io.open('$INDEX', encoding='utf-8').read()
+          sys.stdout.write(re.sub(r'<!--.*?-->', '', html, flags=re.S))
+          ")
+
+          FOUND=0
+
+          # Een <script> zonder src-attribuut is inline en wordt door de CSP geblokkeerd.
+          INLINE=$(printf '%s' "$CLEAN" | grep -oE '<script(([^>]*)?)>' | grep -vE '\ssrc=' || true)
+          if [ -n "$INLINE" ]; then
+            echo "::error::Inline <script> in de gepubliceerde index.html — de productie-CSP blokkeert dit (#659)."
+            printf '%s\n' "$INLINE" | while read -r tag; do echo "::error::  $tag"; done
+            FOUND=1
+          fi
+
+          if printf '%s' "$CLEAN" | grep -q 'type="importmap"'; then
+            echo "::error::Import-map aanwezig in de gepubliceerde index.html. Zet OverrideHtmlAssetPlaceholders op false (#659)."
+            FOUND=1
+          fi
+
+          # Zonder import-map moeten de framework-scripts ongefingerprint bestaan.
+          for f in blazor.webassembly.js dotnet.js; do
+            if [ ! -f "./blazor-publish/wwwroot/_framework/$f" ]; then
+              echo "::error::_framework/$f ontbreekt. Zonder import-map kan de browser de gefingerprinte variant niet resolven (#659)."
+              FOUND=1
+            fi
+          done
+
+          if [ "$FOUND" -eq 1 ]; then
+            echo "::error::Zie docs/CUSTOM-DOMAIN.md niet — maar issue #659 en het commentaar in BlazorAdmin/wwwroot/index.html."
+            exit 1
+          fi
+          echo "✅ Geen inline scripts, geen import-map, framework-scripts ongefingerprint aanwezig."
+
+      # ──────────────────────────────────────────────────────────────────────
       # #595: schema-drift guard.
       #
       # De deploy-pipeline publiceert geen dacpac — `db-migrate` runt alleen

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -4,10 +4,19 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-    <Version>2.17.2.0</Version>
-    <AssemblyVersion>2.17.2.0</AssemblyVersion>
-    <FileVersion>2.17.2.0</FileVersion>
+    <!-- MOET false blijven. (#659)
+         Op true genereert de build een INLINE <script type="importmap"> in index.html en
+         fingerprint het blazor.webassembly.js/dotnet.js. De productie-CSP van Azure Static Web Apps
+         staat geen inline scripts toe ('script-src self wasm-unsafe-eval'), dus die importmap werd
+         geblokkeerd. Zonder importmap kan de browser de gefingerprinte dotnet.js niet resolven →
+         404 → "Failed to start platform" → de app blijft permanent op het laadscherm hangen.
+         Lokaal onzichtbaar: de dev-server past staticwebapp.config.json niet toe.
+         Wie dit terugzet naar true moet óók de CSP oplossen — en nonce/SRI kan niet op statische
+         hosting. Zie index.html voor de volledige afweging. -->
+    <OverrideHtmlAssetPlaceholders>false</OverrideHtmlAssetPlaceholders>
+    <Version>2.17.2.1</Version>
+    <AssemblyVersion>2.17.2.1</AssemblyVersion>
+    <FileVersion>2.17.2.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/wwwroot/index.html
+++ b/BlazorAdmin/wwwroot/index.html
@@ -6,13 +6,33 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>BlazorAdmin</title>
     <base href="/" />
-    <link rel="preload" id="webassembly" />
     <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="lib/bootstrap-icons/bootstrap-icons.min.css" />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="BlazorAdmin.styles.css" rel="stylesheet" />
-    <script type="importmap"></script>
+    <!--
+      Hier hoort GEEN import-map te staan, en de scriptnaam onderaan krijgt GEEN
+      fingerprint-placeholder. Zie #659.
+
+      De productie-CSP van Azure Static Web Apps staat 'script-src self wasm-unsafe-eval' toe,
+      zonder 'unsafe-inline'. Een import-map is per definitie een inline script en werd daar dus
+      geblokkeerd. Zonder die map kon de browser het pad naar dotnet.js niet omzetten naar de
+      gefingerprinte bestandsnaam, vroeg het letterlijke pad op, kreeg een 404 en startte Blazor
+      nooit: de app bleef permanent op het laadscherm hangen.
+
+      Nonce of SRI zijn hier geen alternatief — die vragen server-side rendering per request en
+      kunnen niet op statische hosting. De CSP verzwakken met 'unsafe-inline' zou de XSS-bescherming
+      uit #434 en #603 ongedaan maken. Daarom vervalt de fingerprinting van deze twee bestanden;
+      dat is de door Microsoft gedocumenteerde route wanneer er geen plek is voor een import-map.
+      Gekoppeld: OverrideHtmlAssetPlaceholders staat op false in BlazorAdmin.csproj.
+
+      Cache-busting is gedekt: staticwebapp.config.json zet Cache-Control no-cache op / en
+      /index.html, en Blazor controleert zelf de integriteit van de assetset.
+
+      Let op: schrijf in dit commentaar niet de letterlijke script-tag of placeholder-syntaxis.
+      Scans en CI-checks die op die tekst zoeken slaan dan aan op het commentaar zelf.
+    -->
 </head>
 
 <body>
@@ -31,30 +51,9 @@
     </div>
     <script src="js/theme.js"></script>
     <script src="_content/Microsoft.Authentication.WebAssembly.Msal/AuthenticationService.js"></script>
-    <script src="_framework/blazor.webassembly#[.{fingerprint}].js"></script>
-    <script>
-        window.blazorHelpers = {
-            copyToClipboard: function (text) {
-                return navigator.clipboard.writeText(text);
-            },
-            downloadHtml: function (filename, content) {
-                var blob = new Blob([content], { type: 'text/html' });
-                var url = URL.createObjectURL(blob);
-                var a = document.createElement('a');
-                a.href = url;
-                a.download = filename;
-                document.body.appendChild(a);
-                a.click();
-                document.body.removeChild(a);
-                URL.revokeObjectURL(url);
-            },
-            // Dedicated helpers i.p.v. JS eval(): de productie-CSP van Azure SWA staat alleen
-            // 'wasm-unsafe-eval' toe, niet 'unsafe-eval'. eval() gooit daar een EvalError. (#597)
-            getUserAgent: function () {
-                return navigator.userAgent || '';
-            }
-        };
-    </script>
+    <script src="_framework/blazor.webassembly.js"></script>
+    <!-- Extern i.p.v. inline: inline scripts worden door de productie-CSP geblokkeerd (#659). -->
+    <script src="js/blazor-helpers.js"></script>
 </body>
 
 </html>

--- a/BlazorAdmin/wwwroot/js/blazor-helpers.js
+++ b/BlazorAdmin/wwwroot/js/blazor-helpers.js
@@ -1,0 +1,28 @@
+// JS-helpers voor Blazor interop.
+//
+// Dit stond eerder als inline <script> in index.html. De productie-CSP van Azure Static Web Apps
+// staat 'script-src self wasm-unsafe-eval' toe — géén 'unsafe-inline'. Inline scripts worden daar
+// dus geblokkeerd, waardoor window.blazorHelpers niet bestond en clipboard, downloadHtml en
+// getUserAgent stil faalden. Een extern bestand van dezelfde origin valt onder 'self' en mag wel.
+// Zie #659. Lokaal was dit onzichtbaar: de dev-server past staticwebapp.config.json niet toe.
+window.blazorHelpers = {
+    copyToClipboard: function (text) {
+        return navigator.clipboard.writeText(text);
+    },
+    downloadHtml: function (filename, content) {
+        var blob = new Blob([content], { type: 'text/html' });
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    },
+    // Dedicated helpers i.p.v. JS eval(): de productie-CSP staat alleen 'wasm-unsafe-eval' toe,
+    // niet 'unsafe-eval'. eval() gooit daar een EvalError. (#597)
+    getUserAgent: function () {
+        return navigator.userAgent || '';
+    }
+};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 Alle noemenswaardige wijzigingen in dit project worden bijgehouden in dit bestand.
 
@@ -17,6 +17,14 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 ---
 
 ## [Unreleased]
+
+## [2.17.2.1] — 2026-07-26
+
+### Fixed
+- **De beheeromgeving was in productie onbruikbaar: de pagina bleef op het laadscherm hangen.** De beveiligingsinstellingen van de website blokkeren scripts die direct in de pagina staan. Twee van zulke scripts waren nodig om de applicatie te starten en om kopiëren, downloaden en de FEEDBACK-knop te laten werken. Beide zijn nu naar losse bestanden verplaatst, waarmee de beveiliging onverkort blijft gelden. Lokaal was dit niet te zien omdat die beveiliging daar niet actief is. (#659)
+
+### Changed
+- De bouwstraat controleert nu bij elke wijziging of er scripts direct in de pagina staan. Dezelfde fout kan daarmee niet opnieuw ongemerkt in productie komen. (#659)
 
 ## [2.17.2.0] — 2026-07-26
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,19 +224,25 @@ ITERATIE:
        Write-Host "Versie: $($health.version)"
        → niet 200? Fix, kill services, ga terug naar a.
 
-  f. Blazor fingerprint consistency check (VERPLICHT — detecteert root cause van "An unhandled error"):
-       # .NET 10 Blazor WASM: importmap key is './_framework/dotnet.js' (niet 'dotnet')
-       $html = (Invoke-WebRequest "http://localhost:5242/" -UseBasicParsing -ErrorAction SilentlyContinue).Content
-       $importmapMatch = [regex]::Match($html, '<script type="importmap"[^>]*>(.*?)</script>',
-           [System.Text.RegularExpressions.RegexOptions]::Singleline)
-       if ($importmapMatch.Success) {
-           $dotnetEntry = ($importmapMatch.Groups[1].Value | ConvertFrom-Json).imports."./_framework/dotnet.js" -replace '^\.\/', ''
-           $check = Invoke-WebRequest "http://localhost:5242/$dotnetEntry" -UseBasicParsing -ErrorAction SilentlyContinue
-           if ($check.StatusCode -ne 200) {
-               Write-Host "FINGERPRINT MISMATCH: $dotnetEntry → $($check.StatusCode)" -ForegroundColor Red
-           }
+  f. CSP-compatibiliteit van de gepubliceerde index.html (VERPLICHT — zie #659):
+       # Er MOET géén import-map en géén inline <script> in de publish-output staan: de
+       # productie-CSP van Azure SWA staat 'script-src self wasm-unsafe-eval' toe, zonder
+       # 'unsafe-inline'. Een inline script wordt daar geblokkeerd. Bij de import-map betekende
+       # dat: dotnet.js niet resolvebaar → 404 → Blazor start nooit → permanent laadscherm.
+       #
+       # Dit is NIET zichtbaar op :5242 en ook NIET op de SWA CLI-emulator (:4280) — geen van
+       # beide zet de CSP-header. Daarom op de publish-output controleren.
+       dotnet publish BlazorAdmin/BlazorAdmin.csproj -c Release -o $env:TEMP\bapub | Out-Null
+       $raw = Get-Content "$env:TEMP\bapub\wwwroot\index.html" -Raw
+       $clean = [regex]::Replace($raw, '<!--.*?-->', '', [System.Text.RegularExpressions.RegexOptions]::Singleline)
+       $inline = [regex]::Matches($clean, '<script(?:[^>]*)?>') | Where-Object { $_.Value -notmatch '\ssrc=' }
+       if ($inline -or $clean -match 'type="importmap"') {
+           Write-Host "CSP-PROBLEEM: inline script of import-map in publish-output" -ForegroundColor Red
        }
-       → mismatch of importmap leeg? Stop services → dotnet clean BlazorAdmin → terug naar d.
+       → treffer? OverrideHtmlAssetPlaceholders moet false blijven; inline scripts naar een
+         extern bestand in wwwroot/js/. Terug naar a.
+
+       De CI-job 'Build FunctionApp + BlazorAdmin' bevat deze guard ook, dus een PR faalt hierop.
 
   g. .\scripts\dev\Test-App.ps1 (met live services — secties 4+5+6 worden nu uitgevoerd)
      → exit 1? Fix, kill services, ga terug naar a.
@@ -366,6 +372,36 @@ Deze regels gelden altijd, zonder uitzondering:
    gh run view <run-id> --json jobs --jq '.jobs[] | {name: .name, conclusion: .conclusion}'
    ```
    **Stap C is verplicht**, ook als Stap B exit 0 geeft. `gh run watch` kan in de achtergrond exit 0 teruggeven terwijl individuele jobs (bijv. `blazor-deploy`) later falen. Pas als ALLE jobs `"conclusion": "success"` of `"conclusion": "skipped"` tonen is de deploy succesvol. Als één job `"conclusion": "failure"` toont: direct proberen te fixen (bijv. `gh run rerun <run-id> --failed` bij transient fouten). Lukt fix niet: onmiddellijk melden aan gebruiker. Nooit melden dat een PR succesvol is afgerond zonder Stap C te hebben uitgevoerd.
+
+2a. **Na elke productie-deploy: browser-rendercheck op de LIVE Admin GUI — verplicht (#659).**
+
+   > **Groene deploy-jobs en HTTP 200 bewijzen niets over de Admin GUI.** Bij release v2.17.2.0 waren
+   > alle zes deploy-jobs `success`, gaf de SWA HTTP 200 en stond het woord "blazor" in de HTML —
+   > terwijl de GUI in werkelijkheid permanent op het laadscherm hing. Een Blazor WASM-app levert op
+   > élke route dezelfde `index.html` met status 200; die controle kan de fout per definitie niet zien.
+
+   Verplicht ná Stap C, en **vóór** je meldt dat de release geslaagd is. Met een echte browser
+   (Playwright of handmatig in een verse incognito-sessie):
+
+   ```
+   □ Open de productie-URL van de Admin GUI
+   □ Console (F12): ZERO fouten — let specifiek op:
+       - "violates the following Content Security Policy directive"  → inline script geblokkeerd (#659)
+       - "Failed to start platform"                                  → Blazor start niet
+       - "Failed to load resource: 404" op iets in /_framework/       → asset niet resolvebaar
+   □ De pagina hangt NIET op het laadscherm: window.Blazor bestaat
+   □ Er is een redirect naar login.microsoftonline.com, óf de UI rendert voor een ingelogde sessie
+   □ Geen "An unhandled error has occurred"-banner
+   □ Na inloggen: een pagina met gegevens laadt daadwerkelijk gegevens (bewijst dat CORS klopt)
+   ```
+
+   Faalt één punt? Dan is de release **niet** geslaagd: direct een hotfix vanuit `main`, en melden
+   aan de gebruiker. Nooit "release geslaagd" rapporteren op basis van alleen CI en HTTP-status.
+
+   **Waarom dit niet lokaal te ondervangen is:** de CSP komt uit `staticwebapp.config.json` en wordt
+   alleen door Azure SWA toegepast — niet door de dev-server op :5242 en ook niet door de SWA
+   CLI-emulator op :4280. Stap `f` van de verificatielus dekt dit statisch af op de publish-output,
+   maar de live check blijft het enige echte bewijs.
 
 3. **Build- en runtime-fouten zijn zelfherstelbaar — Security Gate niet.** Bij een build-fout, startup-fout of testfout: fix het zelf en herhaal de verificatielus (zie "Autonome ontwikkelcyclus"). Bij een **Security Gate-fout of AVG-schending**: stop direct en meld aan de gebruiker — nooit stilzwijgend doorgaan of zelf mergen.
 

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.17.2.0</Version>
-    <AssemblyVersion>2.17.2.0</AssemblyVersion>
-    <FileVersion>2.17.2.0</FileVersion>
+    <Version>2.17.2.1</Version>
+    <AssemblyVersion>2.17.2.1</AssemblyVersion>
+    <FileVersion>2.17.2.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->


### PR DESCRIPTION
> **HOTFIX — productie-uitval.** De Admin GUI hangt permanent op het laadscherm, op beide hostnames.

Closes #659

## Oorzaak
De productie-CSP van Azure SWA staat `script-src 'self' 'wasm-unsafe-eval'` toe, **zonder** `unsafe-inline`. Twee inline scripts in `index.html` werden daardoor geblokkeerd:

| # | Inline script | Gevolg |
|---|---|---|
| 1 | de import-map die de build injecteert bij `OverrideHtmlAssetPlaceholders=true` | Browser kan het pad naar `dotnet.js` niet omzetten naar de gefingerprinte naam → vraagt het letterlijke pad op → **404** → `Failed to start platform` → eeuwig laadscherm |
| 2 | `window.blazorHelpers` | `copyToClipboard`, `downloadHtml` en `getUserAgent` undefined — raakt o.a. de FEEDBACK-widget |

Ironisch: het commentaar bij punt 2 verwees al naar #597 over exact deze CSP.

## Fix — zonder de CSP te verzwakken
- `OverrideHtmlAssetPlaceholders` → **`false`**, en `index.html` naar de ongefingerprinte `_framework/blazor.webassembly.js`. Dit is de [door Microsoft gedocumenteerde route](https://learn.microsoft.com/aspnet/core/blazor/host-and-deploy/webassembly/?view=aspnetcore-10.0#publish-without-an-html-document) wanneer er geen plek is voor een import-map.
- `blazorHelpers` → `wwwroot/js/blazor-helpers.js`. Extern van dezelfde origin valt onder `'self'`.

Nonce of SRI kan hier niet: die vragen server-side rendering per request, en dat bestaat niet op statische hosting. `'unsafe-inline'` toevoegen zou de XSS-bescherming uit #434 en #603 ongedaan maken.

Cache-busting blijft gedekt: `staticwebapp.config.json` zet `Cache-Control: no-cache` op `/` en `/index.html`, en Blazor controleert zelf de integriteit van de assetset.

## Verificatie — met de echte CSP
Noch de dev-server (`:5242`) noch de SWA CLI-emulator (`:4280`) zet de CSP-header; daar is dit per definitie onzichtbaar. **Dat is precies waarom dit door alle netten glipte.**

Daarom de publish-output geserveerd met exact de CSP uit `staticwebapp.config.json` en met een echte browser getest:

| Controle | Vóór | Ná |
|---|---|---|
| CSP-overtredingen | 2 | **0** |
| `window.Blazor` bestaat | nee | **ja** |
| Vast op laadscherm | ja | **nee** |
| `blazorHelpers` beschikbaar | nee | **ja** |
| MSAL | crashte | **redirect naar `login.microsoftonline.com`** met correcte OAuth2-URL |

Publish-output: 0 inline scripts, geen import-map, `blazor.webassembly.js` en `dotnet.js` bestaan ongefingerprint.

## Regressiewacht
Nieuwe stap in de CI-build: publiceert BlazorAdmin en faalt bij een inline script of import-map in de output. Controleert ook dat de framework-scripts ongefingerprint bestaan. Guard-logica getest met een positieve én een negatieve casus.

## Procesfix — dit had de release moeten tegenhouden
Bij v2.17.2.0 waren alle zes deploy-jobs `success`, gaf de SWA HTTP 200 en stond "blazor" in de HTML — terwijl de GUI stuk was. Een Blazor WASM-app levert op élke route dezelfde `index.html` met status 200, dus die controle kón de fout niet zien.

Twee wijzigingen in CLAUDE.md:
- **Stap `f`** van de verificatielus controleerde de import-map en zou nu juist vals alarm geven → vervangen door de CSP-guard op de publish-output.
- **Nieuwe stap `2a`**: verplichte browser-rendercheck op de **live** Admin GUI na elke productie-deploy, met een concrete lijst foutsignaturen, en expliciet vóór er "release geslaagd" gemeld mag worden.

## Versie
`2.17.2.0` → **`2.17.2.1`** (REVISION, hotfix).