### PR TITLE
fix(#738): drie stille SQL-fouten in de productiemigratie dichten

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -14,9 +14,9 @@
          Wie dit terugzet naar true moet óók de CSP oplossen — en nonce/SRI kan niet op statische
          hosting. Zie index.html voor de volledige afweging. -->
     <OverrideHtmlAssetPlaceholders>false</OverrideHtmlAssetPlaceholders>
-    <Version>2.18.0.0</Version>
-    <AssemblyVersion>2.18.0.0</AssemblyVersion>
-    <FileVersion>2.18.0.0</FileVersion>
+    <Version>2.18.0.1</Version>
+    <AssemblyVersion>2.18.0.1</AssemblyVersion>
+    <FileVersion>2.18.0.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,18 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+## [2.18.0.1] — 2026-07-28
+
+### Fixed
+- **Drie stille fouten in de databasemigratie naar productie zijn opgelost.** Bij het uitrollen van een nieuwe versie draait een migratiescript tegen de productiedatabase. Dat script meldde "geslaagd", terwijl er in werkelijkheid tien fouten in het uitvoerlog stonden — bij twee opeenvolgende releases, zonder dat iemand het kon zien. (#738)
+  - De tabel met de KNVB-speeldagenkalender bestond helemaal niet in productie: hij stond alleen in de schemadefinitie, en die wordt bij een uitrol niet meegenomen. Alle acht vullingen van die tabel faalden dus. Daardoor kon de KNVB-kalenderbijlage bij een verzet-verzoek zonder datum in productie niet werken. De tabel wordt nu aangemaakt vóór hij gevuld wordt; het gaat om 423 speeldagen over zes regio's en twee seizoenen.
+  - De aanvulling van ontbrekende leeftijdscategorieën (`JO6` en alle `MO`-categorieën) faalde omdat de clubcode niet werd meegegeven. Die categorieën ontbraken daardoor in productie, en elke opzoeking van wedstrijdduur of standaard voorkeurstijd voor zo'n categorie vond niets.
+  - De primaire sleutel op de speeltijden bestond in productie nog uit één kolom in plaats van twee. Daardoor kon de democlub geen eigen speeltijden krijgen — het kopiëren botste op de gegevens van de echte club — en konden twee clubs niet dezelfde leeftijdscategorie hebben. Dat laatste is een schending van de multi-club-opzet.
+
+  Alle drie zijn geverifieerd door de productiesituatie lokaal na te bootsen (tabel verwijderd, categorieën verwijderd, sleutel teruggezet) en het script daarna twee keer te draaien: geen enkele fout, en herhalen is veilig.
+
+  De onderliggende oorzaak dat zulke fouten onzichtbaar bleven, is apart vastgelegd (#739), net als een vierde bevinding die alleen een nieuwe clubinstallatie raakt (#740).
+
 ## [2.18.0.0] — 2026-07-28
 
 ### Added

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -178,6 +178,38 @@ BEGIN
 END
 GO
 
+-- #738: dbo.KnvbKalenderDag AANMAKEN vóór de seeds.
+-- De tabel stond alleen in het DB-project, en de deploy publiceert geen dacpac — alleen dit
+-- script draait tegen de productiedatabase. Alle acht seed-blokken hieronder faalden daardoor
+-- met "Invalid object name 'dbo.KnvbKalenderDag'", bij twee opeenvolgende releases, zonder dat
+-- de deploy rood werd (zie #739 voor die maskering). De schema-drift check uit #595 zag het niet:
+-- die accepteert elke vermelding van de tabelnaam als dekking, ook een INSERT (zie #734).
+IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE object_id = OBJECT_ID('dbo.KnvbKalenderDag'))
+BEGIN
+    CREATE TABLE [dbo].[KnvbKalenderDag] (
+        [Seizoen]          VARCHAR(9)    NOT NULL,
+        [Regio]            VARCHAR(20)   NOT NULL,
+        [Datum]            DATE          NOT NULL,
+        [DagType]          VARCHAR(20)   NOT NULL,
+        [HeeftSenioren]    BIT           NOT NULL,
+        [HeeftJeugd]       BIT           NOT NULL,
+        [HeeftMeiden]      BIT           NOT NULL,
+        [PupillenToernooi] BIT           NOT NULL CONSTRAINT [DF_KnvbKalenderDag_Pup] DEFAULT 0,
+        [Schoolvakantie]   VARCHAR(10)   NULL,
+        [Feestdag]         NVARCHAR(50)  NULL,
+        [Opmerking]        NVARCHAR(200) NULL,
+        [Bron]             NVARCHAR(200) NULL,
+        CONSTRAINT [PK_KnvbKalenderDag] PRIMARY KEY CLUSTERED ([Seizoen] ASC, [Regio] ASC, [Datum] ASC),
+        CONSTRAINT [CK_KnvbKalenderDag_DagType] CHECK ([DagType] IN ('Competitie','Beker','Inhaal','Vrij','NC','Toernooi','Feestdag'))
+    );
+END
+GO
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE object_id = OBJECT_ID('dbo.KnvbKalenderDag') AND name = 'IX_KnvbKalenderDag_Datum')
+    CREATE NONCLUSTERED INDEX [IX_KnvbKalenderDag_Datum]
+        ON [dbo].[KnvbKalenderDag] ([Datum] ASC)
+        INCLUDE ([Regio], [DagType]);
+GO
+
 -- KnvbKalenderDag: KNVB speeldagenkalender seizoen 2025/2026 (West + Landelijk)
 -- Bron: https://www.knvb.nl/assist-wedstrijdsecretarissen/veldvoetbal/seizoensplanning/speeldagenkalenders
 -- Geseed per regio+seizoen; her-runs zijn idempotent dankzij IF NOT EXISTS.
@@ -850,6 +882,36 @@ GO
 IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_Speeltijden_ClubCode')
     ALTER TABLE [dbo].[Speeltijden] DROP CONSTRAINT [DF_Speeltijden_ClubCode];
 GO
+
+-- #738: PK_Speeltijden moet ([Leeftijd], [ClubCode]) zijn, niet ([Leeftijd]) alleen.
+-- Het toevoegen van de ClubCode-kolom hierboven verandert een bestaande primaire sleutel niet, dus
+-- op gemigreerde databases staat de PK nog op één kolom. Gevolg: twee clubs kunnen niet dezelfde
+-- leeftijdscategorie hebben, en het kopiëren van de speeltijden naar de democlub botst op
+-- "Violation of PRIMARY KEY ... duplicate key (1-99)". Dat is een schending van de
+-- multi-club-invariant, geen cosmetisch verschil.
+--
+-- Idempotent: alleen herbouwen als de sleutel nu uit precies één kolom bestaat. Draait ná de
+-- ClubCode-toevoeging, want anders bestaat de kolom nog niet om in de sleutel op te nemen.
+IF EXISTS (SELECT 1 FROM sys.columns WHERE object_id = OBJECT_ID('dbo.Speeltijden') AND name = 'ClubCode')
+   AND EXISTS (
+        SELECT 1
+        FROM sys.key_constraints kc
+        WHERE kc.parent_object_id = OBJECT_ID('dbo.Speeltijden')
+          AND kc.type = 'PK'
+          AND (SELECT COUNT(*) FROM sys.index_columns ic
+               WHERE ic.object_id = kc.parent_object_id AND ic.index_id = kc.unique_index_id) = 1)
+BEGIN
+    DECLARE @pkNaam SYSNAME = (
+        SELECT kc.name FROM sys.key_constraints kc
+        WHERE kc.parent_object_id = OBJECT_ID('dbo.Speeltijden') AND kc.type = 'PK');
+
+    -- Ontdubbelen kan hier niet nodig zijn: met een PK op alleen [Leeftijd] is elke leeftijd
+    -- per definitie al uniek, dus de nieuwe sleutel kan niet botsen.
+    EXEC('ALTER TABLE [dbo].[Speeltijden] DROP CONSTRAINT [' + @pkNaam + ']');
+    ALTER TABLE [dbo].[Speeltijden]
+        ADD CONSTRAINT [PK_Speeltijden] PRIMARY KEY CLUSTERED ([Leeftijd] ASC, [ClubCode] ASC);
+END
+GO
 IF EXISTS (SELECT 1 FROM sys.default_constraints WHERE name = 'DF_TeamRegels_ClubCode')
     ALTER TABLE [dbo].[TeamRegels] DROP CONSTRAINT [DF_TeamRegels_ClubCode];
 GO
@@ -1061,25 +1123,42 @@ SET [WedstrijdTotaal] = 115, [WedstrijdHelft] = 45, [WedstrijdRust] = 15
 WHERE [Leeftijd] IN ('1-99', 'VR') AND [WedstrijdTotaal] < 115;
 GO
 
--- Ontbrekende categorieën aanvullen
+-- Ontbrekende categorieën aanvullen.
+--
+-- #738: geeft nu [ClubCode] expliciet mee. De kolom is NOT NULL en de default-constraint wordt
+-- eerder in dit script bewust gedropt (#435/#598), dus zonder ClubCode faalde deze MERGE in
+-- productie met "Cannot insert the value NULL into column 'ClubCode'". Gevolg: JO6 en alle
+-- MO-categorieën ontbraken daar, waardoor elke opzoeking van wedstrijdduur of standaard
+-- voorkeurstijd voor die categorieën niets vond.
+--
+-- Gescoped op de clubs die al speeltijden hebben, niet op alle clubs in dbo.AppSettings: de
+-- democlub krijgt zijn volledige set verderop in dit script als kopie van de primaire club, en
+-- die kopie wordt overgeslagen zodra er al één rij voor die club bestaat. Zou deze MERGE de
+-- democlub alvast een paar categorieën geven, dan bleef de rest van die set daar ontbreken.
 MERGE [dbo].[Speeltijden] AS target
-USING (VALUES
-    ('JO6',  0.25, 40,  15, 10),
-    ('MO7',  0.25, 50,  20, 10),
-    ('MO8',  0.25, 50,  20, 10),
-    ('MO9',  0.25, 50,  20, 10),
-    ('MO10', 0.25, 65,  25, 15),
-    ('MO11', 0.50, 75,  30, 15),
-    ('MO12', 0.50, 75,  30, 15),
-    ('MO14', 1.00, 85,  35, 15),
-    ('MO16', 1.00, 95,  40, 15),
-    ('MO18', 1.00, 105, 45, 15),
-    ('MO23', 1.00, 105, 45, 15)
-) AS src ([Leeftijd], [Veldafmeting], [WedstrijdTotaal], [WedstrijdHelft], [WedstrijdRust])
-ON target.[Leeftijd] = src.[Leeftijd]
+USING (
+    SELECT v.[Leeftijd], v.[Veldafmeting], v.[WedstrijdTotaal], v.[WedstrijdHelft], v.[WedstrijdRust],
+           c.[ClubCode]
+    FROM (VALUES
+        ('JO6',  0.25, 40,  15, 10),
+        ('MO7',  0.25, 50,  20, 10),
+        ('MO8',  0.25, 50,  20, 10),
+        ('MO9',  0.25, 50,  20, 10),
+        ('MO10', 0.25, 65,  25, 15),
+        ('MO11', 0.50, 75,  30, 15),
+        ('MO12', 0.50, 75,  30, 15),
+        ('MO14', 1.00, 85,  35, 15),
+        ('MO16', 1.00, 95,  40, 15),
+        ('MO18', 1.00, 105, 45, 15),
+        ('MO23', 1.00, 105, 45, 15)
+    ) AS v([Leeftijd], [Veldafmeting], [WedstrijdTotaal], [WedstrijdHelft], [WedstrijdRust])
+    CROSS JOIN (SELECT DISTINCT [ClubCode] FROM [dbo].[Speeltijden]) AS c
+) AS src ([Leeftijd], [Veldafmeting], [WedstrijdTotaal], [WedstrijdHelft], [WedstrijdRust], [ClubCode])
+ON  target.[Leeftijd] = src.[Leeftijd]
+AND target.[ClubCode] = src.[ClubCode]
 WHEN NOT MATCHED THEN
-    INSERT ([Leeftijd], [Veldafmeting], [WedstrijdTotaal], [WedstrijdHelft], [WedstrijdRust])
-    VALUES (src.[Leeftijd], src.[Veldafmeting], src.[WedstrijdTotaal], src.[WedstrijdHelft], src.[WedstrijdRust]);
+    INSERT ([Leeftijd], [Veldafmeting], [WedstrijdTotaal], [WedstrijdHelft], [WedstrijdRust], [ClubCode])
+    VALUES (src.[Leeftijd], src.[Veldafmeting], src.[WedstrijdTotaal], src.[WedstrijdHelft], src.[WedstrijdRust], src.[ClubCode]);
 GO
 
 -- ============================================================

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.18.0.0</Version>
-    <AssemblyVersion>2.18.0.0</AssemblyVersion>
-    <FileVersion>2.18.0.0</FileVersion>
+    <Version>2.18.0.1</Version>
+    <AssemblyVersion>2.18.0.1</AssemblyVersion>
+    <FileVersion>2.18.0.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->


### PR DESCRIPTION
Hotfix vanuit `main` — versie **2.18.0.1**.

Gevonden bij de verificatie van release v2.18.0.0: de deploy-stap `Database-migratie uitvoeren` meldde "Successfully executed SQL file on target database" met `conclusion: success`, terwijl het log **tien SQL-fouten van severity 16** bevatte. Een identieke set staat in het log van de vorige productie-deploy, dus dit liep al minstens twee releases mee. De maskering zelf is apart vastgelegd in #739.

## Wat er stuk was

| Fout | Oorzaak | Gevolg in productie |
|---|---|---|
| 8× `Msg 208: Invalid object name 'dbo.KnvbKalenderDag'` | Tabel stond alleen in het DB-project; de deploy publiceert geen dacpac en het script had geen aanmaak-guard | Tabel bestond niet; alle acht kalender-seeds faalden. De KNVB-kalenderbijlage uit #561 kon niet werken |
| 1× `Msg 515: Cannot insert NULL into 'ClubCode'` | De MERGE die `JO6` en de `MO`-categorieën aanvult gaf `ClubCode` niet mee; die kolom is `NOT NULL` en de default wordt eerder bewust gedropt (#435/#598) | Die categorieën ontbraken; opzoekingen van wedstrijdduur en standaard voorkeurstijd vonden niets |
| 1× `Msg 2627: Violation of PRIMARY KEY, duplicate key (1-99)` | `PK_Speeltijden` bestond nog uit alleen `[Leeftijd]`; een `ALTER TABLE` die `ClubCode` toevoegt verandert een bestaande PK niet | Democlub kreeg geen speeltijden; twee clubs konden niet dezelfde leeftijdscategorie hebben — schending van de multi-club-invariant |

## Wat deze PR doet

1. Idempotente aanmaak van `dbo.KnvbKalenderDag` + `IX_KnvbKalenderDag_Datum`, geplaatst vóór de seed-blokken.
2. De MERGE geeft `ClubCode` mee, gescoped op de clubs die al speeltijden hebben. **Bewust niet** alle clubs uit `dbo.AppSettings`: zou de democlub hier alvast een paar categorieën krijgen, dan slaat het blok verderop zijn volledige kopie over en bleef de rest daar ontbreken.
3. `PK_Speeltijden` idempotent gemigreerd naar `([Leeftijd], [ClubCode])`, uitsluitend wanneer de sleutel nu uit één kolom bestaat. Ontdubbelen is niet nodig: met een PK op alleen `[Leeftijd]` is elke leeftijd per definitie al uniek.

## Verificatie — productiesituatie nagebootst, script echt uitgevoerd

Niet geparseerd maar gedraaid, tegen een database met twee clubs (les uit #564):

1. Productiestand nagebootst: `dbo.KnvbKalenderDag` gedropt, de `JO6`/`MO`-rijen verwijderd, `PK_Speeltijden` teruggezet naar één kolom, rijen van de tweede club verwijderd. Bevestigd: tabel weg, PK op 1 kolom, 1 club met 22 rijen.
2. Gerepareerd script gedraaid: **exit 0, nul `Msg`-regels**.
3. Nog een keer gedraaid voor idempotentie: **exit 0, nul `Msg`-regels**.
4. Eindstand bevestigd: tabel bestaat met **423 rijen over 6 regio's en 2 seizoenen**, index aanwezig, **PK op 2 kolommen**, 11 ontbrekende categorieën aangevuld.

Daarnaast: `dotnet build` FunctionApp + BlazorAdmin exit 0 met 0 warnings, `dotnet test` 406 passed, `Test-App.ps1 -Fix` exit 0 (24 checks).

## Buiten scope, wel vastgelegd

- **#739** — de deploy moet falen op `Msg`-fouten van severity ≥ 11. Zolang dat niet gebeurt, bewijst een groene `db-migrate` niets. Dit is het belangrijkste vervolgpunt.
- **#734** — de schema-drift check kijkt naar tabellen maar niet naar kolommen, en accepteert een `INSERT` als aanmaak-dekking. Precies daarom zag de CI dit niet.
- **#740** — de seed van `dbo.Speeltijden` kiest de alfabetisch eerste club in plaats van de primaire club. Raakt de huidige productiedatabase niet, wél een verse clubinstallatie.

## Kostenbeleid

Uitsluitend SQL- en versiewijzigingen. Geen nieuwe Azure-resources, geen tier- of retentiewijziging. Geen kosteneffect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)