### PR TITLE
feat(#670): coordinatorNaam in de afsluitzin van het multi-datum antwoord

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -14,9 +14,9 @@
          Wie dit terugzet naar true moet óók de CSP oplossen — en nonce/SRI kan niet op statische
          hosting. Zie index.html voor de volledige afweging. -->
     <OverrideHtmlAssetPlaceholders>false</OverrideHtmlAssetPlaceholders>
-    <Version>2.18.0.2</Version>
-    <AssemblyVersion>2.18.0.2</AssemblyVersion>
-    <FileVersion>2.18.0.2</FileVersion>
+    <Version>2.18.1.0</Version>
+    <AssemblyVersion>2.18.1.0</AssemblyVersion>
+    <FileVersion>2.18.1.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Added
+- **Bij een vraag over meerdere datums noemt het antwoord nu de coördinator bij naam:** "Laat weten welke optie(s) de voorkeur hebben, dan gaan we samen met [naam] plannen en definitief opnemen in de planning." Staat er geen coördinatornaam in de instellingen, dan blijft de zin gewoon compleet zonder naam. De naam komt uit de instellingen van de club waarvoor het antwoord wordt opgebouwd, dus in een test met de demoklub verschijnt de demo-coördinator. (#670)
+
 ### Fixed
 - **Een mislukte databasemigratie laat de uitrol nu falen in plaats van "geslaagd" te melden.** Bij het uitrollen van een nieuwe versie draait een migratiescript tegen de database. Dat script meldde succes zolang het tot het einde kwam, ook als er onderweg fouten optraden — precies wat er twee releases achter elkaar gebeurde. De uitrol stopt nu bij de eerste echte fout. Zie issue #739.
 - **Een club die de software voor het eerst in gebruik neemt, krijgt nu een compleet werkende database.** Zeven tabellen — waaronder de tabel met alle instellingen — werden door het migratiescript wel gevuld en aangepast, maar nooit aangemaakt. Op de bestaande omgeving valt dat niet op, omdat die tabellen er al jaren staan; bij een nieuwe installatie ontbraken ze. Datzelfde gold voor een aantal schema's en voor vier overzichten die op de Sportlink-gegevens leunen. Het script controleert nu overal eerst of iets bestaat, en slaat wat nog niet kan netjes over tot de eerste synchronisatie is gelopen. Zie issue #734.

--- a/FunctionApp.Tests/Email/MultiDatumAfsluitzinTests.cs
+++ b/FunctionApp.Tests/Email/MultiDatumAfsluitzinTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using SportlinkFunction.Email;
+using SportlinkFunction.Planner;
+using Xunit;
+
+namespace FunctionApp.Tests.Email;
+
+/// <summary>
+/// Tests voor issue #670: de afsluitzin van een multi-datum beschikbaarheidsantwoord noemt de
+/// coördinator bij naam.
+///
+/// <para>
+/// De naam wordt via dezelfde weg gelezen als de handtekening: uit de meegegeven club-snapshot
+/// wanneer die er is, en anders uit de proces-globale cache. Dat is de regel uit #677 — een dry-run
+/// voor de democlub mag niet terugvallen op de gegevens van de productieclub. Zonder live database is
+/// die globale cache in dit testproces nooit geladen, wat hem bruikbaar maakt als kanarie: valt de
+/// code ooit alsnog terug, dan gooit dat een <see cref="InvalidOperationException"/> in plaats van
+/// stilzwijgend de verkeerde club te tonen.
+/// </para>
+/// </summary>
+public class MultiDatumAfsluitzinTests
+{
+    private static InkomendBericht MaakEmail() => new()
+    {
+        MessageId = "multi-datum-test",
+        ConversationId = "",
+        Afzender = "trainer@voorbeeld.nl",
+        AfzenderNaam = "Jan de Vries",
+        Onderwerp = "Beschikbaarheid",
+        OntvangstDatum = new DateTime(2026, 9, 1, 10, 0, 0, DateTimeKind.Utc),
+        Body = "Kan het 12 of 19 september?"
+    };
+
+    private static BerichtClassificatie MaakClassificatie() => new()
+    {
+        Type = VerzoekType.BeschikbaarheidCheck,
+        Datums = new List<string> { "2026-09-12", "2026-09-19" },
+        LeeftijdsCategorie = "JO13",
+        Samenvatting = "Beschikbaarheid voor twee zaterdagen"
+    };
+
+    private static List<(string datum, CheckAvailabilityResponse response)> MaakResultaten() => new()
+    {
+        ("2026-09-12", new CheckAvailabilityResponse { Beschikbaar = true }),
+        ("2026-09-19", new CheckAvailabilityResponse { Beschikbaar = false, Reden = "Geen ruimte" })
+    };
+
+    [Fact]
+    public void MetCoordinatorInSnapshot_NoemtDeCoordinatorInDeAfsluitzin()
+    {
+        var snapshot = new ClubAppSettingsSnapshot(
+            PlannerAfzenderNaam: "AllStars FC Testomgeving",
+            CoordinatorNaam: "Frenkie",
+            CoordinatorFunctie: "Coördinator",
+            EmailVoetnoot: null,
+            HerplanDeadlineDagen: 3);
+
+        var (_, body) = BerichtResponseGenerator.BouwMultiDatumBeschikbaarheidAntwoord(
+            MaakResultaten(), MaakClassificatie(), MaakEmail(), snapshot);
+
+        body.Should().Contain("samen met Frenkie plannen",
+            "de afsluitzin van een multi-datum antwoord noemt de coördinator bij naam (#670)");
+    }
+
+    /// <summary>
+    /// Ontbreekt de naam, dan moet de zin nog steeds een volledige, clubneutrale zin zijn — geen
+    /// halve zin en geen fallbacknaam in de code (architectuurregel "geen club-specifieke strings").
+    /// </summary>
+    [Fact]
+    public void ZonderCoordinatorInSnapshot_BlijftDeZinCompleetEnClubneutraal()
+    {
+        var snapshot = new ClubAppSettingsSnapshot(
+            PlannerAfzenderNaam: "AllStars FC Testomgeving",
+            CoordinatorNaam: null,
+            CoordinatorFunctie: null,
+            EmailVoetnoot: null,
+            HerplanDeadlineDagen: 3);
+
+        var (_, body) = BerichtResponseGenerator.BouwMultiDatumBeschikbaarheidAntwoord(
+            MaakResultaten(), MaakClassificatie(), MaakEmail(), snapshot);
+
+        body.Should().Contain("dan gaan we samen plannen en definitief opnemen in de planning.");
+        body.Should().NotContain("samen met  plannen", "een ontbrekende naam mag geen dubbele spatie opleveren");
+    }
+
+    /// <summary>
+    /// De coördinator uit de snapshot mag niet worden overschreven door de globale cache. Die cache is
+    /// in dit testproces leeg, dus een terugval zou hier direct opvallen.
+    /// </summary>
+    [Fact]
+    public void MetSnapshot_ValtNietTerugOpDeGlobaleCache()
+    {
+        var snapshot = new ClubAppSettingsSnapshot(
+            PlannerAfzenderNaam: "AllStars FC Testomgeving",
+            CoordinatorNaam: "Frenkie",
+            CoordinatorFunctie: "Coördinator",
+            EmailVoetnoot: null,
+            HerplanDeadlineDagen: 3);
+
+        var act = () => BerichtResponseGenerator.BouwMultiDatumBeschikbaarheidAntwoord(
+            MaakResultaten(), MaakClassificatie(), MaakEmail(), snapshot);
+
+        act.Should().NotThrow<InvalidOperationException>(
+            "met een expliciete club-snapshot mag de globale AppSettings-cache niet worden geraadpleegd (#677)");
+    }
+}

--- a/FunctionApp/Email/BerichtResponseGenerator.cs
+++ b/FunctionApp/Email/BerichtResponseGenerator.cs
@@ -126,9 +126,34 @@ public static class BerichtResponseGenerator
             inhoud += BouwDatumSectie(datum, response, classificatie) + "\n";
         }
 
-        inhoud += "Laat weten welke optie(s) de voorkeur hebben, dan plannen we het in.";
+        inhoud += BouwMultiDatumAfsluitzin(clubSettings);
 
         return WrapMetReviewEnHandtekening(inhoud, classificatie, email, clubSettings);
+    }
+
+    /// <summary>
+    /// Afsluitzin van een multi-datum beschikbaarheidsantwoord, met de coördinator bij naam (#670).
+    ///
+    /// <para>
+    /// Leest de instelling via dezelfde weg als <see cref="GetHandtekening"/>: uit de meegegeven
+    /// club-snapshot wanneer die er is, en anders uit de globale cache. Dat is de regel uit #677 —
+    /// een dry-run voor de democlub mag niet terugvallen op de gegevens van de productieclub.
+    /// </para>
+    ///
+    /// <para>
+    /// Ontbreekt de naam, dan blijft de zin clubneutraal en compleet: geen halve zin, en bewust geen
+    /// fallbacknaam in de code (architectuurregel "geen club-specifieke strings").
+    /// </para>
+    /// </summary>
+    private static string BouwMultiDatumAfsluitzin(ClubAppSettingsSnapshot? clubSettings)
+    {
+        var coordinatorNaam = clubSettings != null
+            ? clubSettings.CoordinatorNaam
+            : SystemUtilities.AppSettings.GetSetting("coordinatorNaam");
+
+        return string.IsNullOrWhiteSpace(coordinatorNaam)
+            ? "Laat weten welke optie(s) de voorkeur hebben, dan gaan we samen plannen en definitief opnemen in de planning."
+            : $"Laat weten welke optie(s) de voorkeur hebben, dan gaan we samen met {coordinatorNaam} plannen en definitief opnemen in de planning.";
     }
 
     /// <summary>

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.18.0.2</Version>
-    <AssemblyVersion>2.18.0.2</AssemblyVersion>
-    <FileVersion>2.18.0.2</FileVersion>
+    <Version>2.18.1.0</Version>
+    <AssemblyVersion>2.18.1.0</AssemblyVersion>
+    <FileVersion>2.18.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/docs/EMAIL-VERWERKING.md
+++ b/docs/EMAIL-VERWERKING.md
@@ -423,8 +423,14 @@ Per datum wordt dezelfde logica als Template A–F toegepast, in een eigen secti
 **{datum 2}:** Om {tijd} is helaas geen ruimte. Beschikbare mogelijkheden:
 - {veld}: beschikbaar van {van} tot {tot}
 
