### PR TITLE
fix(#784): woordgrens toevoegen aan Nederlandse-mobiel-regex

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -94,7 +94,7 @@ jobs:
             fi
           }
 
-          check_pattern "Nederlandse mobiele nummers"  "06[-\s]?[0-9]{8}"
+          check_pattern "Nederlandse mobiele nummers"  "\b06[-\s]?[0-9]{8}\b"
           check_pattern "Nederlandse mobiele nummers (+31)" "\+316[0-9]{8}"
           check_pattern "Hotmail-adressen"             "[a-z0-9._%+\-]+@hotmail\.(com|nl)"
           check_pattern "Persoonlijke e-mailadressen"  "[a-z0-9._%+\-]+@(gmail\.com|outlook\.(com|nl)|ziggo\.nl|kpnmail\.nl|casema\.nl|home\.nl)"
@@ -165,7 +165,7 @@ jobs:
 
           EMAIL_HITS=$(echo "$MESSAGES" | grep -oiP '[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}' \
             | grep -viP '@(github\.com|anthropic\.com|example\.(com|nl|org)|voorbeeld\.nl)$' || true)
-          PHONE_HITS=$(echo "$MESSAGES" | grep -oP '06[-\s]?[0-9]{8}|\+316[0-9]{8}' || true)
+          PHONE_HITS=$(echo "$MESSAGES" | grep -oP '\b06[-\s]?[0-9]{8}\b|\+316[0-9]{8}' || true)
 
           if [ -n "$EMAIL_HITS" ]; then
             # Waarschuwing: emailadres in commit-message (bijv. als beschrijving van een fix).

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -59,7 +59,12 @@ tags = ["infrastructure", "club-data"]
 [[rules]]
 id = "dutch-mobile-number"
 description = "Dutch mobile phone number (AVG/GDPR personal data)"
-regex = '''06[-\s]?[0-9]{8}'''
+# Woordgrens verplicht: zonder \b matcht dit patroon toevallig binnen elke hex-hash
+# (SHA256 digest e.d.) die 8+ cijfers na een "06"-substring bevat. Hex-tekens zijn
+# allemaal word characters, dus \b kan niet matchen binnen een aaneengesloten hex-string
+# — de regel blijft een echt telefoonnummer detecteren. Zie #784 (false positive op
+# bruno/.bruno-gen/lock.json in PR #783).
+regex = '''\b06[-\s]?[0-9]{8}\b'''
 tags = ["pii", "avg", "gdpr"]
 
 [[rules]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- **De PII-scan (gitleaks + de eigen patroonscan) blokkeert niet meer op een toevallige treffer binnen een hex-hash.** Het patroon voor Nederlandse mobiele nummers had geen woordgrens, waardoor het regelmatig binnen een SHA256-hash (bijv. in een gegenereerd lockfile) matchte en de Security Gate onterecht rood liet zien. De regex is nu verankerd met `\b`, waardoor hij binnen een aaneengesloten hex-string niet meer kan matchen maar een echt telefoonnummer nog steeds herkent. (#784)
+
 ### Added
 - **Teambegeleiding: het "Email Aan"-veld bepaalt nu zelf wie de doorstuur-mail ontvangt.** Voorheen was dit een read-only regeltje om naar Outlook te kopiëren, terwijl de "Vraag doorsturen"-knop altijd naar precies één, server-side bepaalde begeleider mailde — dat verschil was in het scherm niet te zien. Het veld is nu bewerkbaar (standaard gevuld met alle begeleiders van het team), een "Herstel"-knop zet het terug, en de doorstuurkaart toont exact naar wie verstuurd wordt. Verwijder wie niet mee hoeft te lezen, voeg gerust uw eigen adres toe om de flow zelf te testen — dat kon eerder niet, omdat een beheerder meestal zelf geen trainer of teamleider is. Maximaal 15 ontvangers per verzending; een ongeldig adres of een adres op de uitsluitingslijst wordt geweigerd met een duidelijke melding. Elke verzending — automatisch of handmatig opgegeven — wordt vastgelegd voor de bestaande 30-dagen-anonimisering. (#765)
 


### PR DESCRIPTION
## Probleem

De regex voor Nederlandse mobiele nummers had geen woordgrens en matchte daardoor toevallig
binnen elke hex-hash (SHA256 digest e.d.) die 8+ cijfers na een "06"-substring bevat. Concreet:
PR #783 (Bruno-collectie) faalde op de Security Gate omdat `bruno/.bruno-gen/lock.json` een hash
bevat die toevallig matchte — geverifieerd als false positive.

## Fix

`06[-\s]?[0-9]{8}` → `\b06[-\s]?[0-9]{8}\b` in drie plekken:
- `.gitleaks.toml` (`dutch-mobile-number`)
- `.github/workflows/security-scan.yml` (PII Pattern Scan + PII in commit-messages)

Hex-tekens zijn allemaal word characters, dus `\b` kan niet matchen binnen een aaneengesloten
hex-string — de regel blijft een echt telefoonnummer detecteren.

Aanbevolen en gedocumenteerd door de `bruno-collection-generator`-repo (commit b348fe6,
2026-08-04) na dit incident, als betere repair dan een pad-allowlist — een allowlist verbergt
alleen dit ene bestand, niet de volgende hash die dezelfde false positive triggert.

## Getest
- Los telefoonnummer (`0612345678`, `06-12345678`) matcht nog steeds ✅
- Synthetische hex-achtige string (`abc06123456789fedcba`) matcht niet meer, terwijl de oude
  regex daar wél op matchte ✅

Closes #784