### PR TITLE
fix(#756): teamdropdown gebruikt canonieke dbo.Teams i.p.v. rauwe his.teams

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -14,9 +14,9 @@
          Wie dit terugzet naar true moet óók de CSP oplossen — en nonce/SRI kan niet op statische
          hosting. Zie index.html voor de volledige afweging. -->
     <OverrideHtmlAssetPlaceholders>false</OverrideHtmlAssetPlaceholders>
-    <Version>2.19.0.0</Version>
-    <AssemblyVersion>2.19.0.0</AssemblyVersion>
-    <FileVersion>2.19.0.0</FileVersion>
+    <Version>2.19.0.1</Version>
+    <AssemblyVersion>2.19.0.1</AssemblyVersion>
+    <FileVersion>2.19.0.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- **De teamdropdown bij Voorkeurstijden en Teamregels toont niet meer dezelfde teams dubbel of in rauwe schrijfwijze.** De lijst kwam rechtstreeks uit de ongenormaliseerde brondata, waarin elk team meerdere keren voorkomt — per poule en in twee schrijfwijzen ("O13" naast "JO13"). De dropdown gebruikt nu de al bestaande, ontdubbelde teamlijst die na elke synchronisatie wordt bijgewerkt: één rij per fysiek team. Als onderdeel van dezelfde fix krijgt de democlub AllStars FC nu ook een gevulde, ontdubbelde teamlijst — die liep eerder nooit mee in de ontdubbelingsstap omdat die alleen voor de echte club draaide. (#756)
+
 ## [2.19.0.0] — 2026-07-28
 
 ### Changed

--- a/FunctionApp/Admin/AdminTeamsFunction.cs
+++ b/FunctionApp/Admin/AdminTeamsFunction.cs
@@ -5,8 +5,9 @@ using Microsoft.Azure.Functions.Worker;
 namespace SportlinkFunction.Admin;
 
 /// <summary>
-/// Levert de lijst van teams uit his.teams (gesynchroniseerd via Sportlink API), gefilterd op ClubCode.
-/// Gebruikt door de Blazor Admin UI voor dropdowns in voorkeurstijden en teamregels.
+/// Levert de lijst van canonieke teamnamen uit dbo.Teams (#756) — één rij per fysiek team,
+/// ontdubbeld en genormaliseerd door TeamCanonicalisatieService. Gebruikt door de Blazor Admin UI
+/// voor dropdowns in voorkeurstijden en teamregels.
 /// </summary>
 public static class AdminTeamsFunction
 {

--- a/FunctionApp/Admin/Repositories/AdminTeamsRepository.cs
+++ b/FunctionApp/Admin/Repositories/AdminTeamsRepository.cs
@@ -9,10 +9,10 @@ internal static class AdminTeamsRepository
         using var conn = new SqlConnection(cs);
         await conn.OpenAsync();
         using var cmd = new SqlCommand(@"
-            SELECT DISTINCT [teamnaam]
-            FROM [his].[teams]
-            WHERE [ClubCode] = @Cc
-            ORDER BY [teamnaam]", conn);
+            SELECT [Teamnaam]
+            FROM [dbo].[Teams]
+            WHERE [ClubCode] = @Cc AND [IsActief] = 1
+            ORDER BY [Teamnaam]", conn);
         cmd.Parameters.AddWithValue("@Cc", clubCode);
         using var r = await cmd.ExecuteReaderAsync();
         var list = new List<string>();

--- a/FunctionApp/Sync/SportlinkSyncPipeline.cs
+++ b/FunctionApp/Sync/SportlinkSyncPipeline.cs
@@ -106,6 +106,23 @@ internal static class SportlinkSyncPipeline
             log.LogError(ex, "TEAMS CANONICALISATIE - mislukt voor club {ClubCode}", clubCode);
         }
 
+        // AllStars FC (#756) heeft geen eigen Sportlink-sync — zijn his.teams-rijen komen uit de
+        // PostDeployment-demodata-seed, niet uit deze pipeline. Zonder deze aanroep blijft dbo.Teams
+        // voor de democlub voor altijd leeg, terwijl her/matches wel gevuld zijn: de teamdropdown in de
+        // Admin UI zou dan voor de democlub 0 teams tonen in plaats van de rauwe (niet-ontdubbelde) lijst
+        // van vóór #756. Meelopen op elke echte sync houdt de demodata dus canoniek zonder een aparte job.
+        if (!clubCode.Equals("ALLSTARS", StringComparison.OrdinalIgnoreCase))
+        {
+            try
+            {
+                await TeamResolution.TeamCanonicalisatieService.RefreshAsync("ALLSTARS", log);
+            }
+            catch (Exception ex)
+            {
+                log.LogError(ex, "TEAMS CANONICALISATIE - mislukt voor democlub ALLSTARS");
+            }
+        }
+
         await Planner.PlannerDataAccess.MarkeerVervallenGeplandeWedstrijdenAsync(log);
 
         if (!partialFailure)

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.19.0.0</Version>
-    <AssemblyVersion>2.19.0.0</AssemblyVersion>
-    <FileVersion>2.19.0.0</FileVersion>
+    <Version>2.19.0.1</Version>
+    <AssemblyVersion>2.19.0.1</AssemblyVersion>
+    <FileVersion>2.19.0.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/docs/ARCHITECTUUR-TEAMRESOLUTIE.md
+++ b/docs/ARCHITECTUUR-TEAMRESOLUTIE.md
@@ -109,6 +109,13 @@ verbruikt.
 Logregels om op te zoeken: `TEAMRESOLUTIE` (per bericht: teamId, bron, confidence) en
 `TEAMS CANONICALISATIE` (per sync: aantal teams, gekoppelde schrijfwijzen, niet-herleidbare namen).
 
+**AllStars FC-uitzondering (#756):** de democlub heeft geen eigen Sportlink-sync — zijn
+`his.teams`/`his.matches`-rijen komen uit de PostDeployment-demodata-seed. `SportlinkSyncPipeline`
+roept `TeamCanonicalisatieService.RefreshAsync` daarom na elke echte sync **twee keer** aan: één keer
+voor de geconfigureerde `clubCode`, één keer expliciet voor `"ALLSTARS"`. Zonder die tweede aanroep
+blijft `dbo.Teams` voor de democlub permanent leeg en toont elke UI die daaruit leest (bijv. de
+teamdropdown bij Voorkeurstijden) nul teams voor AllStars FC.
+
 ## Waarom exacte matching in plaats van LIKE
 
 De schrijfwijze verschilt per bron: `his.matches` gebruikt "[club] JO10-1" (mét J), de bondsrijen in


### PR DESCRIPTION
## Probleem
De teamdropdown bij "Nieuwe teamregel"/"Nieuwe voorkeur" op de Voorkeurstijden-pagina toonde teams dubbel en in niet-genormaliseerde schrijfwijze (bijv. "O13" naast "JO13").

## Root cause
`AdminTeamsRepository.GetTeamnamenAsync` (`GET /api/beheer/teams`) query'de rechtstreeks `SELECT DISTINCT teamnaam FROM his.teams` — ruwe, ongenormaliseerde Sportlink-brondata waarin elk fysiek team meerdere keren voorkomt: per poule/competitiesoort, én in twee schrijfwijzen (lokale notatie `JO10-1` vs KNVB-notatie `[club] O10-1`, zie [docs/ARCHITECTUUR-TEAMRESOLUTIE.md](docs/ARCHITECTUUR-TEAMRESOLUTIE.md)). `SELECT DISTINCT` dedupliceert alleen byte-identieke strings.

De canonicalisatielaag die dit al oplost bestond al (`dbo.Teams`, gevuld door `TeamCanonicalisatieService` na elke sync, #692/#696) — dit endpoint gebruikte hem alleen nooit.

## Fix
1. `AdminTeamsRepository.GetTeamnamenAsync` leest nu uit `dbo.Teams` (`IsActief = 1`) i.p.v. `his.teams`.
2. Tijdens het testen bleek dat AllStars FC (de democlub) nooit meeliep in de canonicalisatiestap — die draaide alleen voor de geconfigureerde clubCode, terwijl AllStars geen eigen Sportlink-sync heeft. Zonder extra fix zou de teamdropdown voor AllStars FC van "rommelig gevuld" naar "volledig leeg" gaan. `SportlinkSyncPipeline` roept `TeamCanonicalisatieService.RefreshAsync` nu na elke sync ook expliciet voor `ALLSTARS` aan.

## Verificatie
- `dotnet build` FunctionApp + BlazorAdmin: groen
- `dotnet test`: 409 passed, 4 skipped (ongewijzigd)
- Lokaal: manuele sync gedraaid, `dbo.Teams` bevat nu 116 (VRC) + 28 (ALLSTARS) canonieke rijen; `GET /api/beheer/teams` geeft voor beide clubs een schone, ontdubbelde lijst
- `Test-App.ps1`: 43/43 checks groen
- Browsercheck (Playwright): Voorkeurstijden-pagina rendert zonder foutbanner, versienummer v2.19.0.1 zichtbaar, teamdropdown toont de schone lijst, console zonder errors/warnings

## Overig
- CHANGELOG.md bijgewerkt onder `[Unreleased]`
- Versie gebumpt naar 2.19.0.1 (REVISION — bugfix zonder nieuwe feature)
- `docs/ARCHITECTUUR-TEAMRESOLUTIE.md` uitgebreid met de AllStars-uitzondering

Closes #756