### PR TITLE
fix(#812): AllStars FC demo-seed gebruikte verkeerde DagVanWeek-conventie

### DIFF
--- a/BlazorAdmin/BlazorAdmin.csproj
+++ b/BlazorAdmin/BlazorAdmin.csproj
@@ -14,9 +14,9 @@
          Wie dit terugzet naar true moet óók de CSP oplossen — en nonce/SRI kan niet op statische
          hosting. Zie index.html voor de volledige afweging. -->
     <OverrideHtmlAssetPlaceholders>false</OverrideHtmlAssetPlaceholders>
-    <Version>2.20.0.3</Version>
-    <AssemblyVersion>2.20.0.3</AssemblyVersion>
-    <FileVersion>2.20.0.3</FileVersion>
+    <Version>2.20.0.4</Version>
+    <AssemblyVersion>2.20.0.4</AssemblyVersion>
+    <FileVersion>2.20.0.4</FileVersion>
     <!-- Azure Static Web Apps doet content negotiation op .wasm en serveert de pre-compressed
          .wasm.br data ZONDER 'Content-Encoding: br' header te zetten. Chrome (vooral Incognito)
          interpreteert de Brotli-bytes dan als raw wasm → SRI integrity check faalt → app crasht.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Versienummering volgt het 4-cijferig schema `MAJOR.MINOR.PATCH.REVISION` — zie
   database. (#800)
 
 ### Fixed
+- **AllStars FC-democlub had geen veldbeschikbaarheid voor maandag t/m donderdag en vrijdag, en de zondagrij werd nooit door de planner gevonden.** De demoseed gebruikte per abuis de .NET-native dagconventie (0=zondag) in plaats van de 1=maandag/7=zondag-conventie die de rest van de applicatie hanteert, en zaaide daardoor maar 2 van de 7 dagen. De UI toonde de foutieve rij als "Dag 0". Seedscript gecorrigeerd naar alle 7 dagen met de juiste conventie; al gezaaide omgevingen herstellen zichzelf bij de volgende deploy. (#812)
 - **Database-verbindingen laten de gratis vCore-secondenlimiet niet meer onnodig snel oplopen.** Alle SQL-verbindingen in de FunctionApp draaiden met standaard connection-pooling; een pooled verbinding blijft na afsluiten als actieve sessie op de server staan, wat de free-tier database verhindert automatisch te pauzeren. Pooling staat nu uit voor alle databaseverbindingen. (#808)
 - **`Verify-AzureAuthSetup.ps1` rapporteerde de auth-lagen 4 en 5 altijd als FAIL**, ook als ze
   correct waren. Het script zocht `App.razor` en de admin-endpoints één directoryniveau te hoog,

--- a/Database/Script.PostDeployment1.sql
+++ b/Database/Script.PostDeployment1.sql
@@ -2771,17 +2771,32 @@ BEGIN
                (102, 'Kunstgras 2', 'kunstgras',  1, 1, @DemoClub),
                (103, 'Gras',        'natuurgras', 0, 1, @DemoClub);
 
-    -- VeldBeschikbaarheid: DagVanWeek volgt .NET DayOfWeek (0 = zondag, 6 = zaterdag), dezelfde
-    -- conventie als de bestaande rijen van de primaire club.
+    -- VeldBeschikbaarheid: DagVanWeek volgt dezelfde conventie als de rest van de applicatie —
+    -- 1=maandag ... 7=zondag (zie PlannerAvailabilityRepository, dat .NET DayOfWeek.Sunday (0)
+    -- expliciet omzet naar 7) — niet de .NET-native DayOfWeek-waarden. Een eerdere versie van deze
+    -- seed gebruikte per abuis .NET DayOfWeek en zaaide daardoor maar 2 van de 7 dagen, met de
+    -- "zondag"-rij als DagVanWeek=0 (geen match in DagNaam() en onvindbaar voor de planner, die
+    -- altijd op 7 zoekt) — zie #812.
     -- 08:30-22:00 sluit aan op wat een club in de praktijk aanhoudt en is ruim genoeg voor de
     -- 14 thuiswedstrijden per speeldag; met een krapper venster loopt de planner over zijn
     -- beschikbaarheid heen en eindigt de demo met een onrealistisch schema.
-    IF NOT EXISTS (SELECT 1 FROM [dbo].[VeldBeschikbaarheid] WHERE [ClubCode] = @DemoClub)
-        INSERT INTO [dbo].[VeldBeschikbaarheid]
-            ([VeldNummer], [DagVanWeek], [BeschikbaarVanaf], [BeschikbaarTot], [GebruikZonsondergang], [ClubCode])
-        SELECT v.[VeldNummer], d.[Dag], '08:30', '22:00', 0, @DemoClub
-        FROM (VALUES (101), (102), (103)) AS v([VeldNummer])
-        CROSS JOIN (VALUES (6), (0)) AS d([Dag]);
+    --
+    -- Idempotente correctie (i.p.v. IF NOT EXISTS ... INSERT): een omgeving die al met de foutieve
+    -- #812-seed is gevuld, herstelt zichzelf zo alsnog bij de volgende deploy, in plaats van dat de
+    -- oude IF NOT EXISTS-guard verdere seeding blokkeert omdat er al (foutieve) rijen bestaan.
+    UPDATE [dbo].[VeldBeschikbaarheid]
+    SET [DagVanWeek] = 7
+    WHERE [ClubCode] = @DemoClub AND [DagVanWeek] = 0;
+
+    INSERT INTO [dbo].[VeldBeschikbaarheid]
+        ([VeldNummer], [DagVanWeek], [BeschikbaarVanaf], [BeschikbaarTot], [GebruikZonsondergang], [ClubCode])
+    SELECT v.[VeldNummer], d.[Dag], '08:30', '22:00', 0, @DemoClub
+    FROM (VALUES (101), (102), (103)) AS v([VeldNummer])
+    CROSS JOIN (VALUES (1), (2), (3), (4), (5), (6), (7)) AS d([Dag])
+    WHERE NOT EXISTS (
+        SELECT 1 FROM [dbo].[VeldBeschikbaarheid] vb
+        WHERE vb.[ClubCode] = @DemoClub AND vb.[VeldNummer] = v.[VeldNummer] AND vb.[DagVanWeek] = d.[Dag]
+    );
 
     -- Speeltijden: overgenomen van de primaire club in plaats van hardcoded. Dit zijn
     -- KNVB-standaarden, dus zo blijft de demo consistent met wat de club zelf heeft ingesteld

--- a/FunctionApp/fa-dev-sportlink-01.csproj
+++ b/FunctionApp/fa-dev-sportlink-01.csproj
@@ -11,9 +11,9 @@
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerfileContext>.</DockerfileContext>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Version>2.20.0.3</Version>
-    <AssemblyVersion>2.20.0.3</AssemblyVersion>
-    <FileVersion>2.20.0.3</FileVersion>
+    <Version>2.20.0.4</Version>
+    <AssemblyVersion>2.20.0.4</AssemblyVersion>
+    <FileVersion>2.20.0.4</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Test-project heeft toegang tot internal members via InternalsVisibleTo (#476) -->


### PR DESCRIPTION
## Samenvatting
- `dbo.VeldBeschikbaarheid` gebruikt overal 1=maandag...7=zondag (planner-repository, Blazor `DagNaam()`). De AllStars FC-demoseed gebruikte per abuis .NET DayOfWeek (0=zondag) en zaaide maar 2 van de 7 dagen.
- Gevolg: geen beschikbaarheid voor ma-do/vrijdag in de democlub, en de zondagrij (opgeslagen als `DagVanWeek=0`) werd nooit door de planner gevonden — UI toonde hem als "Dag 0".
- Seedscript gecorrigeerd: alle 7 dagen, juiste conventie, idempotente UPDATE+INSERT zodat een al gezaaide omgeving zichzelf herstelt bij de volgende deploy (i.p.v. de oude `IF NOT EXISTS`-guard die verdere seeding blokkeerde).
- Lokale Docker-devdatabase meteen gecorrigeerd met dezelfde logica; geverifieerd dat alle 3 velden nu alle 7 dagen hebben.
- CHANGELOG bijgewerkt, versie gebumpt naar 2.20.0.4 (REVISION — bugfix, geen nieuwe feature).

Closes #812

## Test plan
- [x] `dotnet build FunctionApp/fa-dev-sportlink-01.csproj` groen
- [x] Corrigerende SQL lokaal uitgevoerd tegen de Docker-devdatabase en resultaat geverifieerd (3 velden × 7 dagen, geen `DagVanWeek=0` meer)
- [ ] CI: Security Gate + build-job groen
- [ ] Na merge naar develop: browsercheck op Instellingen > Velden voor AllStars FC (alle 7 dagen zichtbaar, geen "Dag 0" meer)