### PR TITLE
fix(#761): dedup Outlook-kopieerregel + exacte duplicaat-rijen bij teambegeleiding-import

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -14,9 +14,9 @@
          Wie dit terugzet naar true moet óók de CSP oplossen — en nonce/SRI kan niet op statische
          hosting. Zie index.html voor de volledige afweging. -->
     <OverrideHtmlAssetPlaceholders>false</OverrideHtmlAssetPlaceholders>
-    <Version>2.19.0.0</Version>
-    <AssemblyVersion>2.19.0.0</AssemblyVersion>
-    <FileVersion>2.19.0.0</FileVersion>
+    <Version>2.19.0.1</Version>
+    <AssemblyVersion>2.19.0.1</AssemblyVersion>
+    <FileVersion>2.19.0.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/BlazorAdmin/Pages/Teambegeleiding.razor
+++ b/BlazorAdmin/Pages/Teambegeleiding.razor
@@ -256,7 +256,18 @@ else if (_selectedTeam != null && !_loadingBegeleiders)
 
     private string OutlookRegel => string.Join("; ", _begeleiders
         .Where(b => !string.IsNullOrWhiteSpace(b.Emailadres))
-        .Select(b => $"\"{b.Naam}\" <{b.Emailadres}>"));
+        .GroupBy(b => (Naam: b.Naam.Trim(), Email: b.Emailadres!.Trim()), StringTupleComparer.OrdinalIgnoreCase)
+        .Select(g => $"\"{g.Key.Naam}\" <{g.Key.Email}>"));
+
+    private sealed class StringTupleComparer : IEqualityComparer<(string Naam, string Email)>
+    {
+        public static readonly StringTupleComparer OrdinalIgnoreCase = new();
+        public bool Equals((string Naam, string Email) x, (string Naam, string Email) y) =>
+            string.Equals(x.Naam, y.Naam, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(x.Email, y.Email, StringComparison.OrdinalIgnoreCase);
+        public int GetHashCode((string Naam, string Email) obj) =>
+            HashCode.Combine(obj.Naam.ToUpperInvariant(), obj.Email.ToUpperInvariant());
+    }
 
     protected override async Task OnInitializedAsync()
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- **Teambegeleiding: iemand met twee functies in hetzelfde team wordt in de Outlook-kopieerregel nu maar één keer opgenomen.** De kaartenweergave toont nog steeds elke functie apart, maar de "Kopieer naar Outlook"-regel mailt niet langer dezelfde persoon twee keer. Daarnaast worden exacte duplicaat-rijen uit de Sportlink-export (dezelfde persoon met dezelfde rol twee keer) voortaan bij import overgeslagen, met een waarschuwing in het importresultaat. (#761)
+
 ## [2.19.0.0] — 2026-07-28
 
 ### Changed

--- a/FunctionApp.Tests/Admin/AdminTeambegeleidingFunctionTests.cs
+++ b/FunctionApp.Tests/Admin/AdminTeambegeleidingFunctionTests.cs
@@ -1,0 +1,62 @@
+using FluentAssertions;
+using SportlinkFunction.Admin;
+using Xunit;
+
+namespace FunctionApp.Tests.Admin;
+
+/// <summary>
+/// Tests voor AdminTeambegeleidingFunction.ParseCsv — regressietest voor #761:
+/// exacte duplicaat-rijen in de bron-CSV mogen niet dubbel geïmporteerd worden.
+/// </summary>
+public class AdminTeambegeleidingFunctionTests
+{
+    private const string Header = "Team;Rol in team;Voornaam;Familienaam;E-mailadres";
+
+    [Fact]
+    public void ParseCsv_ExacteDuplicaatRij_WordtEenmaalGeteld()
+    {
+        var csv = $"""
+            {Header}
+            JO13-1;Technische staf;Jan;de Vries;trainer@voorbeeld.nl
+            JO13-1;Technische staf;Jan;de Vries;trainer@voorbeeld.nl
+            """;
+
+        var result = AdminTeambegeleidingFunction.ParseCsv(csv);
+
+        result.IsValid.Should().BeTrue();
+        result.Rows.Should().HaveCount(1);
+        result.Waarschuwingen.Should().Contain(w => w.Contains("1 exacte duplicaat-rij"));
+    }
+
+    [Fact]
+    public void ParseCsv_ZelfdePersoonMetTweeRollen_BlijftTweeRijen()
+    {
+        var csv = $"""
+            {Header}
+            JO13-1;Technische staf;Jan;de Vries;trainer@voorbeeld.nl
+            JO13-1;Overige staf;Jan;de Vries;trainer@voorbeeld.nl
+            """;
+
+        var result = AdminTeambegeleidingFunction.ParseCsv(csv);
+
+        result.IsValid.Should().BeTrue();
+        result.Rows.Should().HaveCount(2);
+        result.Waarschuwingen.Should().NotContain(w => w.Contains("duplicaat"));
+    }
+
+    [Fact]
+    public void ParseCsv_GeenDuplicaten_GeenWaarschuwing()
+    {
+        var csv = $"""
+            {Header}
+            JO13-1;Technische staf;Jan;de Vries;trainer@voorbeeld.nl
+            JO13-1;Technische staf;Piet;Jansen;piet@voorbeeld.nl
+            """;
+
+        var result = AdminTeambegeleidingFunction.ParseCsv(csv);
+
+        result.IsValid.Should().BeTrue();
+        result.Rows.Should().HaveCount(2);
+        result.Waarschuwingen.Should().NotContain(w => w.Contains("duplicaat"));
+    }
+}

--- a/FunctionApp/Admin/AdminTeambegeleidingFunction.cs
+++ b/FunctionApp/Admin/AdminTeambegeleidingFunction.cs
@@ -327,11 +327,11 @@ public static class AdminTeambegeleidingFunction
 
     private static readonly string[] _vereistKolommen = ["Team", "Teamrol", "Roepnaam", "Achternaam", "Emailadres"];
 
-    private record ImportRij(
+    internal record ImportRij(
         string? Team, string? LeeftijdscategorieTeam, string? Teamrol,
         string? Naam, string? Emailadres, string? Telefoonnummer);
 
-    private class CsvParseResult
+    internal class CsvParseResult
     {
         public bool IsValid { get; set; }
         public string? Error { get; set; }
@@ -341,7 +341,7 @@ public static class AdminTeambegeleidingFunction
         public List<ImportRij> Rows { get; set; } = [];
     }
 
-    private static CsvParseResult ParseCsv(string csvContent)
+    internal static CsvParseResult ParseCsv(string csvContent)
     {
         var result = new CsvParseResult();
         var lines = csvContent
@@ -412,6 +412,20 @@ public static class AdminTeambegeleidingFunction
                 GetVeld("Emailadres"),
                 telefoon));
         }
+
+        var voorDedup = result.Rows.Count;
+        result.Rows = [.. result.Rows
+            .GroupBy(r => (
+                Team: r.Team?.Trim().ToUpperInvariant(),
+                Teamrol: r.Teamrol?.Trim().ToUpperInvariant(),
+                Naam: r.Naam?.Trim().ToUpperInvariant(),
+                Email: r.Emailadres?.Trim().ToUpperInvariant(),
+                Telefoon: r.Telefoonnummer?.Trim().ToUpperInvariant()))
+            .Select(g => g.First())];
+        var duplicaten = voorDedup - result.Rows.Count;
+        if (duplicaten > 0)
+            result.Waarschuwingen.Add(
+                $"{duplicaten} exacte duplicaat-rij{(duplicaten == 1 ? "" : "en")} overgeslagen (zelfde team, rol, naam en e-mailadres).");
 
         result.IsValid = true;
         return result;

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.19.0.0</Version>
-    <AssemblyVersion>2.19.0.0</AssemblyVersion>
-    <FileVersion>2.19.0.0</FileVersion>
+    <Version>2.19.0.1</Version>
+    <AssemblyVersion>2.19.0.1</AssemblyVersion>
+    <FileVersion>2.19.0.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/docs/ADMIN-TEAMBEGELEIDING-IMPORT.md
+++ b/docs/ADMIN-TEAMBEGELEIDING-IMPORT.md
@@ -137,3 +137,4 @@ Deze export wordt **wekelijks** uitgevoerd — kies een vast moment dat past bij
 | Geen exportknop zichtbaar | Onvoldoende rechten | Vraag een beheerder om de export uit te voeren |
 | Script geeft een fout | Geen bestand gevonden | Controleer of de download in stap 3 geslaagd is en het bestand in de Downloadmap staat |
 | Verificatiecode werkt niet | Code verlopen | Wacht tot de authenticator-app een nieuwe code toont en probeer opnieuw |
+| Waarschuwing "exacte duplicaat-rij(en) overgeslagen" | Sportlink-export bevat dezelfde persoon met exact dezelfde rol twee keer | Geen actie nodig — de import slaat deze duplicaten automatisch over, de rest van de lijst is correct geïmporteerd |


### PR DESCRIPTION
## Samenvatting
- `BlazorAdmin/Pages/Teambegeleiding.razor`: de "Kopieer naar Outlook"-regel groepeert begeleiders nu op Naam+Emailadres (case-insensitive), zodat iemand met twee functies in hetzelfde team niet meer dubbel in de mailto-lijst staat. De kaartenweergave blijft ongewijzigd (toont elke rol apart).
- `FunctionApp/Admin/AdminTeambegeleidingFunction.cs`: `ParseCsv` verwijdert exacte duplicaat-rijen (zelfde Team+Teamrol+Naam+Emailadres+Telefoonnummer) vóór insert, met een waarschuwing in het importresultaat als er iets is overgeslagen.
- Root cause: verificatie van de lokale database toonde een letterlijke duplicaat-rij voor één begeleider van team O13-1 (ClubCode VRC) — geen "2 functies"-geval, maar een exacte kopie die blijkbaar al zo in de Sportlink-export zat.
- Versie gebumpt naar 2.19.0.1 (fix → REVISION), CHANGELOG en `docs/ADMIN-TEAMBEGELEIDING-IMPORT.md` bijgewerkt.
- Nieuwe unit tests in `FunctionApp.Tests/Admin/AdminTeambegeleidingFunctionTests.cs` (met AVG-veilige testdata `Jan de Vries` / `.voorbeeld.nl`, zie CLAUDE.md-uitzondering).

Closes #761

## Test plan
- [x] `dotnet build FunctionApp/fa-dev-sportlink-01.csproj -c Debug` — groen
- [x] `dotnet build BlazorAdmin/BlazorAdmin.csproj` — groen
- [x] `dotnet test FunctionApp.Tests` — 412 passed, 4 skipped (incl. 3 nieuwe tests)
- [x] `.\scripts\dev\Test-App.ps1 -Fix` — alles in orde
- [x] Live services gestart, health endpoint bevestigt v2.19.0.1
- [x] Browsercheck (Playwright) op `/teambegeleiding` → team O13-1 geselecteerd: kaartenlijst toont de bestaande duplicaat-rij nog (data-niveau, wordt pas bij volgende CSV-import opgeschoond), maar de Outlook-kopieerregel toont die persoon nu precies één keer
- [x] Geen foutbanner, geen console-errors