### PR TITLE
feat(#689): Dagplanning als twee gespiegelde tabs + verdwaalde schuifbalk weg

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -14,9 +14,9 @@
          Wie dit terugzet naar true moet óók de CSP oplossen — en nonce/SRI kan niet op statische
          hosting. Zie index.html voor de volledige afweging. -->
     <OverrideHtmlAssetPlaceholders>false</OverrideHtmlAssetPlaceholders>
-    <Version>2.18.1.0</Version>
-    <AssemblyVersion>2.18.1.0</AssemblyVersion>
-    <FileVersion>2.18.1.0</FileVersion>
+    <Version>2.18.2.0</Version>
+    <AssemblyVersion>2.18.2.0</AssemblyVersion>
+    <FileVersion>2.18.2.0</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/Pages/Dagplanning.razor
+++ b/BlazorAdmin/Pages/Dagplanning.razor
@@ -68,11 +68,11 @@
                     @* Tijdas-header *@
                     <div style="display:flex; margin-bottom:4px;">
                         <div style="width:120px; flex-shrink:0;"></div>
-                        <div style="flex:1; position:relative; height:22px; min-width:500px;">
+                        <div style="flex:1; position:relative; height:22px; min-width:200px;">
                             @for (int _h = _vsMin; _h <= _veMin; _h += 60)
                             {
                                 string _lftH = GanttPct(_h - _vsMin, _vTotMin);
-                                <div style="position:absolute; left:@(_lftH)%; transform:translateX(-50%);
+                                <div style="position:absolute; left:@(_lftH)%; transform:@GanttLabelTransform(_h, _vsMin, _veMin);
                                             font-size:0.7rem; color:#6c757d; white-space:nowrap; user-select:none;">
                                     @TimeOnly.FromTimeSpan(TimeSpan.FromMinutes(_h)).ToString("HH:mm")
                                 </div>
@@ -89,7 +89,7 @@
                                         border-right:1px solid #dee2e6; display:flex; align-items:center;">
                                 @_veld
                             </div>
-                            <div style="flex:1; position:relative; height:72px; min-width:500px; background:#fff;">
+                            <div style="flex:1; position:relative; height:72px; min-width:200px; background:#fff;">
                                 @* Uurlijnen *@
                                 @for (int _h = _vsMin + 60; _h < _veMin; _h += 60)
                                 {
@@ -211,172 +211,36 @@
         </div>
     </div>
 
-    @* ── Per-wedstrijd vergelijking ── *@
-    <div class="card mb-3">
-        <div class="card-header d-flex align-items-center gap-2 flex-wrap">
-            <span class="fw-semibold me-2">Per wedstrijd: huidig vs. optimaal</span>
-            <div class="btn-group btn-group-sm">
-                <button class="btn @(_filter == "alles" ? "btn-primary" : "btn-outline-secondary")"
-                        @onclick='() => _filter = "alles"'>Alles (@_plan.TotaalWedstrijden)</button>
-                <button class="btn @(_filter == "wijzigingen" ? "btn-primary" : "btn-outline-secondary")"
-                        @onclick='() => _filter = "wijzigingen"'>Wijzigingen (@_plan.TeWijzigen)</button>
-                @if (_plan.NietInplanbaar > 0)
-                {
-                    <button class="btn @(_filter == "probleem" ? "btn-danger" : "btn-outline-danger")"
-                            @onclick='() => _filter = "probleem"'>Probleem (@_plan.NietInplanbaar)</button>
-                }
-            </div>
-            @if (IsAllstars && _plan.TeWijzigen > 0)
-            {
-                <button class="btn btn-sm btn-warning ms-auto" @onclick="ToepassenAsync" disabled="@_bezig">
-                    @(_bezig ? "Toepassen..." : $"Toepassen in testmodus ({_plan.TeWijzigen})")
-                </button>
-            }
-        </div>
-        <div class="card-body p-0">
-            <div class="table-responsive">
-                <table class="table table-sm table-hover mb-0">
-                    <thead class="table-light">
-                        <tr>
-                            <th>Wedstrijd</th>
-                            <th>Huidige situatie</th>
-                            <th>Optimale situatie</th>
-                            <th title="Gewenste tijd en de afwijking daarvan">Voorkeurstijd</th>
-                            <th title="Verplaatst de planner deze wedstrijd t.o.v. de huidige stand?">Wijziging</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach (var item in GefilterdeLijst())
-                        {
-                            <tr class="@RowClass(item.Status)">
-                                <td style="font-size:0.85rem;">
-                                    <div class="fw-semibold">@(string.IsNullOrWhiteSpace(item.Wedstrijd) ? item.TeamNaam : item.Wedstrijd)</div>
-                                </td>
-                                <td style="font-size:0.85rem;">
-                                    @if (!item.HeeftVeld && !item.HeeftTijd)
-                                    {
-                                        <span class="text-warning">&#10007; Geen veld &amp; tijd</span>
-                                    }
-                                    else if (!item.HeeftVeld)
-                                    {
-                                        <span class="text-warning">&#10007; Geen veld</span>
-                                        @if (!string.IsNullOrWhiteSpace(item.HuidigeTijd))
-                                        {<span class="text-muted ms-1">@item.HuidigeTijd</span>}
-                                    }
-                                    else if (!item.HeeftTijd)
-                                    {
-                                        <span class="text-warning">&#10007; Geen tijd</span>
-                                        @if (!string.IsNullOrWhiteSpace(item.HuidigeVeld))
-                                        {<span class="text-muted ms-1">@item.HuidigeVeld</span>}
-                                    }
-                                    else
-                                    {
-                                        <span>@item.HuidigeVeld</span>
-                                        <span class="ms-2 fw-bold">@item.HuidigeTijd</span>
-                                    }
-                                </td>
-                                <td style="font-size:0.85rem;">
-                                    @if (item.Status == "niet-inplanbaar")
-                                    {
-                                        <span class="text-danger" title="@item.NietInplanbaaarReden">
-                                            &#10007; @(item.NietInplanbaaarReden ?? "Niet inplanbaar")
-                                        </span>
-                                    }
-                                    else if (item.Status == "onbekend-team")
-                                    {
-                                        @* Onbekend team: toon huidige situatie ongewijzigd — geen foutmelding (#487) *@
-                                        @if (!string.IsNullOrWhiteSpace(item.OptimaalVeld))
-                                        {
-                                            <span class="text-muted">@item.OptimaalVeld</span>
-                                            @if (!string.IsNullOrWhiteSpace(item.OptimaalTijd))
-                                            {<span class="text-muted ms-2">@item.OptimaalTijd</span>}
-                                        }
-                                    }
-                                    else if (item.OptimaalVeld != null)
-                                    {
-                                        <span class="@(item.Status == "ongewijzigd" ? "" : "fw-bold")">@item.OptimaalVeld</span>
-                                        <span class="ms-2 @(item.Status == "ongewijzigd" ? "" : "fw-bold")">@item.OptimaalTijd</span>
-                                    }
-                                </td>
-                                @* Voorkeurstijd los van de wijzig-status (#666): een wedstrijd kan
-                                   ongewijzigd blijven én tóch ver van de voorkeurstijd liggen. *@
-                                <td style="font-size:0.85rem;">
-                                    @if (string.IsNullOrWhiteSpace(item.VoorkeurTijd))
-                                    {
-                                        <span class="text-muted" title="Geen voorkeurstijd voor dit team en geen standaardtijd voor de leeftijdscategorie">—</span>
-                                    }
-                                    else
-                                    {
-                                        <span class="badge @VoorkeurBadgeClass(item.VoorkeurStatus)"
-                                              title="@VoorkeurTitel(item)">
-                                            @item.VoorkeurTijd@VoorkeurAfwijkingTekst(item.VoorkeurAfwijkingMinuten)
-                                        </span>
-                                        <span class="text-muted ms-1" style="font-size:0.75rem;">@VoorkeurBronLabel(item.VoorkeurBron)</span>
-                                        @if (item.VoorkeurVeldToegepast == false)
-                                        {
-                                            <span class="badge bg-secondary ms-1"
-                                                  title="Voorkeursveld was niet beschikbaar; de planner koos een ander veld">
-                                                ander veld
-                                            </span>
-                                        }
-                                    }
-                                </td>
-                                <td>
-                                    @switch (item.Status)
-                                    {
-                                        case "ongewijzigd":
-                                            <span class="badge bg-light text-dark border" title="De planner laat deze wedstrijd staan">Ongewijzigd</span>
-                                            break;
-                                        case "nieuw-slot":
-                                            <span class="badge bg-warning text-dark">Nieuw</span>
-                                            break;
-                                        case "wijziging":
-                                            <span class="badge bg-primary">Wijzig</span>
-                                            break;
-                                        case "niet-inplanbaar":
-                                            <span class="badge bg-danger">Probleem</span>
-                                            break;
-                                        case "onbekend-team":
-                                            <span class="badge bg-secondary">Onbekend</span>
-                                            break;
-                                    }
-                                </td>
-                            </tr>
-                        }
-                    </tbody>
-                </table>
-            </div>
-        </div>
-        @if (!string.IsNullOrEmpty(_toepassenMelding))
-        {
-            <div class="card-footer">
-                <div class="alert @(_toepassenFout ? "alert-danger" : "alert-success") mb-0 py-2">
-                    @_toepassenMelding
-                    @if (!_toepassenFout)
-                    {
-                        <button class="btn btn-sm btn-outline-success ms-3" @onclick="AutoPlanAsync">Herlaad plan</button>
-                    }
-                </div>
-            </div>
-        }
-    </div>
+    @* ── Vergelijking: twee tabs met identieke opbouw (#689) ──
+       Eén kaart met de tabs op het hoogste niveau. Elke tab bevat op dezelfde plek eerst de
+       veldvisual en daaronder de wedstrijdenlijst van diezelfde stand. Wisselen werkt daardoor als
+       een flip book: de visuals staan op gelijke hoogte, dus het oog springt niet en het verschil in
+       veldbezetting valt direct op.
 
-    @* ── Visuele Gantt-planning ── *@
+       Dit verving twee tegenstrijdige vergelijkingspatronen op één pagina: een diff-tabel met
+       "huidig" en "optimaal" in kolommen naast elkaar, plus een aparte kaart waar tabs alléén de
+       visual wisselden en de tabel niet meeliep. *@
     <div class="card mb-3">
-        <div class="card-header d-flex align-items-center gap-3">
+        <div class="card-header d-flex align-items-center gap-3 flex-wrap">
             <ul class="nav nav-tabs card-header-tabs mb-0">
                 <li class="nav-item">
                     <button class="nav-link @(_visTab == "optimaal" ? "active" : "")"
-                            @onclick='() => _visTab = "optimaal"'>&#128197; Optimale planning</button>
+                            @onclick='() => _visTab = "optimaal"'>&#128197; Optimaal</button>
                 </li>
                 <li class="nav-item">
                     <button class="nav-link @(_visTab == "huidig" ? "active" : "")"
-                            @onclick='() => _visTab = "huidig"'>Huidige situatie</button>
+                            @onclick='() => _visTab = "huidig"'>Huidig</button>
                 </li>
             </ul>
             @if (_visTab == "optimaal" && !string.IsNullOrEmpty(_plan.GeschatteEindTijd))
             {
-                <span class="small text-muted ms-auto">Eindtijd: <strong>@_plan.GeschatteEindTijd</strong></span>
+                <span class="small text-muted">Eindtijd: <strong>@_plan.GeschatteEindTijd</strong></span>
+            }
+            @if (IsAllstars && _plan.TeWijzigen > 0 && _visTab == "optimaal")
+            {
+                <button class="btn btn-sm btn-warning ms-auto" @onclick="ToepassenAsync" disabled="@_bezig">
+                    @(_bezig ? "Toepassen..." : $"Toepassen in testmodus ({_plan.TeWijzigen})")
+                </button>
             }
         </div>
         <div class="card-body p-3">
@@ -415,38 +279,40 @@
                     <span><span class="gantt-legenda-balk" style="background:#ef4444;"></span> &gt;15 min afwijking</span>
                 </div>
 
-                @if (_isOptimaal)
-                {
-                    <p class="text-muted small mb-2">
-                        <i class="bi bi-arrows-move me-1" aria-hidden="true"></i>
-                        Sleep een wedstrijd naar een andere tijd of een ander veld. De tijd springt op stappen
-                        van 5 minuten; de tabel en de eindtijd lopen mee. Handmatig verplaatste wedstrijden
-                        krijgen een stippellijn.
-                    </p>
-
-                    @if (_conflicten.Count > 0)
+                @* #689: beide tabs krijgen hier één regel toelichting met dezelfde opmaak, zodat de
+                   visual eronder in beide tabs op exact dezelfde hoogte begint. Stond deze regel
+                   alleen in de Optimaal-tab, dan schoof de tijdlijn 50 pixels bij het wisselen — en
+                   juist dat springen is wat het vergelijken onbruikbaar maakt. De Huidig-tab krijgt
+                   geen opvultekst maar echte informatie: dat die stand uit Sportlink komt. *@
+                <p class="text-muted small mb-2">
+                    @if (_isOptimaal)
                     {
-                        <div class="alert alert-warning py-2 small">
-                            <strong>Let op — deze planning kan zo niet:</strong>
-                            <ul class="mb-0 ps-3">
-                                @foreach (var c in _conflicten)
-                                {
-                                    <li>@c</li>
-                                }
-                            </ul>
-                        </div>
+                        <i class="bi bi-arrows-move me-1" aria-hidden="true"></i>
+                        <text>
+                            Sleep een wedstrijd naar een andere tijd of een ander veld. De tijd springt op stappen
+                            van 5 minuten; de tabel en de eindtijd lopen mee. Handmatig verplaatste wedstrijden
+                            krijgen een stippellijn.
+                        </text>
                     }
-                }
+                    else
+                    {
+                        <i class="bi bi-lock me-1" aria-hidden="true"></i>
+                        <text>
+                            Dit is de stand zoals die nu in Sportlink staat. Niet te verslepen — wissel naar
+                            Optimaal om te schuiven. De statuskolom laat zien wat de planner zou wijzigen.
+                        </text>
+                    }
+                </p>
 
                 <div style="overflow-x:auto; min-width:0;">
                     @* Tijdas-header *@
                     <div style="display:flex; margin-bottom:4px;">
                         <div style="width:120px; flex-shrink:0;"></div>
-                        <div style="flex:1; position:relative; height:22px; min-width:500px;">
+                        <div style="flex:1; position:relative; height:22px; min-width:200px;">
                             @for (int _h = _sMin; _h <= _eMin; _h += 60)
                             {
                                 string _lftH = GanttPct(_h - _sMin, _totMin);
-                                <div style="position:absolute; left:@(_lftH)%; transform:translateX(-50%);
+                                <div style="position:absolute; left:@(_lftH)%; transform:@GanttLabelTransform(_h, _sMin, _eMin);
                                             font-size:0.7rem; color:#6c757d; white-space:nowrap; user-select:none;">
                                     @TimeOnly.FromTimeSpan(TimeSpan.FromMinutes(_h)).ToString("HH:mm")
                                 </div>
@@ -467,7 +333,7 @@
                                 @_veld
                             </div>
                             <div id="gantt-rij-@_rij"
-                                 style="flex:1; position:relative; height:72px; min-width:500px; background:#fff;"
+                                 style="flex:1; position:relative; height:72px; min-width:200px; background:#fff;"
                                  ondragover="event.preventDefault();"
                                  @ondrop="@(e => SleepDrop(_veldNaam, _rij, _sMin, _totMin, e))">
                                 @* Uurlijnen *@
@@ -521,7 +387,196 @@
                     <div style="height:1px; background:#dee2e6; margin-left:120px;"></div>
                 </div>
             }
+
+            @* #689: conflicten staan onder de tijdlijn, niet erboven. Boven de visual zou een
+               waarschuwing van wisselende hoogte de tijdlijn verschuiven zodra je van tab wisselt,
+               precies wat deze herstructurering wil voorkomen. Hier blijft hij even zichtbaar en
+               staat hij pal onder de planning waar hij over gaat. *@
+            @if (_isOptimaal && _conflicten.Count > 0)
+            {
+                <div class="alert alert-warning py-2 small mt-2 mb-0">
+                    <strong>Let op — deze planning kan zo niet:</strong>
+                    <ul class="mb-0 ps-3">
+                        @foreach (var c in _conflicten)
+                        {
+                            <li>@c</li>
+                        }
+                    </ul>
+                </div>
+            }
+
+            @* ── Wedstrijdenlijst van dézelfde stand (#689) ──
+               Bewust dezelfde kolommen in beide tabs, zodat de rijen tussen "Optimaal" en "Huidig"
+               op precies dezelfde regel staan. Alleen Veld en Tijd komen uit een andere bron.
+
+               De statusbadge staat in béide tabs. Het issue vroeg alleen om de badge in de
+               Optimaal-tab, om de diff-informatie niet te verliezen nu de kolommen-naast-elkaar-tabel
+               verdwijnt. In de Huidig-tab is dezelfde badge juist het nuttigst: je ziet dáár welke
+               wedstrijd gaat verschuiven, en flipt dan naar Optimaal om te zien waarheen. *@
+            <hr class="my-3" />
+
+            <div class="d-flex align-items-center gap-2 flex-wrap mb-2">
+                <span class="fw-semibold me-1">
+                    @(_isOptimaal ? "Wedstrijden in de optimale planning" : "Wedstrijden in de huidige situatie")
+                </span>
+                @* Het filter geldt voor beide tabs: filter je op "Wijzigingen", dan vergelijk je in
+                   beide standen dezelfde deelverzameling. *@
+                <div class="btn-group btn-group-sm">
+                    <button class="btn @(_filter == "alles" ? "btn-primary" : "btn-outline-secondary")"
+                            @onclick='() => _filter = "alles"'>Alles (@_plan.TotaalWedstrijden)</button>
+                    <button class="btn @(_filter == "wijzigingen" ? "btn-primary" : "btn-outline-secondary")"
+                            @onclick='() => _filter = "wijzigingen"'>Wijzigingen (@_plan.TeWijzigen)</button>
+                    @if (_plan.NietInplanbaar > 0)
+                    {
+                        <button class="btn @(_filter == "probleem" ? "btn-danger" : "btn-outline-danger")"
+                                @onclick='() => _filter = "probleem"'>Probleem (@_plan.NietInplanbaar)</button>
+                    }
+                </div>
+            </div>
+
+            <div class="table-responsive">
+                <table class="table table-sm table-hover mb-0">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Wedstrijd</th>
+                            <th>Veld</th>
+                            <th>Tijd</th>
+                            <th>Competitie</th>
+                            <th title="Gewenste tijd en de afwijking daarvan in de optimale planning">Voorkeurstijd</th>
+                            <th title="Verplaatst de planner deze wedstrijd t.o.v. de huidige stand?">Wijziging</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var item in GefilterdeLijst())
+                        {
+                            <tr class="@RowClass(item.Status)">
+                                <td style="font-size:0.85rem;">
+                                    <div class="fw-semibold">@(string.IsNullOrWhiteSpace(item.Wedstrijd) ? item.TeamNaam : item.Wedstrijd)</div>
+                                </td>
+
+                                @if (_isOptimaal)
+                                {
+                                    @* Veld en tijd zoals de planner ze voorstelt *@
+                                    @if (item.Status == "niet-inplanbaar")
+                                    {
+                                        <td colspan="2" style="font-size:0.85rem;">
+                                            <span class="text-danger" title="@item.NietInplanbaaarReden">
+                                                &#10007; @(item.NietInplanbaaarReden ?? "Niet inplanbaar")
+                                            </span>
+                                        </td>
+                                    }
+                                    else
+                                    {
+                                        @* Onbekend team: huidige situatie blijft staan, gedempt en zonder
+                                           foutmelding (#487) *@
+                                        var _gedempt = item.Status is "ongewijzigd" or "onbekend-team";
+                                        <td style="font-size:0.85rem;">
+                                            <span class="@(_gedempt ? "" : "fw-bold")">@(item.OptimaalVeld ?? "—")</span>
+                                        </td>
+                                        <td style="font-size:0.85rem;">
+                                            <span class="@(_gedempt ? "" : "fw-bold")">@(item.OptimaalTijd ?? "—")</span>
+                                        </td>
+                                    }
+                                }
+                                else
+                                {
+                                    @* Veld en tijd zoals ze nu in Sportlink staan *@
+                                    <td style="font-size:0.85rem;">
+                                        @if (!item.HeeftVeld)
+                                        {
+                                            <span class="text-warning">&#10007; Geen veld</span>
+                                        }
+                                        else
+                                        {
+                                            <span>@item.HuidigeVeld</span>
+                                        }
+                                    </td>
+                                    <td style="font-size:0.85rem;">
+                                        @if (!item.HeeftTijd)
+                                        {
+                                            <span class="text-warning">&#10007; Geen tijd</span>
+                                        }
+                                        else
+                                        {
+                                            <span>@item.HuidigeTijd</span>
+                                        }
+                                    </td>
+                                }
+
+                                <td style="font-size:0.85rem;">@(item.Competitiesoort ?? "—")</td>
+
+                                @* Voorkeurstijd los van de wijzig-status (#666): een wedstrijd kan
+                                   ongewijzigd blijven én tóch ver van de voorkeurstijd liggen.
+                                   De afwijking is berekend t.o.v. de optimale planning, dus die wordt
+                                   alleen in die tab getoond — anders zou hij bij "Huidig" iets beweren
+                                   over een stand waarop hij niet is berekend. *@
+                                <td style="font-size:0.85rem;">
+                                    @if (string.IsNullOrWhiteSpace(item.VoorkeurTijd))
+                                    {
+                                        <span class="text-muted" title="Geen voorkeurstijd voor dit team en geen standaardtijd voor de leeftijdscategorie">—</span>
+                                    }
+                                    else if (_isOptimaal)
+                                    {
+                                        <span class="badge @VoorkeurBadgeClass(item.VoorkeurStatus)"
+                                              title="@VoorkeurTitel(item)">
+                                            @item.VoorkeurTijd@VoorkeurAfwijkingTekst(item.VoorkeurAfwijkingMinuten)
+                                        </span>
+                                        <span class="text-muted ms-1" style="font-size:0.75rem;">@VoorkeurBronLabel(item.VoorkeurBron)</span>
+                                        @if (item.VoorkeurVeldToegepast == false)
+                                        {
+                                            <span class="badge bg-secondary ms-1"
+                                                  title="Voorkeursveld was niet beschikbaar; de planner koos een ander veld">
+                                                ander veld
+                                            </span>
+                                        }
+                                    }
+                                    else
+                                    {
+                                        <span class="badge bg-light text-dark border"
+                                              title="Gewenste tijd volgens @VoorkeurBronLabel(item.VoorkeurBron). De afwijking staat in de tab Optimaal.">
+                                            @item.VoorkeurTijd
+                                        </span>
+                                    }
+                                </td>
+
+                                <td>
+                                    @switch (item.Status)
+                                    {
+                                        case "ongewijzigd":
+                                            <span class="badge bg-light text-dark border" title="De planner laat deze wedstrijd staan">Ongewijzigd</span>
+                                            break;
+                                        case "nieuw-slot":
+                                            <span class="badge bg-warning text-dark">Nieuw</span>
+                                            break;
+                                        case "wijziging":
+                                            <span class="badge bg-primary">Wijzig</span>
+                                            break;
+                                        case "niet-inplanbaar":
+                                            <span class="badge bg-danger">Probleem</span>
+                                            break;
+                                        case "onbekend-team":
+                                            <span class="badge bg-secondary">Onbekend</span>
+                                            break;
+                                    }
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
         </div>
+        @if (!string.IsNullOrEmpty(_toepassenMelding))
+        {
+            <div class="card-footer">
+                <div class="alert @(_toepassenFout ? "alert-danger" : "alert-success") mb-0 py-2">
+                    @_toepassenMelding
+                    @if (!_toepassenFout)
+                    {
+                        <button class="btn btn-sm btn-outline-success ms-3" @onclick="AutoPlanAsync">Herlaad plan</button>
+                    }
+                </div>
+            </div>
+        }
     </div>
 
     @* ── Deelbare weergave van de berekende planning ── *@
@@ -1071,6 +1126,27 @@
         => totaal > 0
             ? ((double)deel / totaal * 100).ToString("F2", System.Globalization.CultureInfo.InvariantCulture)
             : "0.00";
+
+    /// <summary>
+    /// Horizontale uitlijning van een tijdlabel op de tijdas (#689).
+    ///
+    /// <para>
+    /// Alle labels stonden op <c>translateX(-50%)</c>, dus gecentreerd op hun uurlijn. Voor het
+    /// eerste en het laatste label valt daarmee de helft buiten de container: links vóór 0% en rechts
+    /// ná 100%. Die paar pixels overschrijding zijn precies waarom er op een breed scherm nog een
+    /// horizontale scrollbalk verscheen — de container was 14 pixels breder dan hij hoefde te zijn,
+    /// terwijl de inhoud ruim paste.
+    /// </para>
+    ///
+    /// <para>
+    /// Het eerste label lijnt daarom links uit, het laatste rechts, en alles ertussen blijft
+    /// gecentreerd. Geen enkel label wordt afgekapt en de scrollbalk is weg.
+    /// </para>
+    /// </summary>
+    private static string GanttLabelTransform(int uur, int startMinuut, int eindMinuut)
+        => uur <= startMinuut ? "translateX(0)"
+         : uur >= eindMinuut  ? "translateX(-100%)"
+         : "translateX(-50%)";
 
     private static double GanttTop(string? sub) => sub switch
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Changed
+- **De Dagplanning vergelijkt nu met twee tabs: Optimaal en Huidig.** Elke tab toont dezelfde opbouw — eerst de tijdlijn per veld, daaronder de wedstrijdenlijst van diezelfde stand. Omdat beide tabs op exact dezelfde hoogte beginnen, werkt wisselen als het vergelijken van twee foto's: het oog springt niet en je ziet direct wat er in de veldbezetting verandert. Eerder stonden er twee verschillende vergelijkingen door elkaar op één pagina — een tabel met "huidig" en "optimaal" in kolommen naast elkaar, én tabs die alléén de tijdlijn wisselden terwijl de tabel bleef staan. De filterknoppen gelden nu voor beide tabs, en de kolom Wijziging staat in beide: in de tab Huidig zie je daarmee welke wedstrijd gaat verschuiven, en met één klik waarheen. (#689)
+- **De verdwaalde horizontale schuifbalk onder de tijdlijn is weg.** Op een breed scherm verscheen die terwijl de inhoud ruim paste. Oorzaak: het eerste en laatste tijdlabel stonden gecentreerd op hun uurlijn en vielen daardoor half buiten de tijdlijn — precies genoeg om de browser een schuifbalk te laten reserveren. Die twee labels lijnen nu links en rechts uit; geen label wordt afgekapt en op een smal scherm past de tijdlijn nu binnen het scherm in plaats van een vaste minimumbreedte te forceren. (#689)
+
 ### Added
 - **Bij een vraag over meerdere datums noemt het antwoord nu de coördinator bij naam:** "Laat weten welke optie(s) de voorkeur hebben, dan gaan we samen met [naam] plannen en definitief opnemen in de planning." Staat er geen coördinatornaam in de instellingen, dan blijft de zin gewoon compleet zonder naam. De naam komt uit de instellingen van de club waarvoor het antwoord wordt opgebouwd, dus in een test met de demoklub verschijnt de demo-coördinator. (#670)
 

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.18.1.0</Version>
-    <AssemblyVersion>2.18.1.0</AssemblyVersion>
-    <FileVersion>2.18.1.0</FileVersion>
+    <Version>2.18.2.0</Version>
+    <AssemblyVersion>2.18.2.0</AssemblyVersion>
+    <FileVersion>2.18.2.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/docs/BEHEERDER-HANDLEIDING.md
+++ b/docs/BEHEERDER-HANDLEIDING.md
@@ -64,9 +64,35 @@ In testmodus:
 
 Volledige documentatie: [docs/TESTMODUS-ALLSTARS.md](TESTMODUS-ALLSTARS.md)
 
-### Dagplanning — status-badges
+### Dagplanning — twee tabs: Optimaal en Huidig
 
-De dagplanning toont per wedstrijd een badge in de Status-kolom:
+Na een klik op **Optimaliseer** staat bovenaan de samenvattingsbalk (wedstrijden, zonder veld,
+zonder tijd, te wijzigen, optimale eindtijd). Daaronder staan twee tabs (#689):
+
+| Tab | Wat je ziet |
+|---|---|
+| **Optimaal** | De planning zoals de planner die voorstelt. Wedstrijden zijn hier te **verslepen** naar een andere tijd of een ander veld. |
+| **Huidig** | De stand zoals die nu in Sportlink staat. Niet te verslepen. |
+
+Elke tab heeft dezelfde opbouw: eerst de **tijdlijn per veld**, daaronder de **wedstrijdenlijst** van
+diezelfde stand. Omdat beide tabs op exact dezelfde hoogte beginnen, werkt wisselen als het
+vergelijken van twee foto's: je oog springt niet en je ziet direct wat er in de veldbezetting
+verandert. Eerder stonden hier twee verschillende vergelijkingen door elkaar — een tabel met
+"huidig" en "optimaal" in kolommen naast elkaar, én tabs die alléén de tijdlijn wisselden terwijl de
+tabel bleef staan.
+
+De **filterknoppen** (Alles / Wijzigingen / Probleem) gelden voor beide tabs. Filter je op
+"Wijzigingen", dan zie je in beide standen dezelfde selectie — dat maakt de vergelijking pas echt
+bruikbaar.
+
+De kolom **Wijziging** staat in beide tabs. In de tab Huidig is die juist het nuttigst: daar zie je
+welke wedstrijd gaat verschuiven, en met één klik op Optimaal zie je waarheen.
+
+De kolom **Voorkeurstijd** toont in de tab Optimaal de gewenste tijd mét de afwijking; in de tab
+Huidig alleen de gewenste tijd. Die afwijking is namelijk berekend op de optimale planning — hem bij
+de huidige stand tonen zou een getal beweren dat daar niet op is berekend.
+
+### Dagplanning — status-badges
 
 De dagplanning heeft **twee losse kolommen** die makkelijk verward worden (#666):
 


### PR DESCRIPTION
Op de Dagplanning stonden **twee tegenstrijdige vergelijkingspatronen** op één pagina: een diff-tabel met "huidig" en "optimaal" in kolommen naast elkaar, en daaronder een aparte kaart waar tabs alléén de tijdlijn wisselden terwijl de tabel bleef staan. Geen van beide liet de visual en de bijbehorende lijst van dezelfde stand op gelijke hoogte zien.

**Nu:** één kaart met de tabs op het hoogste niveau, direct onder de samenvattingsbalk. Elke tab bevat op dezelfde plek eerst de tijdlijn per veld, daaronder de wedstrijdenlijst van diezelfde stand.

## Twee dingen die pas bij het meten bleken

Het flip-book-effect werkt alleen als de tijdlijn in beide tabs op exact dezelfde hoogte staat. Dat was na de eerste opzet **niet** zo:

| Bevinding | Gemeten | Oplossing |
|---|---|---|
| De sleep-hint stond alleen in de Optimaal-tab | tijdlijn verschoof **50px** bij wisselen | Beide tabs krijgen één regel toelichting met dezelfde opmaak. De Huidig-tab krijgt geen opvultekst maar echte informatie: stand uit Sportlink, niet sleepbaar. **Nu 0px** |
| Het conflictblok stond boven de tijdlijn, met wisselende hoogte | zelfde effect zodra er een conflict is | Staat nu ónder de tijdlijn — pal onder de planning waar het over gaat, en even zichtbaar |

## De schuifbalk had een andere oorzaak dan gedacht

Het issue vermoedde de hardcoded `min-width:500px` of subpixel-afronding. Het bleek de **tijdlabels**: het eerste en laatste label stonden op `translateX(-50%)`, dus gecentreerd op hun uurlijn, en vielen daarmee half buiten de container. Dat is exact de 14px overschrijding die ik op een breed scherm meette.

Die twee labels lijnen nu links respectievelijk rechts uit — geen label wordt afgekapt. De `min-width` is daarnaast van 500px naar 200px, zodat de tijdlijn op een smal scherm meekrimpt in plaats van de pagina breder te maken.

| Viewport | Overschrijding vóór | Na |
|---|---|---|
| 2560px | 14px (in beide tabs) | **0px** |
| 420px | tijdlijn forceerde 620px | past binnen het scherm |

Op 420px blijft er 44px paginabreedte over. Die komt van de layout-header (versienummer + FEEDBACK + About) en de interne scroll van een brede tabel — beide bestaand en buiten de scope van dit issue. De tijdlijn zelf is schoon.

## Keuzes waar ik van het issue afwijk, met reden

**De statusbadge staat in béide tabs.** Het issue vroeg die alleen in de Optimaal-tab, om de diff-informatie niet te verliezen nu de kolommen-naast-elkaar-tabel verdwijnt. In de Huidig-tab is dezelfde badge juist het nuttigst: daar zie je welke wedstrijd gaat verschuiven, en met één klik op Optimaal waarheen. Dat maakt het DOM bovendien identiek tussen de tabs, wat de uitlijning helpt.

**De filterknoppen staan in beide tabs, niet alleen in Optimaal.** Filter je op "Wijzigingen", dan vergelijk je in beide standen dezelfde selectie — dat is wat de vergelijking bruikbaar maakt. Alleen in Optimaal zou het filter bij het wisselen stilletjes vervallen.

**De afwijking bij Voorkeurstijd blijft alleen in Optimaal.** Die is berekend op de optimale planning; hem bij de huidige stand tonen zou een getal beweren dat daar niet op is gebaseerd. In de Huidig-tab staat wél de gewenste tijd zelf.

## Verificatie

Met echte productiedata (22-08-2026, 3 thuiswedstrijden):

- Tabs renderen, tijdlijn en lijst wisselen samen, kop verandert mee ("Wedstrijden in de optimale planning" / "…in de huidige situatie")
- Tijdlijn-uitlijning tussen tabs: **0px** verschil
- Schuifbalk op 2560px: **0px** overschrijding in beide tabs
- Nul console-fouten, geen foutbanner
- `dotnet build` BlazorAdmin exit 0, 0 warnings
- `dotnet test`: 409 passed
- Getest op 2560px, 1440px en 420px

Buiten scope gehouden, conform het issue: planner-logica en het sleepgedrag zijn ongewijzigd.

`docs/BEHEERDER-HANDLEIDING.md` heeft een nieuwe sectie die de twee tabs uitlegt, inclusief waarom de afwijking alleen in Optimaal staat.

## Kostenbeleid

Alleen frontend en documentatie. Geen Azure-resources, geen kosteneffect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)