### PR TITLE
chore(#789): geen losse comment meer bij het sluiten van gereleasede issues

### DIFF
--- a/.github/workflows/close-released-issues.yml
+++ b/.github/workflows/close-released-issues.yml
@@ -106,18 +106,17 @@ jobs:
               await clearIssueStatus({ github, context, core, issueNumber: number });
 
               if (issue.state === 'open') {
+                // Geen losse createComment hier (#789): dat verdubbelt de notificatie-e-mail per
+                // issue (close-event + comment-event). De releaseinfo staat al op de GitHub
+                // Release-pagina (gegenereerd door release.yml uit de CHANGELOG-sectie) en in de
+                // CHANGELOG zelf, dus de comment voegde geen traceerbaarheid toe die niet al
+                // ergens anders stond.
                 await github.rest.issues.update({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: number,
                   state: 'closed',
                   state_reason: 'completed',
-                });
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: number,
-                  body: `✅ Uitgerold naar productie in release \`${tag}\`.`,
                 });
                 core.notice(`#${number}: gesloten (${tag})`);
               }


### PR DESCRIPTION
## Probleem
16 e-mails bij de laatste release (8 issues × 2 events: close + comment).

## Fix
De losse "✅ Uitgerold naar productie in release vX"-comment laten vervallen in
`close-released-issues.yml`. Alleen de close-actie blijft over. Releaseinfo blijft zichtbaar via:
- de GitHub Release-pagina (auto-gegenereerd door `release.yml` uit de CHANGELOG-sectie)
- de CHANGELOG zelf

Halveert het aantal notificaties per release (16 → 8 bij de laatste release).

## Niet in scope
Persoonlijke GitHub-notificatie-instellingen — dat regelt de gebruiker zelf via
Watch ▾ → Custom → Issues uitschakelen.

Closes #789