### PR TITLE
feat(#667, #668, #669): duidelijker exportinstructie, vervang-waarschuwing en Teambegeleiding vooraan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -979,14 +979,14 @@ De `exports/` map bevat **scripts** voor data-exports. De databestanden zelf (CS
 - `exports/*.csv` en `exports/*.xlsx` bevatten persoonsgegevens (namen, e-mails, telefoonnummers, geboortedatums van clubleden)
 - **NOOIT een CSV of Excel-bestand committen of pushen** — `.gitignore` blokkeert dit, maar controleer altijd
 - De databestanden staan alleen lokaal en zijn alleen beschikbaar voor de applicatie zelf
-- Alleen `.ps1` scripts, `README.md` en `HANDLEIDING-teambegeleiding-export.md` mogen in git
+- Alleen `.ps1` scripts en `README.md` mogen in git
 
 **Scripts in exports/:**
-- `import-teambegeleiding-to-sql.ps1` — importeert CSV naar `avg.Teambegeleiding` in SQL Server (TRUNCATE + bulk insert)
+- `import-teambegeleiding-to-sql.ps1` — importeert CSV naar `avg.Teambegeleiding` in SQL Server (rijen van de club verwijderen + bulk insert; géén TRUNCATE, dat zou andere clubs wissen)
 
 **Workflow:**
-1. Download CSV via club.sportlink.com (zie `exports/HANDLEIDING-teambegeleiding-export.md` voor exacte stappen)
-2. Sla op in de lokale `exports/` map — nooit committen
-3. Voer `.\exports\import-teambegeleiding-to-sql.ps1` uit om de data in SQL te laden
+1. Download CSV via club.sportlink.com (zie [docs/ADMIN-TEAMBEGELEIDING-IMPORT.md](docs/ADMIN-TEAMBEGELEIDING-IMPORT.md) voor exacte stappen)
+2. Importeer via de Admin GUI (**Teambegeleiding → Teambegeleiding importeren**) — CSV wordt in de browser verwerkt, niets op de server opgeslagen
+3. Alternatief vanaf de commandline: sla de CSV op in de lokale `exports/` map (nooit committen) en voer `.\exports\import-teambegeleiding-to-sql.ps1` uit
 
 ## Imported Claude Cowork project instructions

--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -14,9 +14,9 @@
          Wie dit terugzet naar true moet óók de CSP oplossen — en nonce/SRI kan niet op statische
          hosting. Zie index.html voor de volledige afweging. -->
     <OverrideHtmlAssetPlaceholders>false</OverrideHtmlAssetPlaceholders>
-    <Version>2.17.2.1</Version>
-    <AssemblyVersion>2.17.2.1</AssemblyVersion>
-    <FileVersion>2.17.2.1</FileVersion>
+    <Version>2.17.2.2</Version>
+    <AssemblyVersion>2.17.2.2</AssemblyVersion>
+    <FileVersion>2.17.2.2</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/Layout/NavMenu.razor
+++ b/BlazorAdmin/Layout/NavMenu.razor
@@ -36,6 +36,12 @@
                 <i class="bi bi-speedometer2 me-1" aria-hidden="true"></i> Dashboard
             </NavLink>
         </div>
+        @* Teambegeleiding staat bewust vooraan: meest gebruikte scherm (#669) *@
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="teambegeleiding">
+                <i class="bi bi-people me-1" aria-hidden="true"></i> Teambegeleiding
+            </NavLink>
+        </div>
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="dagplanning">
                 <i class="bi bi-calendar-week me-1" aria-hidden="true"></i> Dagplanning
@@ -49,11 +55,6 @@
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="email-tester">
                 <i class="bi bi-envelope-check me-1" aria-hidden="true"></i> Email-tester
-            </NavLink>
-        </div>
-        <div class="nav-item px-3">
-            <NavLink class="nav-link" href="teambegeleiding">
-                <i class="bi bi-people me-1" aria-hidden="true"></i> Teambegeleiding
             </NavLink>
         </div>
 

--- a/BlazorAdmin/Pages/Home.razor
+++ b/BlazorAdmin/Pages/Home.razor
@@ -15,7 +15,19 @@
 <h1>Dashboard</h1>
 <p class="text-muted mb-4">Welkom in de beheeromgeving. Kies een functie om te beginnen.</p>
 
+@* Tegelvolgorde loopt gelijk met het navigatiemenu; Teambegeleiding vooraan (#669) *@
 <div class="row g-3 mt-2">
+    <div class="col-sm-6 col-xl-3">
+        <a href="teambegeleiding" class="text-decoration-none">
+            <div class="card h-100 shadow-sm border-0 dashboard-card">
+                <div class="card-body d-flex flex-column align-items-center text-center p-4">
+                    <i class="bi bi-people dashboard-card-icon mb-3" aria-hidden="true"></i>
+                    <h5 class="card-title mb-1">Teambegeleiding</h5>
+                    <p class="card-text text-muted small mb-0">Bekijk en beheer de contactgegevens van teambegeleid&shy;ers.</p>
+                </div>
+            </div>
+        </a>
+    </div>
     <div class="col-sm-6 col-xl-3">
         <a href="dagplanning" class="text-decoration-none">
             <div class="card h-100 shadow-sm border-0 dashboard-card">
@@ -45,17 +57,6 @@
                     <i class="bi bi-envelope-check dashboard-card-icon mb-3" aria-hidden="true"></i>
                     <h5 class="card-title mb-1">Email-tester</h5>
                     <p class="card-text text-muted small mb-0">Test de e-mailverwerking en verstuur testberichten vanuit de beheeromgeving.</p>
-                </div>
-            </div>
-        </a>
-    </div>
-    <div class="col-sm-6 col-xl-3">
-        <a href="teambegeleiding" class="text-decoration-none">
-            <div class="card h-100 shadow-sm border-0 dashboard-card">
-                <div class="card-body d-flex flex-column align-items-center text-center p-4">
-                    <i class="bi bi-people dashboard-card-icon mb-3" aria-hidden="true"></i>
-                    <h5 class="card-title mb-1">Teambegeleiding</h5>
-                    <p class="card-text text-muted small mb-0">Bekijk en beheer de contactgegevens van teambegeleid&shy;ers.</p>
                 </div>
             </div>
         </a>

--- a/BlazorAdmin/Pages/Teambegeleiding.razor
+++ b/BlazorAdmin/Pages/Teambegeleiding.razor
@@ -134,14 +134,34 @@ else if (_selectedTeam != null && !_loadingBegeleiders)
 @* ── Teambegeleiding importeren ─────────────────────────────────────────────── *@
 <hr class="mt-4" />
 <h4>Teambegeleiding importeren</h4>
-<p class="text-muted small">
-    Download de CSV via club.sportlink.com → Leden → Exporteer tabel.<br />
+<p class="text-muted small mb-2">
     De CSV wordt in de browser ingelezen en verwerkt — er worden geen bestanden opgeslagen op de server.
 </p>
+
+<div class="card bg-light border-0 mb-3" style="max-width: 640px;">
+    <div class="card-body py-2 px-3">
+        <div class="small fw-semibold mb-1">De juiste CSV exporteren uit Sportlink</div>
+        <ol class="small text-muted mb-0 ps-3">
+            <li>Log in op <a href="https://club.sportlink.com" target="_blank" rel="noopener">club.sportlink.com</a></li>
+            <li>Ga naar <strong>Personen</strong></li>
+            <li>Kies <strong>Teams</strong></li>
+            <li>Klik bij <strong>Bondsteam</strong> op <em>alles selecteren</em></li>
+            <li>Klik bij <strong>Rol binnen het team</strong> op <em>alles selecteren</em></li>
+            <li>Verwijder de <strong>Teamspeler</strong>-opties (aanvaller, keeper, middenvelder, verdediger)</li>
+            <li>Klik op <strong>Zoeken</strong></li>
+            <li>Kies <strong>Exporteren</strong> en sla het document op</li>
+            <li>Kies het opgeslagen bestand hieronder</li>
+        </ol>
+    </div>
+</div>
 
 <div class="mb-3" style="max-width: 480px;">
     <InputFile OnChange="BestandGeselecteerdAsync" accept=".csv" class="form-control"
                disabled="@_importBezig" />
+    <div class="alert alert-warning small mt-2 mb-0" role="alert">
+        <strong>Let op:</strong> alle gegevens worden opnieuw ingelezen en vervangen de oude gegevens
+        van deze club volledig.
+    </div>
 </div>
 
 @if (_importLeesError != null)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ### Added
 - **Een club kan de beheeromgeving nu onder een eigen webadres bereikbaar maken**, bijvoorbeeld `wz.[clubdomein]` in plaats van het automatisch gegenereerde Azure-adres. Er is een handleiding en een script dat de drie benodigde wijzigingen in één keer doorvoert. Dat is meer werk dan alleen een DNS-record: zonder de bijbehorende instellingen laadt de omgeving wel, maar blijven alle schermen leeg of mislukt het inloggen. Het script controleert dat vooraf en laat zich veilig herhalen. Kost niets — het gratis Azure-pakket staat twee eigen webadressen toe, inclusief automatisch vernieuwende beveiligingscertificaten. (#657)
+- **Het scherm Teambegeleiding legt nu stap voor stap uit hoe je de juiste lijst uit Sportlink haalt.** De oude toelichting was één regel en sloeg de belangrijkste keuzes over. De negen stappen staan nu op het scherm zelf, inclusief het selecteren van alle bondsteams — wordt die stap overgeslagen, dan komen ook lokale teams in de lijst terecht. (#667)
+- **Er staat nu een duidelijke waarschuwing bij het importeren:** alle gegevens worden opnieuw ingelezen en vervangen de oude gegevens van de club volledig. Dat was altijd al zo, maar het scherm vertelde het niet. Een onvolledige lijst herstel je dus door simpelweg een complete lijst opnieuw te importeren. (#668)
+
+### Changed
+- **Teambegeleiding staat nu bovenaan** in het menu en als eerste tegel op het dashboard, direct onder Dashboard. Het is het meest gebruikte scherm: contactgegevens van begeleiders zijn hier sneller te vinden dan in Sportlink zelf. De overige schermen behouden hun onderlinge volgorde. (#669)
+
+### Fixed
+- De handleidingen beschreven een verouderd navigatiepad voor de Sportlink-export en verwezen naar een handleidingbestand dat niet meer bestaat. Ook stond er dat een import de tabel volledig leegt, terwijl uitsluitend de gegevens van de eigen club worden vervangen — bij meerdere clubs in één database was die beschrijving misleidend. (#667, #668)
 
 ## [2.17.2.1] — 2026-07-26
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1053,12 +1053,12 @@ De `exports/` map bevat **scripts** voor data-exports. De databestanden zelf (CS
 - `exports/*.csv` en `exports/*.xlsx` bevatten persoonsgegevens (namen, e-mails, telefoonnummers, geboortedatums van clubleden)
 - **NOOIT een CSV of Excel-bestand committen of pushen** — `.gitignore` blokkeert dit, maar controleer altijd
 - De databestanden staan alleen lokaal en zijn alleen beschikbaar voor de applicatie zelf
-- Alleen `.ps1` scripts, `README.md` en `HANDLEIDING-teambegeleiding-export.md` mogen in git
+- Alleen `.ps1` scripts en `README.md` mogen in git
 
 **Scripts in exports/:**
-- `import-teambegeleiding-to-sql.ps1` — importeert CSV naar `avg.Teambegeleiding` in SQL Server (TRUNCATE + bulk insert)
+- `import-teambegeleiding-to-sql.ps1` — importeert CSV naar `avg.Teambegeleiding` in SQL Server (rijen van de club verwijderen + bulk insert; géén TRUNCATE, dat zou andere clubs wissen)
 
 **Workflow:**
-1. Download CSV via club.sportlink.com (zie `exports/HANDLEIDING-teambegeleiding-export.md` voor exacte stappen)
-2. Sla op in de lokale `exports/` map — nooit committen
-3. Voer `.\exports\import-teambegeleiding-to-sql.ps1` uit om de data in SQL te laden
+1. Download CSV via club.sportlink.com (zie [docs/ADMIN-TEAMBEGELEIDING-IMPORT.md](docs/ADMIN-TEAMBEGELEIDING-IMPORT.md) voor exacte stappen)
+2. Importeer via de Admin GUI (**Teambegeleiding → Teambegeleiding importeren**) — CSV wordt in de browser verwerkt, niets op de server opgeslagen
+3. Alternatief vanaf de commandline: sla de CSV op in de lokale `exports/` map (nooit committen) en voer `.\exports\import-teambegeleiding-to-sql.ps1` uit

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.17.2.1</Version>
-    <AssemblyVersion>2.17.2.1</AssemblyVersion>
-    <FileVersion>2.17.2.1</FileVersion>
+    <Version>2.17.2.2</Version>
+    <AssemblyVersion>2.17.2.2</AssemblyVersion>
+    <FileVersion>2.17.2.2</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/docs/ADMIN-TEAMBEGELEIDING-IMPORT.md
+++ b/docs/ADMIN-TEAMBEGELEIDING-IMPORT.md
@@ -25,13 +25,20 @@ Deze handleiding legt stap voor stap uit hoe je de lijst met teambegeleiders (tr
 
 ## Stap 2 — Filter instellen: alleen teambegeleiding
 
-Je ziet nu de ledenzoekopdracht. We filteren zodat alleen begeleiders zichtbaar zijn en geen spelers.
+We filteren zodat alleen begeleiders zichtbaar zijn en geen spelers.
 
-1. Klik op de knop **Teams** in de filterbalk bovenaan de pagina
+1. Ga naar **Personen**
 
-2. Klik in het uitklapmenu op **Rol binnen team**
+2. Kies **Teams**
 
-3. Je ziet een lijst met rollen en aangevinkte checkboxes. Verwijder het vinkje bij de volgende vier rollen door er één voor één op te klikken:
+3. Klik bij **Bondsteam** op **alles selecteren**
+
+   > Deze stap wordt gemakkelijk overgeslagen. Zonder deze selectie komen ook lokale (niet-bonds)teams
+   > in de export terecht, waardoor de lijst ruis bevat.
+
+4. Klik bij **Rol binnen het team** op **alles selecteren** — nu staan alle rollen aangevinkt
+
+5. Verwijder het vinkje bij de volgende vier rollen door er één voor één op te klikken:
 
    - **Teamspeler / Aanvaller**
    - **Teamspeler / Keeper**
@@ -40,9 +47,9 @@ Je ziet nu de ledenzoekopdracht. We filteren zodat alleen begeleiders zichtbaar 
 
    > Controleer dat deze vier rollen **niet** aangevinkt zijn. Alle andere rollen zoals trainer, leider en coach mogen aangevinkt blijven.
 
-4. Klik op de knop **Zoek**
+6. Klik op de knop **Zoeken**
 
-5. Wacht even — dit duurt soms 5 tot 10 seconden. Je ziet daarna het resultaat verschijnen met het aantal gevonden personen.
+7. Wacht even — dit duurt soms 5 tot 10 seconden. Je ziet daarna het resultaat verschijnen met het aantal gevonden personen.
 
 ---
 
@@ -58,9 +65,26 @@ Je ziet nu de ledenzoekopdracht. We filteren zodat alleen begeleiders zichtbaar 
 
 ---
 
-## Stap 4 — Bestand importeren naar de database
+## Stap 4 — Bestand importeren
 
-Nu het bestand gedownload is, voer je het importscript uit zodat de gegevens in de database worden bijgewerkt.
+Er zijn twee manieren om het bestand te importeren. **Optie A is de eenvoudigste** en vereist geen
+technische kennis.
+
+> **Let op — geldt voor beide opties:** een import **vervangt de bestaande teambegeleiding van de club
+> volledig**. Alle eerder geïmporteerde rijen worden eerst verwijderd, daarna wordt de nieuwe lijst
+> ingelezen. Er wordt niets samengevoegd. Is je export onvolledig (bijv. Bondsteam niet geselecteerd in
+> stap 2), importeer dan simpelweg een nieuwe, complete export — die overschrijft de foutieve lijst weer.
+
+### Optie A — via de Admin GUI (aanbevolen)
+
+1. Open de Admin GUI en ga naar **Teambegeleiding**
+2. Scroll naar **Teambegeleiding importeren**
+3. Kies het gedownloade bestand
+4. Controleer de voorbeeldweergave en bevestig de import
+
+De CSV wordt in de browser ingelezen en verwerkt — er wordt geen bestand op de server opgeslagen.
+
+### Optie B — via het PowerShell-script
 
 1. Open **PowerShell** (zoek via het Startmenu op "PowerShell")
 
@@ -108,7 +132,8 @@ Deze export wordt **wekelijks** uitgevoerd — kies een vast moment dat past bij
 
 | Probleem | Mogelijke oorzaak | Oplossing |
 |---|---|---|
-| Minder dan 400 personen gevonden | Filter niet goed ingesteld | Herhaal stap 2 en controleer of de 4 Teamspeler-rollen uitgevinkt zijn |
+| Veel minder personen gevonden dan verwacht | Filter niet goed ingesteld | Herhaal stap 2 en controleer of de 4 Teamspeler-rollen uitgevinkt zijn |
+| Lijst bevat teams die geen bondsteam zijn | **Bondsteam** niet op *alles selecteren* gezet (stap 2.3) | Herhaal stap 2 mét die selectie en importeer opnieuw — de nieuwe import vervangt de foutieve lijst volledig |
 | Geen exportknop zichtbaar | Onvoldoende rechten | Vraag een beheerder om de export uit te voeren |
 | Script geeft een fout | Geen bestand gevonden | Controleer of de download in stap 3 geslaagd is en het bestand in de Downloadmap staat |
 | Verificatiecode werkt niet | Code verlopen | Wacht tot de authenticator-app een nieuwe code toont en probeer opnieuw |

--- a/docs/BEHEERDER-HANDLEIDING.md
+++ b/docs/BEHEERDER-HANDLEIDING.md
@@ -448,6 +448,18 @@ De pagina `/teambegeleiding` stelt beheerders én gebruikers met de **user-rol**
    - Reply-To: e-mailadres van de aanvrager (automatisch uit Entra ID)
    - BCC: coördinator (uit `dbo.AppSettings.plannerEmailAdres`)
    - Coach antwoordt rechtstreeks naar aanvrager — aanvrager ziet nooit het coach-adres
+4. **Teambegeleiding importeren** — CSV-export uit Sportlink inlezen; het scherm bevat de exportstappen
+   en een voorbeeldweergave vóór bevestiging. De CSV wordt in de browser verwerkt en nooit op de server
+   opgeslagen.
+   - **Een import vervangt de bestaande teambegeleiding van de club volledig** — alle bestaande rijen
+     van de club worden eerst verwijderd (`DELETE WHERE ClubCode`), daarna volgt de nieuwe lijst. Er
+     wordt niets samengevoegd, dus een onvolledige export herstel je door een complete export opnieuw
+     te importeren.
+   - Volledige exportinstructie voor de beheerder: [ADMIN-TEAMBEGELEIDING-IMPORT.md](ADMIN-TEAMBEGELEIDING-IMPORT.md)
+
+> **Menupositie:** Teambegeleiding staat bewust direct onder Dashboard in de zijbalk en als eerste tegel
+> op het dashboard — het is het meest gebruikte scherm, omdat contactgegevens hier sneller te vinden
+> zijn dan in Sportlink Club zelf (#669).
 
 ### API-endpoints
 
@@ -456,6 +468,7 @@ De pagina `/teambegeleiding` stelt beheerders én gebruikers met de **user-rol**
 | `GET /api/beheer/teambegeleiding` | Alle teams met begeleiding |
 | `GET /api/beheer/teambegeleiding/{team}` | Begeleiders van team (naam + rol, nooit contactgegevens) |
 | `POST /api/beheer/teambegeleiding/doorsturen` | Doorsturen van vraag naar coach |
+| `POST /api/beheer/teambegeleiding/import` | CSV-import; vervangt alle rijen van de club |
 
 Auth: `RequireAuthenticated()` — toegankelijk voor zowel admin- als user-rol.
 

--- a/exports/README.md
+++ b/exports/README.md
@@ -36,10 +36,10 @@ WHERE  Team      = @team
 #### Handmatig downloaden (universeel, werkt voor alle clubs)
 
 1. Ga naar [club.sportlink.com](https://club.sportlink.com) en log in met je verenigingsaccount
-2. Navigeer naar **Leden → Ledenlijst** (of ga direct naar `/member/search`)
-3. Klik op de filter **Teams**
-4. Klik op **Rol binnen team**
-5. Klik op **Alles geselecteerd** — nu staan alle rollen aangevinkt
+2. Navigeer naar **Personen**
+3. Kies **Teams**
+4. Klik bij **Bondsteam** op **alles selecteren** — zonder deze stap komen ook lokale (niet-bonds)teams in de export
+5. Klik bij **Rol binnen het team** op **alles selecteren** — nu staan alle rollen aangevinkt
 6. Vink de volgende vier opties **uit** (dit zijn de spelers):
    - `Teamspeler / Aanvaller`
    - `Teamspeler / Keeper`
@@ -50,6 +50,10 @@ WHERE  Team      = @team
 9. Klik op het kleine **"Exporteer tabel"** icoon rechts boven de resultatenlijst (pijl-omlaag icoon)
 10. Klik in de popup op **Download**
 11. De CSV wordt opgeslagen in je standaard downloadmap
+
+> De eenvoudigste route om de export daarna in te lezen is de Admin GUI: **Teambegeleiding →
+> Teambegeleiding importeren**. Het PowerShell-script hieronder is het alternatief voor wie liever
+> vanaf de commandline werkt. Beide vervangen de bestaande gegevens van de club volledig.
 
 > **Tip:** de bestandsnaam die Sportlink meegeeft bevat het aantal gevonden personen, bijv. `Teams 420 personen gevonden.csv`. Dit is normaal.
 
@@ -72,7 +76,7 @@ Het script:
 1. Leest `SqlConnectionString` uit `FunctionApp/local.settings.json`
 2. Detecteert automatisch welke kolommen aanwezig zijn in de CSV (zie aliassen hieronder)
 3. Valideert dat de verplichte kolommen beschikbaar zijn — geeft duidelijke fout als iets ontbreekt
-4. Leegt `avg.Teambegeleiding` volledig (TRUNCATE) en importeert alle rijen opnieuw
+4. Verwijdert alle bestaande rijen van deze club uit `avg.Teambegeleiding` (`DELETE WHERE ClubCode`) en importeert daarna alle rijen opnieuw — er wordt niets samengevoegd
 5. Schrijft een auditregel naar `avg.ImportLog` (datum, aantal rijen, Windows-gebruikersnaam, duur)
 
 **Controleren na import:**
@@ -200,8 +204,8 @@ Wijzigingen in `exports/` gaan **altijd rechtstreeks naar `main`** — nooit via
 `avg.Teambegeleiding` hanteert een bewaartermijn van **1 jaar** vanaf de laatste import (`mta_imported`).
 
 **Hoe het werkt:**
-- Het importscript doet een TRUNCATE + volledige herinsert. Bij elke import krijgen alle actieve begeleiders een verse `mta_imported`.
-- Personen die niet meer actief zijn, verdwijnen automatisch bij de volgende import via de TRUNCATE.
+- Een import verwijdert eerst alle rijen van de club en doet daarna een volledige herinsert. Bij elke import krijgen alle actieve begeleiders een verse `mta_imported`.
+- Personen die niet meer actief zijn, verdwijnen automatisch bij de volgende import doordat de oude rijen eerst verwijderd worden.
 - De `CleanupTeambegeleiding` Azure Function (maandelijks, 1e van de maand 04:00 UTC) verwijdert als vangnet alle rijen ouder dan 1 jaar — dit beschermt tegen het scenario waarbij het importscript een langere tijd niet draait.
 
 **Aanbeveling:** voer het importscript minimaal **1× per seizoen** uit (seizoensstart ≈ augustus). Dit garandeert dat de data actueel is én dat de bewaartermijn correct verloopt.

--- a/exports/import-teambegeleiding-to-sql.ps1
+++ b/exports/import-teambegeleiding-to-sql.ps1
@@ -1,6 +1,7 @@
 # import-teambegeleiding-to-sql.ps1
 # Importeert de lokale teambegeleiding CSV naar avg.Teambegeleiding in SQL Server.
-# Strategie: TRUNCATE TABLE + volledige bulk-insert — altijd de laatste CSV als bron.
+# Strategie: alle rijen van de club verwijderen (DELETE WHERE ClubCode) + volledige bulk-insert —
+# altijd de laatste CSV als bron. Geen TRUNCATE: dat zou de rijen van andere clubs ook wissen.
 #
 # Flexibel: het script detecteert automatisch de aanwezige CSV-kolommen via een alias-map.
 # Ontbrekende vereiste kolommen worden gemeld; extra kolommen worden genegeerd.
@@ -213,7 +214,7 @@ foreach ($row in $csvRows) {
 
 Write-Host "  $($table.Rows.Count) rijen verwerkt." -ForegroundColor Green
 
-# ── Stap 4: TRUNCATE + SqlBulkCopy ────────────────────────────────────────────
+# ── Stap 4: rijen van deze club verwijderen + SqlBulkCopy ─────────────────────
 Write-Host "`n[4/5] Importeren naar SQL Server..." -ForegroundColor Yellow
 
 $conn = New-Object System.Data.SqlClient.SqlConnection($connectionStr)


### PR DESCRIPTION
Lost #667, #668 en #669 op. Alle drie raken hetzelfde scherm (Teambegeleiding) en de navigatie, daarom
één PR.

## #667 — Exportinstructie duidelijker

De toelichting op het importblok was één regel ("Download de CSV via club.sportlink.com → Leden →
Exporteer tabel") en sloeg de bepalende filterkeuzes over. Nu staan de negen stappen op het scherm zelf,
inclusief het selecteren van alle bondsteams — zonder die stap komen ook lokale teams in de export.

Hetzelfde pad is doorgevoerd in `docs/ADMIN-TEAMBEGELEIDING-IMPORT.md` en `exports/README.md`; die
beschreven nog het oude navigatiepad ("Leden → Ledenlijst") en misten de Bondsteam-stap volledig.

## #668 — Waarschuwing dat een import volledig vervangt

Een import verwijdert eerst alle rijen van de club en leest daarna de nieuwe lijst in
(`AdminTeambegeleidingFunction.cs:252-257`). Dat gedrag is correct en gewenst, maar stond nergens op het
scherm. Er staat nu een waarschuwing bij de bestandskiezer.

## #669 — Teambegeleiding vooraan

Teambegeleiding staat nu direct onder Dashboard in het menu en als eerste dashboard-tegel. De overige
items behouden hun onderlinge volgorde. Reden: het is het meest gebruikte scherm, omdat
contactgegevens hier sneller te vinden zijn dan in Sportlink Club zelf.

## Meegenomen documentatiecorrecties

Twee onjuistheden die tijdens het werk boven kwamen:

- `CLAUDE.md` en `AGENTS.md` verwezen naar `exports/HANDLEIDING-teambegeleiding-export.md` — een bestand
  dat niet in de repo bestaat. Vervangen door de wél bestaande `docs/ADMIN-TEAMBEGELEIDING-IMPORT.md`.
- Vijf plekken beschreven de import als een `TRUNCATE`, terwijl de code een club-scoped `DELETE`
  uitvoert. Bij meerdere clubs in één database suggereerde die tekst dat álle clubs gewist worden.

## Verificatie

- `dotnet build` FunctionApp (net9.0) en BlazorAdmin (net10.0): beide 0 warnings, 0 errors
- `Test-App.ps1`: exit 0, 31 checks geslaagd — zowel zonder als met live services
- Health endpoint: 200, versie `2.17.2.2`
- CSP-guard op de Release publish-output: geen inline script, geen import-map (#659)
- Browser-rendercheck op `/` en `/teambegeleiding`: `window.Blazor` aanwezig, 0 console-fouten, geen
  foutbanner. Menu- en tegelvolgorde in de DOM bevestigd als
  `Dashboard → Teambegeleiding → Dagplanning → Leermomenten → Email-tester`, en de negen exportstappen
  plus de waarschuwing renderen correct.

Versie 2.17.2.1 → 2.17.2.2 (REVISION: UX met zichtbaar effect), synchroon in beide csproj's.

Geen Azure-resources geraakt, geen kostenimpact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