-Laat weten welke optie(s) de voorkeur hebben, dan plannen we het in.
+Laat weten welke optie(s) de voorkeur hebben, dan gaan we samen met {coordinatorNaam} plannen en definitief opnemen in de planning.
 ```
+
+De afsluitzin noemt de coördinator bij naam (#670). Ontbreekt `coordinatorNaam` in `dbo.AppSettings`,
+dan valt de zin terug op *"…dan gaan we samen plannen en definitief opnemen in de planning."* — een
+volledige, clubneutrale zin, zonder fallbacknaam in de code. De naam komt uit de instellingen van de
+club waarvoor het antwoord wordt opgebouwd, niet uit de globale cache; in een dry-run voor de
+democlub staat er dus de democoördinator (#677).
 
 #### Template H — Wedstrijd al ingepland
 


### PR DESCRIPTION
De afsluitzin van een multi-datum beschikbaarheidsantwoord was onpersoonlijk — *"Laat weten welke optie(s) de voorkeur hebben, dan plannen we het in."* — en noemde de coördinator niet, terwijl die naam al als instelling bestaat en al in de handtekening staat.

**Nieuw:** *"Laat weten welke optie(s) de voorkeur hebben, dan gaan we samen met {coordinatorNaam} plannen en definitief opnemen in de planning."*

## Twee dingen die het issue expliciet noemde

**Club-scoping.** De naam wordt via dezelfde weg gelezen als `GetHandtekening()`: uit de meegegeven `ClubAppSettingsSnapshot` als die er is, en anders uit de globale cache. Dat is de regel uit #677 — een dry-run voor de democlub mag niet terugvallen op de gegevens van de productieclub. Het issue stelde nog `SystemUtilities.AppSettings.GetSetting(...)` voor; dat was vóór #677 geschreven en zou de scoping opnieuw omzeilen.

**Geen club-specifieke fallback.** Ontbreekt de naam, dan is de zin *"…dan gaan we samen plannen en definitief opnemen in de planning."* — een volledige, clubneutrale zin. Geen halve zin, geen fallbacknaam in de code.

## De enkele-datum-variant: bewust ongemoeid

Het issue vroeg om na te gaan of de kortere zin bij één datum (*"Laat weten welke optie de voorkeur heeft."*) dezelfde behandeling moet krijgen. Ik heb dat **niet** gedaan, om één reden: de coördinatornaam staat al in de ondertekening van élk antwoord (*"Geautomatiseerd antwoord namens {naam}"*). Bij een multi-datum antwoord staat er veel tussen de vraag en de ondertekening, dus daar voegt de naam in de slotzin echt iets toe. Bij een kort antwoord met één datum staan slotzin en ondertekening pal onder elkaar en noem je de naam twee keer in drie regels.

Wil je het toch overal, dan is het één regel — laat het weten.

## Verificatie

- Drie nieuwe tests in `FunctionApp.Tests/Email/MultiDatumAfsluitzinTests.cs`:
  1. met naam in de snapshot → de naam staat in de zin
  2. zonder naam → de zin is compleet en clubneutraal, en er ontstaat geen dubbele spatie
  3. kanarietest: met een snapshot mag de globale cache niet worden geraadpleegd. Die cache is in het testproces nooit geladen, dus een terugval zou een `InvalidOperationException` geven in plaats van stilzwijgend de verkeerde club te tonen
- `dotnet test`: 409 passed (was 406)
- `dotnet build` exit 0, 0 warnings
- `docs/EMAIL-VERWERKING.md` bijgewerkt: Template G toont de nieuwe zin plus het gedrag zonder naam

## Kostenbeleid

Alleen applicatiecode en documentatie. Geen Azure-resources, geen kosteneffect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)