### PR TITLE
docs: kruisverwijzingen in de CHANGELOG uit haakjesnotatie halen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
   Alle drie zijn geverifieerd door de productiesituatie lokaal na te bootsen (tabel verwijderd, categorieën verwijderd, sleutel teruggezet) en het script daarna twee keer te draaien: geen enkele fout, en herhalen is veilig.
 
-  De onderliggende oorzaak dat zulke fouten onzichtbaar bleven, is apart vastgelegd (#739), net als een vierde bevinding die alleen een nieuwe clubinstallatie raakt (#740).
+  De onderliggende oorzaak dat zulke fouten onzichtbaar bleven, is apart vastgelegd in issue #739, net als een vierde bevinding die alleen een nieuwe clubinstallatie raakt: zie issue #740.
 
 ## [2.18.0.0] — 2026-07-28
 
@@ -61,7 +61,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 - **Teambegeleiding staat nu bovenaan** in het menu en als eerste tegel op het dashboard, direct onder Dashboard. Het is het meest gebruikte scherm: contactgegevens van begeleiders zijn hier sneller te vinden dan in Sportlink zelf. De overige schermen behouden hun onderlinge volgorde. (#669)
 
 ### Fixed
-- **De twee nieuwe instellingen voor de KNVB-kalenderbijlage zouden bij het live zetten ontbreken in de database** (#561). Ze waren alleen aan de schemadefinitie toegevoegd, en die definitie wordt bij een deploy niet uitgerold — alleen het migratiescript draait. Zonder deze correctie zou de Instellingen-pagina na deze release een foutmelding geven in plaats van te laden, terwijl er lokaal niets aan de hand leek. De bestaande controle hierop kijkt alleen naar nieuwe tabellen, niet naar nieuwe kolommen; dat gat is apart vastgelegd (#734). Het migratiescript is tegen een database met twee clubs uitgevoerd en twee keer achter elkaar gedraaid om te bevestigen dat herhalen veilig is.
+- **De twee nieuwe instellingen voor de KNVB-kalenderbijlage zouden bij het live zetten ontbreken in de database** (#561). Ze waren alleen aan de schemadefinitie toegevoegd, en die definitie wordt bij een deploy niet uitgerold — alleen het migratiescript draait. Zonder deze correctie zou de Instellingen-pagina na deze release een foutmelding geven in plaats van te laden, terwijl er lokaal niets aan de hand leek. De bestaande controle hierop kijkt alleen naar nieuwe tabellen, niet naar nieuwe kolommen; dat gat is apart vastgelegd in issue #734. Het migratiescript is tegen een database met twee clubs uitgevoerd en twee keer achter elkaar gedraaid om te bevestigen dat herhalen veilig is.
 - **De teamherkenning werkt nu uitsluitend via de nieuwe teamlijst** (#700). De oude tekstregels die een teamnaam probeerden te repareren, en de aanname dat een team "van ons" is zodra er geen spatie in de naam staat, zijn verwijderd. Die aanname kon een tegenstander als eigen team aanmerken, met thuis en uit omgedraaid. Welk van de twee genoemde teams het eigen team is, wordt nu bepaald door te kijken wélke in de teamlijst staat.
 
   Er is ook geen schakelaar meer om de herkenning uit te zetten: als dat het enige pad is, is zo'n schakelaar geen veiligheidsventiel maar een valkuil. In plaats daarvan geldt: is de teamlijst leeg — bijvoorbeeld direct na een update, vóór de eerste nachtelijke synchronisatie — dan wordt hij eenmalig alsnog opgebouwd, en lukt dat niet, dan wordt er niet verwerkt in plaats van berichten koppelen zonder herkenning.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -919,6 +919,16 @@ Zet alle drie velden synchroon in **beide** csproj's:
 2. Gebruik de secties `### Added`, `### Changed`, `### Fixed`, `### Security`, `### Removed`
 3. Schrijf voor de gebruiker, niet voor de developer: "Beheerders kunnen nu X" i.p.v. "Methode Y refactored"
 
+> **Let op de notatie van issuenummers — `(#N)` sluit het issue bij de volgende release.**
+> `close-released-issues.yml` leest de CHANGELOG-sectie van de getagde versie en behandelt elke
+> haakjesgroep die **uitsluitend** issuenummers bevat — `(#574)` of `(#599, #595)` — als attributie
+> van opgeleverd werk. Die issues worden gesloten.
+>
+> Gebruik `(#N)` dus alleen voor werk dat in díe versie zit. Voor een **kruisverwijzing** naar een
+> vervolgpunt schrijf je het nummer in proza: `zie issue #739` — nooit `(#739)`. Dit ging mis bij
+> v2.18.0.1: drie vervolgissues die juist bij die release waren aangemaakt (#734, #739, #740)
+> werden er door gesloten en moesten met de hand worden heropend.
+
 **Verplicht vóór een release:**
 1. Verplaats alles van `## [Unreleased]` naar `## [x.y.z] — YYYY-MM-DD`
 2. Voeg een lege `## [Unreleased]` terug bovenaan


### PR DESCRIPTION
Documentatie-only correctie op `main`, zonder versiebump (geen zichtbaar effect op de applicatie).

## Wat er misging

`close-released-issues.yml` leest de CHANGELOG-sectie van de getagde versie en behandelt elke haakjesgroep die **uitsluitend** issuenummers bevat — `(#574)`, `(#599, #595)` — als attributie van opgeleverd werk. Dat is bewust zo (#630), zodat kruisverwijzingen in proza géén issues sluiten.

In de sectie van v2.18.0.1 schreef ik drie **vervolgpunten** in precies die notatie: `(#734)`, `(#739)`, `(#740)`. Het zijn issues die bij deze release zijn **aangemaakt**, niet opgelost. Bij het pushen van de tag zijn ze daardoor gesloten. Ze zijn met de hand heropend, met uitleg in het issue zelf.

## Wat deze PR doet

1. De drie verwijzingen omgezet naar proza: `zie issue #739` in plaats van `(#739)`. Daarmee kan een volgende release-tag ze niet opnieuw sluiten.
2. De valkuil vastgelegd in `CLAUDE.md`, bij de CHANGELOG-instructies. De regel bestond al als invariant voor de workflows, maar niet als schrijfinstructie voor wie de CHANGELOG bijwerkt — en dat is precies waar het misgaat.

Geen wijziging aan de inhoudelijke beschrijving van de release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)