### PR TITLE
fix(#801): review mode stuurt testantwoord weer naar EmailReviewRecipient

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -14,9 +14,9 @@
          Wie dit terugzet naar true moet óók de CSP oplossen — en nonce/SRI kan niet op statische
          hosting. Zie index.html voor de volledige afweging. -->
     <OverrideHtmlAssetPlaceholders>false</OverrideHtmlAssetPlaceholders>
-    <Version>2.20.0.0</Version>
-    <AssemblyVersion>2.20.0.0</AssemblyVersion>
-    <FileVersion>2.20.0.0</FileVersion>
+    <Version>2.20.0.1</Version>
+    <AssemblyVersion>2.20.0.1</AssemblyVersion>
+    <FileVersion>2.20.0.1</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
 
 ## [Unreleased]
 
+### Fixed
+- **Testmodus stuurt weer een testantwoord naar de reviewer.** In testmodus (`EmailReviewMode=true`) bouwt de AI al sinds een eerdere wijziging een voorgesteld antwoord op, maar dat werd alleen in de database bewaard — nergens te lezen zonder rechtstreekse databasetoegang. Dat testantwoord gaat nu ook naar het ingestelde reviewadres, zoals eerder ook het geval was voordat dit bewust werd uitgeschakeld. Mislukt die verzending, dan blijft het voorstel gewoon in de database staan. (#801)
+
 ## [2.20.0.0] — 2026-08-09
 
 ### Added

--- a/FunctionApp.Tests/Email/EmailReplyPolicyServiceTests.cs
+++ b/FunctionApp.Tests/Email/EmailReplyPolicyServiceTests.cs
@@ -14,10 +14,11 @@ public class EmailReplyPolicyServiceTests
     /// Review mode moet een te beoordelen antwoord opleveren (#712). De vorige versie van deze test
     /// zette het foutieve gedrag vast — <c>buildCalled == false</c> — waardoor er niets te reviewen
     /// was: geen antwoord opgebouwd, <c>AntwoordEmail</c> leeg, en status 'Verwerkt', dezelfde
-    /// waarde als een mislukte verzending.
+    /// waarde als een mislukte verzending. Zonder <c>reviewRecipient</c> gaat er nog steeds geen mail
+    /// de deur uit — dat pad wordt hieronder in een aparte test met een recipient afgedekt (#801).
     /// </summary>
     [Fact]
-    public async Task ReviewMode_SlaatVoorgesteldAntwoordOp_EnVerstuurtNiet()
+    public async Task ReviewMode_ZonderReviewRecipient_SlaatVoorgesteldAntwoordOp_EnVerstuurtNiet()
     {
         var service = new EmailReplyPolicyService();
         var graph = new FakeEmailGraphService();
@@ -30,6 +31,7 @@ public class EmailReplyPolicyServiceTests
             classificatie: new BerichtClassificatie { Type = VerzoekType.HerplanVerzoek },
             plannerResponseJson: "{}",
             reviewMode: true,
+            reviewRecipient: null,
             graphService: graph,
             persistenceService: persistence,
             bouwTemplateAntwoordAsync: () =>
@@ -45,11 +47,85 @@ public class EmailReplyPolicyServiceTests
         persistence.VoorgesteldeAntwoorden.Should().ContainSingle(v =>
             v.VerwerkingId == 42 && v.AntwoordEmail == "voorgestelde-body");
 
-        // Review mode blokkeert alle uitgaande post — dat blijft ongewijzigd.
+        // Review mode blokkeert post naar de originele afzender — dat blijft ongewijzigd. Zonder
+        // reviewRecipient wordt er dus helemaal niets verstuurd.
         graph.SentReplies.Should().BeEmpty();
         persistence.AntwoordUpdates.Should().BeEmpty();
         graph.CategoryUpdates.Should().ContainSingle(c => c.Categories.Contains("Geen AI antwoord"));
         graph.MarkedAsReadIds.Should().ContainSingle(id => id == "m1");
+    }
+
+    /// <summary>
+    /// Herstel van de regressie uit #543 (2026-06-20): review mode stuurde ooit een testantwoord
+    /// naar een apart reviewadres, tot dat bewust werd verwijderd. #801 herstelt dit — met behoud
+    /// van de #712-opslag in <c>AntwoordEmail</c> — omdat het voorstel anders alleen via directe
+    /// databasetoegang te lezen is (de Admin GUI geeft AntwoordEmail nooit terug, AVG).
+    /// </summary>
+    [Fact]
+    public async Task ReviewMode_MetReviewRecipient_VerstuurtTestantwoordNaarRecipient()
+    {
+        var service = new EmailReplyPolicyService();
+        var graph = new FakeEmailGraphService();
+        var persistence = new RecordingEmailPersistenceService();
+
+        var result = await service.HandelReplyFlowAfAsync(
+            verwerkingId: 44,
+            email: new InkomendBericht
+            {
+                MessageId = "m1c", Afzender = "afzender@voorbeeld.test", Onderwerp = "Test",
+                ConversationId = "conv-44",
+            },
+            classificatie: new BerichtClassificatie { Type = VerzoekType.HerplanVerzoek },
+            plannerResponseJson: "{}",
+            reviewMode: true,
+            reviewRecipient: "reviewer@voorbeeld.test",
+            graphService: graph,
+            persistenceService: persistence,
+            bouwTemplateAntwoordAsync: () => Task.FromResult(("subj", "voorgestelde-body")),
+            sanitizeFoutMelding: s => s,
+            log: NullLogger.Instance);
+
+        result.Should().Be(ReplyVerwerkingUitkomst.AfgerondZonderAntwoord);
+        persistence.VoorgesteldeAntwoorden.Should().ContainSingle(v =>
+            v.VerwerkingId == 44 && v.AntwoordEmail == "voorgestelde-body");
+
+        // De testmail gaat naar reviewRecipient, nooit naar de originele afzender.
+        graph.SentReplies.Should().ContainSingle(r =>
+            r.To == "reviewer@voorbeeld.test" && r.Subject == "subj" && r.ConversationId == "conv-44");
+        persistence.AntwoordUpdates.Should().BeEmpty();
+        graph.CategoryUpdates.Should().ContainSingle(c => c.Categories.Contains("Geen AI antwoord"));
+        graph.MarkedAsReadIds.Should().ContainSingle(id => id == "m1c");
+    }
+
+    /// <summary>
+    /// Een mislukte reviewmail mag de opslag en labeling niet blokkeren — het voorstel blijft dan
+    /// alsnog in de database te vinden (#801).
+    /// </summary>
+    [Fact]
+    public async Task ReviewMode_ReviewmailMislukt_SlaatTochOpEnLabelt()
+    {
+        var service = new EmailReplyPolicyService();
+        var graph = new FakeEmailGraphService { ThrowOnSendReply = true };
+        var persistence = new RecordingEmailPersistenceService();
+
+        var result = await service.HandelReplyFlowAfAsync(
+            verwerkingId: 45,
+            email: new InkomendBericht { MessageId = "m1d", Afzender = "afzender@voorbeeld.test", Onderwerp = "Test" },
+            classificatie: new BerichtClassificatie { Type = VerzoekType.HerplanVerzoek },
+            plannerResponseJson: "{}",
+            reviewMode: true,
+            reviewRecipient: "reviewer@voorbeeld.test",
+            graphService: graph,
+            persistenceService: persistence,
+            bouwTemplateAntwoordAsync: () => Task.FromResult(("subj", "voorgestelde-body")),
+            sanitizeFoutMelding: s => s,
+            log: NullLogger.Instance);
+
+        result.Should().Be(ReplyVerwerkingUitkomst.AfgerondZonderAntwoord);
+        persistence.VoorgesteldeAntwoorden.Should().ContainSingle(v =>
+            v.VerwerkingId == 45 && v.AntwoordEmail == "voorgestelde-body");
+        graph.CategoryUpdates.Should().ContainSingle(c => c.Categories.Contains("Geen AI antwoord"));
+        graph.MarkedAsReadIds.Should().ContainSingle(id => id == "m1d");
     }
 
     [Fact]
@@ -68,6 +144,7 @@ public class EmailReplyPolicyServiceTests
             classificatie: new BerichtClassificatie { Type = VerzoekType.BeschikbaarheidCheck },
             plannerResponseJson: JsonConvert.SerializeObject(new CheckAvailabilityResponse { Beschikbaar = true }),
             reviewMode: true,
+            reviewRecipient: null,
             graphService: graph,
             persistenceService: persistence,
             bouwTemplateAntwoordAsync: () =>
@@ -99,6 +176,7 @@ public class EmailReplyPolicyServiceTests
             classificatie: new BerichtClassificatie { Type = VerzoekType.BeschikbaarheidCheck },
             plannerResponseJson: JsonConvert.SerializeObject(new CheckAvailabilityResponse { Beschikbaar = true }),
             reviewMode: false,
+            reviewRecipient: null,
             graphService: graph,
             persistenceService: persistence,
             bouwTemplateAntwoordAsync: () => Task.FromResult(("subj", "body")),
@@ -126,6 +204,7 @@ public class EmailReplyPolicyServiceTests
             classificatie: new BerichtClassificatie { Type = VerzoekType.HerplanVerzoek },
             plannerResponseJson: "{}",
             reviewMode: false,
+            reviewRecipient: null,
             graphService: graph,
             persistenceService: persistence,
             bouwTemplateAntwoordAsync: () => Task.FromResult(("antwoord-subject", "antwoord-body")),
@@ -152,6 +231,7 @@ public class EmailReplyPolicyServiceTests
             classificatie: new BerichtClassificatie { Type = VerzoekType.HerplanVerzoek },
             plannerResponseJson: "{}",
             reviewMode: false,
+            reviewRecipient: null,
             graphService: graph,
             persistenceService: persistence,
             bouwTemplateAntwoordAsync: () => Task.FromResult(("antwoord-subject", "antwoord-body")),
@@ -192,6 +272,7 @@ public class EmailReplyPolicyServiceTests
             classificatie: new BerichtClassificatie { Type = VerzoekType.HerplanVerzoek },
             plannerResponseJson: "{}",
             reviewMode: false,
+            reviewRecipient: null,
             graphService: graph,
             persistenceService: persistence,
             bouwTemplateAntwoordAsync: () => Task.FromResult(("antwoord-subject", "antwoord-body")),
@@ -228,6 +309,7 @@ public class EmailReplyPolicyServiceTests
             classificatie: new BerichtClassificatie { Type = VerzoekType.HerplanVerzoek },
             plannerResponseJson: "{}",
             reviewMode: false,
+            reviewRecipient: null,
             graphService: graph,
             persistenceService: persistence,
             bouwTemplateAntwoordAsync: () => Task.FromResult(("antwoord-subject", "antwoord-body")),
@@ -260,6 +342,7 @@ public class EmailReplyPolicyServiceTests
             classificatie: new BerichtClassificatie { Type = VerzoekType.HerplanVerzoek },
             plannerResponseJson: "{}",
             reviewMode: false,
+            reviewRecipient: null,
             graphService: graph,
             persistenceService: persistence,
             bouwTemplateAntwoordAsync: () => Task.FromResult(("antwoord-subject", "antwoord-body")),
@@ -289,6 +372,7 @@ public class EmailReplyPolicyServiceTests
             classificatie: new BerichtClassificatie { Type = VerzoekType.HerplanVerzoek },
             plannerResponseJson: "{}",
             reviewMode: true,
+            reviewRecipient: null,
             graphService: graph,
             persistenceService: persistence,
             bouwTemplateAntwoordAsync: () => Task.FromResult(("subj", "body")),

--- a/FunctionApp/Email/EmailProcessorFunction.cs
+++ b/FunctionApp/Email/EmailProcessorFunction.cs
@@ -545,12 +545,14 @@ public class EmailProcessorFunction
 
         var reviewMode = string.Equals(
             Environment.GetEnvironmentVariable("EmailReviewMode"), "true", StringComparison.OrdinalIgnoreCase);
+        var reviewRecipient = Environment.GetEnvironmentVariable("EmailReviewRecipient");
         var replyUitkomst = await replyPolicyService.HandelReplyFlowAfAsync(
             verwerkingId,
             email,
             classificatie,
             plannerResponseJson,
             reviewMode,
+            reviewRecipient,
             graphService,
             persistenceService,
             () => BerichtPipeline.BouwTemplateAntwoord(classificatie, plannerResponseJson, email, log),

--- a/FunctionApp/Email/EmailReplyPolicyService.cs
+++ b/FunctionApp/Email/EmailReplyPolicyService.cs
@@ -22,25 +22,50 @@ internal sealed class EmailReplyPolicyService
         BerichtClassificatie classificatie,
         string plannerResponseJson,
         bool reviewMode,
+        string? reviewRecipient,
         IEmailGraphService graphService,
         IEmailPersistenceService persistenceService,
         Func<Task<(string onderwerp, string body)>> bouwTemplateAntwoordAsync,
         Func<string, string> sanitizeFoutMelding,
         ILogger log)
     {
-        // Review mode blijft de eerste check: hier gaat geen enkel bericht de deur uit. Nieuw is dat
-        // het voorgestelde antwoord wél wordt opgebouwd en opgeslagen — anders valt er niets te
-        // reviewen. Voorheen bleef AntwoordEmail leeg en kreeg de rij status 'Verwerkt', dezelfde
-        // waarde als een mislukte verzending, waardoor EmailStatus.Review dode code was. (#712)
+        // Review mode blijft de eerste check: er gaat nooit een antwoord naar de originele
+        // afzender. Het voorgestelde antwoord wordt opgebouwd en opgeslagen (#712) — zonder dat
+        // valt er niets te reviewen. Daarnaast wordt hetzelfde voorstel ook gemaild naar
+        // EmailReviewRecipient (#801, herstel van een regressie uit #543/2026-06-20): zonder deze
+        // mail is het voorstel alleen via directe databasetoegang te lezen, omdat de Admin GUI
+        // AntwoordEmail bewust nooit teruggeeft (AVG). Een mislukte reviewmail blokkeert de opslag
+        // en labeling niet — het voorstel blijft dan alsnog in de database te vinden.
         if (reviewMode)
         {
             var reviewBesluit = ReplyPolicy.Bepaal(classificatie, plannerResponseJson);
             if (reviewBesluit.MoetVersturen)
             {
-                var (_, voorgesteldeBody) = await bouwTemplateAntwoordAsync();
+                var (voorgesteldOnderwerp, voorgesteldeBody) = await bouwTemplateAntwoordAsync();
                 await persistenceService.UpdateVoorgesteldAntwoordAsync(verwerkingId, voorgesteldeBody);
                 log.LogInformation(
-                    "Email {Id} review mode — voorgesteld antwoord opgeslagen ter beoordeling, niets verstuurd", verwerkingId);
+                    "Email {Id} review mode — voorgesteld antwoord opgeslagen ter beoordeling", verwerkingId);
+
+                if (!string.IsNullOrWhiteSpace(reviewRecipient))
+                {
+                    try
+                    {
+                        await graphService.SendReplyAsync(reviewRecipient, voorgesteldOnderwerp, voorgesteldeBody, email.ConversationId);
+                        log.LogInformation(
+                            "Email {Id} review mode — testantwoord verstuurd naar EmailReviewRecipient", verwerkingId);
+                    }
+                    catch (Exception ex)
+                    {
+                        log.LogWarning(ex,
+                            "Email {Id} review mode — testmail naar EmailReviewRecipient mislukt, voorstel blijft wel opgeslagen in de database",
+                            verwerkingId);
+                    }
+                }
+                else
+                {
+                    log.LogInformation(
+                        "Email {Id} review mode — EmailReviewRecipient niet geconfigureerd, geen testmail verstuurd", verwerkingId);
+                }
             }
             else
             {

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.20.0.0</Version>
-    <AssemblyVersion>2.20.0.0</AssemblyVersion>
-    <FileVersion>2.20.0.0</FileVersion>
+    <Version>2.20.0.1</Version>
+    <AssemblyVersion>2.20.0.1</AssemblyVersion>
+    <FileVersion>2.20.0.1</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->

--- a/docs/EMAIL-VERWERKING.md
+++ b/docs/EMAIL-VERWERKING.md
@@ -911,4 +911,7 @@ Template: {key}          ← alleen bij template-gebaseerde antwoorden
 ==================
 ```
 
-Dit blok wordt in review-mode opgeslagen in `AntwoordEmail`; er wordt niets doorgestuurd.
+Dit blok wordt in review-mode opgeslagen in `AntwoordEmail` én verstuurd naar de app setting
+`EmailReviewRecipient` (herstel van een regressie uit #543, zie #801) — de originele afzender
+krijgt nog steeds nooit iets te zien. Is `EmailReviewRecipient` niet geconfigureerd, dan wordt
+alleen opgeslagen en gelogd dat er geen testmail is verstuurd.


### PR DESCRIPTION
## Samenvatting

Herstelt een regressie uit commit `87c451b` (2026-06-20, issue #543): in `EmailReviewMode=true`
werd het voorgestelde AI-antwoord al opgebouwd en opgeslagen (#712), maar nooit ergens getoond —
de Admin GUI geeft `AntwoordEmail` bewust nooit terug (AVG), dus het voorstel was alleen via
directe databasetoegang te lezen. Tijdens de huidige testfase is dat onwerkbaar.

Deze PR stuurt het voorgestelde antwoord weer naar `EmailReviewRecipient` (nog steeds correct
geconfigureerd in productie — geen infra-wijziging nodig), naast de bestaande DB-opslag. Faalt de
verzending, dan blokkeert dat de opslag en labeling niet.

## Wijzigingen

- `EmailReplyPolicyService.HandelReplyFlowAfAsync`: nieuwe `reviewRecipient`-parameter (zelfde
  patroon als `reviewMode` — expliciet doorgegeven i.p.v. een omgevingsvariabele rechtstreeks te
  lezen, voor testbaarheid). Stuurt het voorgestelde antwoord naar dit adres als het geconfigureerd
  is; anders alleen opslag zoals voorheen.
- `EmailProcessorFunction`: leest `EmailReviewRecipient` en geeft het door.
- Tests: bestaande review-mode test hernoemd naar het "geen recipient"-scenario; twee nieuwe tests
  voor "wel recipient, verstuurt" en "verzending mislukt, opslag blijft toch staan".
- `docs/EMAIL-VERWERKING.md`: sectie "Review-mode prefix" bijgewerkt (niet meer "er wordt niets
  doorgestuurd").
- `CHANGELOG.md` + versiebump 2.20.0.0 → 2.20.0.1 (REVISION, fix zonder nieuwe feature).

## Test plan

- [x] `dotnet build FunctionApp/fa-dev-sportlink-01.csproj` — groen
- [x] `dotnet build BlazorAdmin/BlazorAdmin.csproj` — groen (alleen versiebump, geen GUI-wijziging)
- [x] `dotnet test FunctionApp.Tests` — 444 groen, 4 skipped (bestaande DB-integratietests), 0 fouten
- [ ] CI (Security Gate + build-jobs)

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)